### PR TITLE
Implemented IMA-style measurement list (ML) for containers

### DIFF
--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -27,7 +27,7 @@ LOCAL_CFLAGS := -std=gnu99 -Icommon -I.. -I../include -pedantic -Wall -Wextra -W
 LOCAL_CFLAGS += -DDEBUG_BUILD
 LDLIBS := -lc -lprotobuf-c -lprotobuf-c-text -lselinux -Lcommon -lcommon -lutil
 
-TRUSTME_HARDWARE := ppc
+TRUSTME_HARDWARE := x86
 
 .PHONY: all
 all: cmld
@@ -39,6 +39,7 @@ PROTO_SRC := \
 	common/logf.pb-c.c \
 	device.pb-c.c \
 	scd.pb-c.c \
+	tpm2d.pb-c.c \
 	c_service.pb-c.c
 
 SRC_FILES := main.c \
@@ -58,6 +59,7 @@ SRC_FILES := main.c \
 	common/protobuf.c \
 	download.c \
 	smartcard.c \
+	tss.c \
 	common/sock.c \
 	c_cgroups.c \
 	c_service.c \
@@ -80,6 +82,7 @@ protobuf: container.proto control.proto guestos.proto common/logf.proto device.p
 	protoc-c --c_out=. guestos.proto
 	protoc-c --c_out=. device.proto
 	protoc-c --c_out=. scd.proto
+	protoc-c --c_out=. tpm2d.proto
 	protoc-c --c_out=. c_service.proto
 	$(MAKE) -C common protobuf
 

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -852,8 +852,9 @@ cmld_init(const char *path)
 	cmld_c0os_name = c0os_name ? mem_strdup(c0os_name) : NULL;
 
 	if (mount_debugfs() < 0)
-		WARN("Could not mount debugfs");
-	INFO("mounted debugfs");
+		WARN("Could not mount debugfs (already mounted?)");
+	else
+		INFO("mounted debugfs");
 
 #ifdef ANDROID
 	if (power_init() < 0)
@@ -863,7 +864,8 @@ cmld_init(const char *path)
 
 	if (ksm_init() < 0)
 		WARN("Could not init ksm module");
-	INFO("ksm initialized.");
+	else
+		INFO("ksm initialized.");
 
 	if (tss_init() < 0)
 		WARN("Plattform does not support TSS / TPM 2.0");

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -45,6 +45,7 @@
 #include "guestos_mgr.h"
 #include "guestos.h"
 #include "smartcard.h"
+#include "tss.h"
 #include "ksm.h"
 
 #include <dirent.h>
@@ -863,6 +864,11 @@ cmld_init(const char *path)
 	if (ksm_init() < 0)
 		WARN("Could not init ksm module");
 	INFO("ksm initialized.");
