### PR TITLE
daemon: avoid Assertion `if_name' failed by sanitizing mac

### DIFF
--- a/daemon/c_net.c
+++ b/daemon/c_net.c
@@ -1120,7 +1120,7 @@ c_net_cleanup_interface(c_net_interface_t *ni)
 
 	/* shut the network interface down */
 	// check if iface was allready destroyed by kernel
-	if (c_net_is_veth_used(ni->veth_cmld_name)) {
+	if (ni->veth_cmld_name && c_net_is_veth_used(ni->veth_cmld_name)) {
 
 		if (c_net_bring_up_link_and_route(ni->veth_cmld_name, ni->subnet, false))
 			WARN("network interface could not be gracefully shut down");

--- a/daemon/container_config.c
+++ b/daemon/container_config.c
@@ -505,8 +505,6 @@ container_config_get_vnet_cfg_list_new(const container_config_t *config)
 			INFO("Generating new mac for if %s",
 				config->cfg->vnet_configs[i]->if_name);
 			file_read("/dev/urandom", (char*)mac, 6);
-			mac[0] &= 0xfe; /* clear multicast bit */
-			mac[0] |= 0x02; /* set local assignment bit (IEEE802) */
 			config->cfg->vnet_configs[i]->if_mac =
 				mem_printf("%02" PRIx8 ":%02" PRIx8 ":%02" PRIx8
 						":%02" PRIx8 ":%02" PRIx8 ":%02" PRIx8,
@@ -522,6 +520,9 @@ container_config_get_vnet_cfg_list_new(const container_config_t *config)
 				&mac[0], &mac[1], &mac[2],
 				&mac[3], &mac[4], &mac[5]);
 		}
+		// sanitize mac veth otherwise kernel may reject the mac
+		mac[0] &= 0xfe; /* clear multicast bit */
+		mac[0] |= 0x02; /* set local assignment bit (IEEE802) */
 
 		container_vnet_cfg_t *if_cfg = container_vnet_cfg_new(
 			config->cfg->vnet_configs[i]->if_name, NULL, mac,


### PR DESCRIPTION
If the user sets invalid mac address kernel will reject the
creation of the veth pair with "99: Address not available".
In that case, an assertion for the if_name of that interface
is triggered in c_net.c causing a fatal abort.

This patch gives only sanitized mac addresses out of the
config sub module, overwriting the user provided misconfiguration.