### PR TITLE
cmld: container check running state before exec command in c_run

### DIFF
--- a/daemon/container.c
+++ b/daemon/container.c
@@ -1294,6 +1294,17 @@ container_run(container_t *container, int create_pty, char *cmd, ssize_t argc, c
 	ASSERT(container);
 	ASSERT(cmd);
 
+	switch (container_get_state(container)) {
+		case CONTAINER_STATE_BOOTING:
+		case CONTAINER_STATE_RUNNING:
+		case CONTAINER_STATE_SETUP:
+			break;
+		default:
+			WARN("Container %s is not running thus no command could be exec'ed",
+				container_get_description(container));
+			return -1;
+	}
+
 	TRACE("Forwarding request to c_run subsystem");
 	return c_run_exec_process(container->run, create_pty, cmd, argc, argv);
 }

--- a/daemon/control.c
+++ b/daemon/control.c
@@ -1031,7 +1031,7 @@ control_handle_message(control_t *control, const ControllerToDaemon *msg, int fd
 			TRACE("Got exec command: %s, attach PTY: %d", msg->exec_command, msg->exec_pty);
 
 			if ((! container) || container_run(container, msg->exec_pty, msg->exec_command, msg->n_exec_args, msg->exec_args) < 0) {
-				ERROR("Failed to exec. Wrong UUID or or already executing command in this container.");
+				ERROR("Failed to exec");
 
 				DaemonToController out = DAEMON_TO_CONTROLLER__INIT;
 				out.code = DAEMON_TO_CONTROLLER__CODE__EXEC_END;


### PR DESCRIPTION
Without this check undefined behaviour may trigger a general
protection fault causing cmld to abort.