+
+	if (tss_init() < 0)
+		WARN("Plattform does not support TSS / TPM 2.0");
+	else
+		INFO("tss initialized.");
 
 	/* the control module sets up a local or remote socket, registers a
 	 * callback (via event_) and parses incoming commands

--- a/daemon/tpm2d.proto
+++ b/daemon/tpm2d.proto
@@ -1,0 +1,1 @@
+../tpm2d/tpm2d.proto

--- a/daemon/tss.c
+++ b/daemon/tss.c
@@ -1,0 +1,108 @@
+/*
+ * This file is part of trust|me
+ * Copyright(c) 2013 - 2018 Fraunhofer AISEC
+ * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 (GPL 2), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * The full GNU General Public License is included in this distribution in
+ * the file called "COPYING".
+ *
+ * Contact Information:
+ * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ */
+
+#include "tss.h"
+
+#ifdef ANDROID
+#include "device/fraunhofer/common/cml/tpm2_control/tpm2d.pb-c.h"
+#else
+#include "tpm2d.pb-c.h"
+#endif
+
+#include "common/macro.h"
+#include "common/sock.h"
+#include "common/mem.h"
+#include "common/protobuf.h"
+
+#include <protobuf-c-text/protobuf-c-text.h>
+#include <stdbool.h>
+
+#define TPM2D_SOCK_PATH "/data/cml/tpm2d/communication"
+#define TPM2D_SOCKET TPM2D_SOCK_PATH "/control.sock"
+
+static int tss_sock = -1;
+
+/**
+ * Returns the HashAlgLen (proto) for the given tss_hash_algo_t algo.
+ */
+static HashAlgLen
+tss_hash_algo_get_len_proto(tss_hash_algo_t algo)
+{
+	switch (algo) {
+	case TSS_SHA1:
+		return HASH_ALG_LEN__SHA1;
+	case TSS_SHA256:
+		return HASH_ALG_LEN__SHA256;
+	case TSS_SHA384:
+		return HASH_ALG_LEN__SHA384;
+	default:
+		ERROR("Unsupported value for tss_hash_algo_t: %d", algo);
+		return -1;
+	}
+}
+
+int
+tss_init(void)
+{
+	tss_sock = sock_unix_create_and_connect(SOCK_STREAM, TPM2D_SOCKET);
+	return (tss_sock < 0) ? -1 : 0;
+}
+
+void
+tss_ml_append(char *filename, uint8_t *filehash, int filehash_len, tss_hash_algo_t hashalgo)
+{
+	/*
+	 * check if tpm2d socket is connected otherwise silently return,
+	 * since platform may not support tss/tpm2 functionality
+	 */
+	IF_TRUE_RETURN(tss_sock < 0);
+
+	ControllerToTpm msg = CONTROLLER_TO_TPM__INIT;
+
+	msg.code = CONTROLLER_TO_TPM__CODE__ML_APPEND;
+	msg.ml_filename = filename;
+	msg.has_ml_datahash = true;
+	msg.ml_datahash.len = filehash_len;
+	msg.ml_datahash.data = filehash;
+	msg.has_ml_hashalg = true;
+	msg.ml_hashalg = tss_hash_algo_get_len_proto(hashalgo);
+
+	if (protobuf_send_message(tss_sock, (ProtobufCMessage *) &msg) < 0) {
+		WARN("Failed to send measurement to tpm2d");
+	}
+
+	TpmToController *resp = (TpmToController *)protobuf_recv_message(tss_sock, &tpm_to_controller__descriptor);
+	if (!resp) {
+		WARN("Failed to receive and decode TpmToController protobuf message!");
+		return;
+	}
+
+	if (resp->code != TPM_TO_CONTROLLER__CODE__GENERIC_RESPONSE ||
+			resp->response != TPM_TO_CONTROLLER__GENERIC_RESPONSE__CMD_OK) {
+		ERROR("tpmd failed to append measurement to ML");
+	} else {
+		INFO("Sucessfully appended measurement to ML: file %s" , filename);
+	}
+
+	protobuf_free_message((ProtobufCMessage *)resp);
+}

--- a/daemon/tss.h
+++ b/daemon/tss.h
@@ -1,0 +1,44 @@
+/*
+ * This file is part of trust|me
+ * Copyright(c) 2013 - 2018 Fraunhofer AISEC
+ * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 (GPL 2), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * The full GNU General Public License is included in this distribution in
+ * the file called "COPYING".
+ *
+ * Contact Information:
+ * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ */
+
+#ifndef TSS_H
+#define TSS_H
+
+#include <stdint.h>
+
+/*
+ * type of supported hashes
+ */
+typedef enum {
+	TSS_SHA1 = 0,
+	TSS_SHA256,
+	TSS_SHA384
+} tss_hash_algo_t;
+
+int
+tss_init(void);
+
+void
+tss_ml_append(char *filename, uint8_t *filehash, int filehash_len, tss_hash_algo_t hashalgo);
+
+#endif /* TSS_H */

--- a/tpm2d/Makefile
+++ b/tpm2d/Makefile
@@ -39,6 +39,7 @@ SRC_FILES := \
 	control.c \
 	tpm2_commands.c \
 	nvmcrypt.c \
+	ml.c \
 	ek.c \
 	tpm2d.c
 

