### PR TITLE
cmld: added ability to reload container configs  + c_cgroups: check for already mounted tmpfs

### DIFF
--- a/common/file.c
+++ b/common/file.c
@@ -70,6 +70,21 @@ file_is_dir(const char *file)
 	return !lstat(file, &s) && S_ISDIR(s.st_mode);
 }
 
+bool
+file_is_mountpoint(const char *file)
+{
+	bool ret;
+	struct stat s, s_parent;
+	char *parent = mem_printf("%s/..", file);
+
+	ret = !lstat(file, &s);
+	ret &= !lstat(parent, &s_parent);
+	ret &= (s.st_dev != s_parent.st_dev);
+
+	mem_free(parent);
+	return ret;
+}
+
 int
 file_copy(const char *in_file, const char *out_file, ssize_t count, size_t bs, off_t seek)
 {

--- a/common/file.h
+++ b/common/file.h
@@ -45,6 +45,10 @@ file_is_link(const char *file);
 bool
 file_is_dir(const char *file);
 
+bool
+file_is_mountpoint(const char *file);
+
+
 /**
  * Copy a file.
  * @param in_file The file to be read.

--- a/control/control.c
+++ b/control/control.c
@@ -49,6 +49,7 @@ static void print_usage(const char *cmd)
 	printf("\n");
 	printf("commands:\n");
 	printf("   list\n        Lists all containers.\n");
+	printf("   reload\n        Reloads containers ifrom config files.\n");
 	printf("   wipe_device\n        Wipes all containers on the device.\n");
 	printf("   start <container-uuid> [--key=<key>]\n        Starts the container with the given key (default: all '0') .\n");
 	printf("   stop <container-uuid>\n        Stops the specified container.\n");
@@ -159,6 +160,10 @@ int main(int argc, char *argv[])
 	if (!strcasecmp(command, "list")) {
 		msg.command = CONTROLLER_TO_DAEMON__COMMAND__GET_CONTAINER_STATUS;
 		has_response = true;
+		goto send_message;
+	}
+	if (!strcasecmp(command, "reload")) {
+		msg.command = CONTROLLER_TO_DAEMON__COMMAND__RELOAD_CONTAINERS;
 		goto send_message;
 	}
 	if (!strcasecmp(command, "wipe_device")) {

--- a/daemon/cmld.h
+++ b/daemon/cmld.h
@@ -47,6 +47,14 @@ int
 cmld_init(const char *path);
 
 /**
+ * Reloads all containers from storage path.
+ *
+ * @return 0 on success, -1 on error
+ */
+int
+cmld_reload_containers(void);
+
+/**
  * Create a container by cloning from another one.
  *
  * @param container The container object to clone from.

--- a/daemon/control.c
+++ b/daemon/control.c
@@ -597,6 +597,10 @@ control_handle_message(const ControllerToDaemon *msg, int fd)
 		}
 	} break;
 
+	case CONTROLLER_TO_DAEMON__COMMAND__RELOAD_CONTAINERS: {
+		cmld_reload_containers();
+	} break;
+
 	case CONTROLLER_TO_DAEMON__COMMAND__WIPE_DEVICE: {
 		cmld_wipe_device();
 	} break;

--- a/daemon/control.proto
+++ b/daemon/control.proto
@@ -95,6 +95,9 @@ message ControllerToDaemon {
 		// Images will be updated later.
 		PUSH_GUESTOS_CONFIG = 20;
 
+		// Reloads containers from config files, e.g. if a new container should be created
+		RELOAD_CONTAINERS = 21;
+
 		// TODO (optional) REMOVE_CONTAINER, REMOVE_GUESTOS
 		// How to remove? Send same package_info as during install and delete list of files?
 		// TODO: Are there other files/settings/configs to be managed remotely (install/update/remove)?


### PR DESCRIPTION
This patch add the control command "reload" to reread the
container config files from storage. Thus, newly created
container configs will be added as new containers. Already
created containers are skipped for now.