--- a/tpm2d/ml.c
+++ b/tpm2d/ml.c
@@ -1,0 +1,124 @@
+/*
+ * This file is part of trust|me
+ * Copyright(c) 2013 - 2018 Fraunhofer AISEC
+ * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 (GPL 2), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * The full GNU General Public License is included in this distribution in
+ * the file called "COPYING".
+ *
+ * Contact Information:
+ * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ */
+
+#include "ml.h"
+
+#include "common/macro.h"
+#include "common/mem.h"
+#include "common/list.h"
+
+#define CONTAINER_PCR_INDEX 11
+
+typedef struct ml_elem {
+	char *filename;
+	TPM_ALG_ID algid;
+	int hash_len;
+	uint8_t *datahash;
+	tpm2d_pcr_string_t *template;
+} ml_elem_t;
+
+static list_t *measurement_list = NULL;
+static int measurement_list_len = 0;
+
+int
+ml_measurement_list_append(const char *filename, TPM_ALG_ID algid,
+		const uint8_t *datahash, size_t datahash_len)
+{
+	// input checks
+	IF_NULL_RETVAL(filename, -1);
+	IF_NULL_RETVAL(datahash, -1);
+	IF_FALSE_RETVAL((datahash_len > 0), -1);
+
+	// check if filehash is in list
+	for (list_t *l = measurement_list; l; l = l->next) {
+		ml_elem_t *ml_elem = l->data;
+		if (NULL == ml_elem) continue;
+		if ((0 == memcmp(ml_elem->datahash, datahash, datahash_len)) &&
+			(0 == memcmp(ml_elem->filename, filename, strlen(filename)))) {
+			return 0; // container image with that name alread in list
+		}
+	}
+	INFO("Appending new hash for %s len=%zu", filename, datahash_len);
+	// new hash to be added
+	ml_elem_t *new_ml_elem = mem_new0(ml_elem_t, 1);
+	new_ml_elem->filename = mem_strdup(filename);
+	new_ml_elem->hash_len = datahash_len;
+	new_ml_elem->datahash = mem_new0(uint8_t, datahash_len);
+	memcpy(new_ml_elem->datahash, datahash, datahash_len);
+
+	new_ml_elem->algid = algid;
+
+	// extend to TPM
+	int ret = tpm2_pcrextend(CONTAINER_PCR_INDEX, TPM2D_HASH_ALGORITHM, datahash, datahash_len);
+	if (ret) {
+		ERROR("tpm extend failed");
+	}
+	// store the template as hexstring in the ML elem
+	new_ml_elem->template = tpm2_pcrread_new(CONTAINER_PCR_INDEX, TPM2D_HASH_ALGORITHM, true);
+
+	measurement_list = list_append(measurement_list, new_ml_elem);
+	measurement_list_len++;
+
+	return 0;
+}
+
+static const char *
+halg_id_to_ima_string(TPM_ALG_ID alg_id)
+{
+	switch (alg_id) {
+		case TPM_ALG_SHA1:
+			return "sha1";
+		case TPM_ALG_SHA256:
+			return "sha256";
+		case TPM_ALG_SHA384:
+			return "sha384";
+		default:
+			return "none";
+	}
+}
+
+char **
+ml_get_measurement_list_strings_new(void)
+{
+	char **strings = mem_new0(char*, measurement_list_len);
+
+	int i=0;
+	for (list_t *l = measurement_list; l; l = l->next, ++i) {
+		ml_elem_t *ml_elem = l->data;	
+		char *hex_datahash = convert_bin_to_hex_new(ml_elem->datahash, ml_elem->hash_len);
+		const char *halg_string = halg_id_to_ima_string(ml_elem->algid);
+		strings[i] = mem_printf("%d %s ima-ng %s:%s %s",
+				CONTAINER_PCR_INDEX, ml_elem->template->pcr_str,
+				halg_string, hex_datahash, ml_elem->filename);
+		INFO("ML (%d): %s", i, strings[i]);
+		mem_free(hex_datahash);
+	}
+
+	return strings;
+}
+
+int
+ml_get_measurement_list_len(void)
+{
+	return measurement_list_len;
+}

--- a/tpm2d/ml.h
+++ b/tpm2d/ml.h
@@ -1,0 +1,39 @@
+/*
+ * This file is part of trust|me
+ * Copyright(c) 2013 - 2018 Fraunhofer AISEC
+ * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 (GPL 2), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * The full GNU General Public License is included in this distribution in
+ * the file called "COPYING".
+ *
+ * Contact Information:
+ * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ */
+
+#ifndef ML_H
+#define ML_H
+
+#include "tpm2d.h"
+
+int
+ml_measurement_list_append(const char *filename, TPM_ALG_ID algid,
+		const uint8_t *datahash, size_t datahash_len);
+
+char **
+ml_get_measurement_list_strings_new(void);
+
+int
+ml_get_measurement_list_len(void);
+
+#endif /* ML_H */

--- a/tpm2d/tpm2_commands.c
+++ b/tpm2d/tpm2_commands.c
@@ -818,15 +818,15 @@ tpm2_load(TPMI_DH_OBJECT parent_handle, const char *parent_pwd,
 }
 
 TPM_RC
-tpm2_pcrextend(TPMI_DH_PCR pcr_index, TPMI_ALG_HASH hash_alg, const char *data)
+tpm2_pcrextend(TPMI_DH_PCR pcr_index, TPMI_ALG_HASH hash_alg, const uint8_t *data, size_t data_len)
 {
 	TPM_RC rc = TPM_RC_SUCCESS;
 	PCR_Extend_In in;
 
 	IF_NULL_RETVAL_ERROR(tss_context, TSS_RC_NULL_PARAMETER);
 
-	if (strlen(data) > sizeof(TPMU_HA)) {
-		ERROR("Data length %zu exceeds hash size %zu!", strlen(data), sizeof(TPMU_HA));
+	if (data_len > sizeof(TPMU_HA)) {
+		ERROR("Data length %zu exceeds hash size %zu!", data_len, sizeof(TPMU_HA));
 		return EXIT_FAILURE;
 	}
 
@@ -838,7 +838,7 @@ tpm2_pcrextend(TPMI_DH_PCR pcr_index, TPMI_ALG_HASH hash_alg, const char *data)
 	// pad and set data
 	in.digests.digests[0].hashAlg = hash_alg;
 	memset((uint8_t *)&in.digests.digests[0].digest, 0, sizeof(TPMU_HA));
-	memcpy((uint8_t *)&in.digests.digests[0].digest, data, strlen(data));
+	memcpy((uint8_t *)&in.digests.digests[0].digest, data, data_len);
 
 	rc = TSS_Execute(tss_context, NULL,
 			(COMMAND_PARAMETERS *)&in, NULL, TPM_CC_PCR_Extend,

--- a/tpm2d/tpm2d.h
+++ b/tpm2d/tpm2d.h
@@ -194,7 +194,7 @@ TPMI_DH_OBJECT
 tpm2d_get_as_key_handle(void);
 
 TPM_RC
-tpm2_pcrextend(TPMI_DH_PCR pcr_index, TPMI_ALG_HASH hash_alg, const char *data);
+tpm2_pcrextend(TPMI_DH_PCR pcr_index, TPMI_ALG_HASH hash_alg, const uint8_t *data, size_t data_len);
 
 tpm2d_quote_string_t *
 tpm2_quote_new(TPMI_DH_PCR pcr_indices, TPMI_DH_OBJECT sig_key_handle,

--- a/tpm2d/tpm2d.proto
+++ b/tpm2d/tpm2d.proto
@@ -35,6 +35,12 @@ enum IdsAttestationType {
   ADVANCED = 2;
 }
 
+enum HashAlgLen {
+  SHA1   = 20;
+  SHA256 = 32;
+  SHA384 = 48;
+}
+
 message Pcr {
   // the PCR number (usually between 0 and 23)
   optional int32 number = 1;
@@ -53,6 +59,7 @@ message ControllerToTpm {
 		DMCRYPT_LOCK = 6;
 		CHANGE_OWNER_PWD = 7;
 		DMCRYPT_RESET = 8;
+		ML_APPEND = 9;
 	}
 
 	required Code code = 1;
@@ -64,7 +71,7 @@ message ControllerToTpm {
 	optional string qualifyingData = 3;
 
 	// pcr bitmask for AttestationType ADVANCED only
-	//  - for BASIC, the default PCRs are PCRs 0 to 10
+	//  - for BASIC, the default PCRs are PCRs 0 to 11
 	//  - for ALL  , the default PCRs are PCRs 0 to 23
 	optional int32 pcrs = 4;
 
@@ -78,6 +85,11 @@ message ControllerToTpm {
 
 	// new passphrase for auth changing commands, e.g., change owner auth of tpm
 	optional string password_new = 8;
+
+	// file to be measured, e.g., the container readonly filesystem images
+	optional string ml_filename = 9;
+	optional bytes ml_datahash = 10;
+	optional HashAlgLen ml_hashalg = 11;
 }
 
 message TpmToController {
@@ -87,6 +99,7 @@ message TpmToController {
 		FDE_RESPONSE = 3;
 		RANDOM_RESPONSE = 4;
 	}
+
 	enum GenericResponse {
 		CMD_OK = 1;
 		CMD_FAILED = 2;
@@ -126,4 +139,7 @@ message TpmToController {
 	optional FdeResponse fde_response = 9;
 
 	optional string rand_data = 10;
+
+	// the measurement list in ima style hex strings
+	repeated string ml_entry = 11;
 }


### PR DESCRIPTION
This patch provides the implementation to provide an IMA-style
measurement list (ML) for container images. The cmld (guestos.c)
measures (generates the hash) of each read-only image before starting
the container and sends it to the tpm2d through the tss.h interface.
The tpm2d maintains the measurement list and extends new measurements
from the cmld to the TPM's PCR11, thus not interfering with the
IMA default in PCR10.

The ML is send at the end of the attestation request in the tpm2_control
interface to a remote verifier.

A sample ml_entry looks like this:

ml_entry: "11 4bf6d86968043a73640ebeb82d6a67481bc66f2ae7a9f5589d57fdebf3011b20 \
 ima-ng sha256:ace88b9a1573d8e0d2555d89b408b8a15d36f4d2ed1468d46143e4e0e9ff9579 \
 /data/cml/operatingsystems/trustx-coreos-1/root.img"