### PR TITLE
Enable compile- and link-time binary hardening

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -24,7 +24,8 @@
 
 CC ?= gcc
 
-LOCAL_CFLAGS += -I../include -pedantic -Wall -Wextra -Werror -std=gnu99 -D _POSIX_C_SOURCE=200809L -D _XOPEN_SOURCE=700 -D _DEFAULT_SOURCE -O2
+LOCAL_CFLAGS += -I../include -pedantic -std=gnu99 -D _POSIX_C_SOURCE=200809L -D _XOPEN_SOURCE=700 -D _DEFAULT_SOURCE -O2
+LOCAL_CFLAGS += -Wall -Wextra -Wcast-align -Wformat -Wformat-security -Werror -fstack-protector-all -fstack-clash-protection -fPIC
 
 .PHONY: all
 all: libcommon

--- a/control/Makefile
+++ b/control/Makefile
@@ -23,7 +23,7 @@
 
 
 LOCAL_CFLAGS := -std=gnu99 -I.. -I../include -Icommon -DDEBUG_BUILD -O2
-LOCAL_CFLAGS += -pedantic -Wall -Wextra -Werror
+LOCAL_CFLAGS += -pedantic -Wall -Wextra -Wcast-align -Wformat -Wformat-security -Werror -fstack-protector-all -fstack-clash-protection -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -fpic -pie
 
 SRC_FILES := \
 	common/list.c \

--- a/converter/Makefile
+++ b/converter/Makefile
@@ -24,8 +24,9 @@
 
 CC ?= gcc
 
-LOCAL_CFLAGS := -std=gnu99 -Icommon -I.. -I../include -DDEBUG_BUILD -pedantic -Wall -Wextra -Werror
+LOCAL_CFLAGS := -std=gnu99 -Icommon -I.. -I../include -DDEBUG_BUILD -pedantic 
 LOCAL_CFLAGS += -O2
+LOCAL_CFLAGS += -Wall -Wextra -Wcast-align -Wformat -Wformat-security -Werror -fstack-protector-all -fstack-clash-protection -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -fpic -pie
 
 PROTO_SRC := \
 	common/logf.pb-c.c \

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -23,7 +23,8 @@
 
 
 CC ?= gcc
-LOCAL_CFLAGS := -std=gnu99 -Icommon -I.. -I../include -I../tpm2d -pedantic -Wall -Wextra -Werror -O2
+LOCAL_CFLAGS := -std=gnu99 -Icommon -I.. -I../include -I../tpm2d -pedantic -O2
+LOCAL_CFLAGS += -Wall -Wextra -Wcast-align -Wformat -Wformat-security -Werror -fstack-protector-all -fstack-clash-protection -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -fpic -pie
 LOCAL_CFLAGS += -DDEBUG_BUILD
 LDLIBS := -lc -lprotobuf-c -lprotobuf-c-text -lselinux -Lcommon -lcommon -lutil
 

--- a/rattestation/Makefile
+++ b/rattestation/Makefile
@@ -24,7 +24,9 @@
 
 CC ?= gcc
 
-LOCAL_CFLAGS := -std=gnu99 -Icommon -I.. -I../include -DDEBUG_BUILD -pedantic -Wall -Wextra -Werror -O2
+LOCAL_CFLAGS := -std=gnu99 -Icommon -I.. -I../include -pedantic -O2
+LOCAL_CFLAGS += -DDEBUG_BUILD
+LOCAL_CFLAGS += -Wall -Wextra -Wcast-align -Wformat -Wformat-security -Werror -fstack-protector-all -fstack-clash-protection -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -fpic -pie
 
 PROTO_SRC := \
 	attestation.pb-c.c

--- a/run/Makefile
+++ b/run/Makefile
@@ -24,7 +24,9 @@
 
 CC ?= gcc
 
-LOCAL_CFLAGS := -std=gnu99 -I.. -DDEBUG_BUILD
+LOCAL_CFLAGS := -std=gnu99 -I.. -pedantic -O2
+LOCAL_CFLAGS += -DDEBUG_BUILD
+LOCAL_CFLAGS += -Wall -Wextra -Wcast-align -Wformat -Wformat-security -Werror -fstack-protector-all -fstack-clash-protection -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -fpic -pie
 
 SRC_FILES := \
         common/list.c \

--- a/scd/Makefile
+++ b/scd/Makefile
@@ -21,8 +21,9 @@
 # Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
 #
 
-LOCAL_CFLAGS := -std=gnu99 -I.. -I../include -I../tpm2d -Icommon -DDEBUG_BUILD -O2
-LOCAL_CFLAGS += -DTPM_POSIX
+LOCAL_CFLAGS := -std=gnu99 -I.. -I../include -I../tpm2d -Icommon -pedantic -O2
+LOCAL_CFLAGS += -DDEBUG_BUILD -DTPM_POSIX
+LOCAL_CFLAGS += -Wall -Wextra -Wcast-align -Wformat -Wformat-security -Werror -fstack-protector-all -fstack-clash-protection -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -fpic -pie
 
 SRC_FILES := \
 	common/list.c \

--- a/scd/control.c
+++ b/scd/control.c
@@ -303,7 +303,7 @@ scd_control_handle_message(const DaemonToToken *msg, int fd)
 			csr_len = file_size(DEVICE_CSR_FILE);
 			// we set maximum read length one byte grater than file_size
 			// since file_read sets '\0' char at the end of the buffer
-			csr = file_read_new(DEVICE_CSR_FILE, csr_len + 1);
+			csr = (uint8_t *)file_read_new(DEVICE_CSR_FILE, csr_len + 1);
 			if (csr_len < 0 || csr == NULL) {
 				out.code = TOKEN_TO_DAEMON__CODE__DEVICE_CSR_ERROR;
 			} else {
@@ -325,7 +325,7 @@ scd_control_handle_message(const DaemonToToken *msg, int fd)
 		} else if (!msg->has_device_cert) {
 			ERROR("No device_cert in msg!");
 			out.code = TOKEN_TO_DAEMON__CODE__DEVICE_CERT_ERROR;
-		} else if (-1 == file_write(DEVICE_CERT_FILE, msg->device_cert.data,
+		} else if (-1 == file_write(DEVICE_CERT_FILE, (char *)msg->device_cert.data,
 					    msg->device_cert.len)) {
 			ERROR("writing device cert to file :%s", DEVICE_CERT_FILE);
 			out.code = TOKEN_TO_DAEMON__CODE__DEVICE_CERT_ERROR;

--- a/scd/ssl_util.c
+++ b/scd/ssl_util.c
@@ -308,7 +308,7 @@ error:
 }
 
 static X509_REQ *
-ssl_mkreq(EVP_PKEY *pkeyp, const char *common_name, const char *uid, bool tpmkey)
+ssl_mkreq(EVP_PKEY *pkeyp, const char *common_name, const char *uid, UNUSED bool tpmkey)
 {
 	ASSERT(pkeyp);
 	ASSERT(common_name);

--- a/service/Makefile
+++ b/service/Makefile
@@ -24,7 +24,9 @@
 
 CC ?= gcc
 
-LOCAL_CFLAGS := -std=gnu99 -Icommon -I.. -I../include -DDEBUG_BUILD -O2
+LOCAL_CFLAGS := -std=gnu99 -Icommon -I.. -I../include -O2 -pedantic
+LOCAL_CFLAGS += -Wall -Wextra -Wcast-align -Wformat -Wformat-security -Werror -fstack-protector-all -fstack-clash-protection -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -fpic -pie
+LOCAL_CFLAGS += -DDEBUG_BUILD
 # set for sending boot complete protobuf message only
 #LOCAL_CFLAGS += -DBOOT_COMPLETE_ONLY
 
@@ -45,8 +47,6 @@ SRC_FILES := \
 	common/logf.pb-c.c \
 	service.c
 
-${SRC_FILES}: protobuf
-
 .PHONY: all
 all: service
 
@@ -57,11 +57,11 @@ protobuf: c_service.proto container.proto control.proto guestos.proto common/log
 	protoc-c --c_out=. guestos.proto
 	$(MAKE) -C common protobuf
 
-service: ${SRC_FILES}
-	${CC} -static ${LOCAL_CFLAGS} ${SRC_FILES} -lprotobuf-c -lprotobuf-c-text -o cml-service-container
+service: protobuf $(SRC_FILES)
+	$(CC) $(LOCAL_CFLAGS) $(CLAGS) $(SRC_FILES) -lprotobuf-c -lprotobuf-c-text -o cml-service-container
 
-service-static: ${SRC_FILES}
-	${CC} -static ${LOCAL_CFLAGS} ${CFLAGS} ${SRC_FILES} -lprotobuf-c -lprotobuf-c-text -o cml-service-container
+service-static: protobuf $(SRC_FILES)
+	$(CC) -static $(LOCAL_CFLAGS) $(CFLAGS) $(SRC_FILES) -lprotobuf-c -lprotobuf-c-text -o cml-service-container
 
 
 .PHONY: clean

--- a/service/Makefile
+++ b/service/Makefile
@@ -57,10 +57,12 @@ protobuf: c_service.proto container.proto control.proto guestos.proto common/log
 	protoc-c --c_out=. guestos.proto
 	$(MAKE) -C common protobuf
 
-service: protobuf $(SRC_FILES)
+$(SRC_FILES): protobuf
+
+service: $(SRC_FILES)
 	$(CC) $(LOCAL_CFLAGS) $(CLAGS) $(SRC_FILES) -lprotobuf-c -lprotobuf-c-text -o cml-service-container
 
-service-static: protobuf $(SRC_FILES)
+service-static: $(SRC_FILES)
 	$(CC) -static $(LOCAL_CFLAGS) $(CFLAGS) $(SRC_FILES) -lprotobuf-c -lprotobuf-c-text -o cml-service-container
 
 

--- a/tpm2_control/Makefile
+++ b/tpm2_control/Makefile
@@ -22,8 +22,9 @@
 #
 
 
-LOCAL_CFLAGS := -pedantic -Wall -Wextra -Werror -std=gnu99 \
-	-I.. -I../include -I../tpm2d -Icommon -DDEBUG_BUILD -O2
+LOCAL_CFLAGS := -std=gnu99 -I.. -I../include -I../tpm2d -Icommon -pedantic -O2
+LOCAL_CFLAGS += -Wall -Wextra -Wcast-align -Wformat -Wformat-security -Werror -fstack-protector-all -fstack-clash-protection -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -fpic -pie
+LOCAL_CFLAGS += -DDEBUG_BUILD
 
 SRC_FILES := \
 	common/protobuf.c \

--- a/tpm2d/Makefile
+++ b/tpm2d/Makefile
@@ -51,17 +51,17 @@ SRC_FILES := \
 .PHONY: all
 all: tpm2d
 
-
 protobuf: attestation.proto tpm2d.proto
 	protoc-c --c_out=. attestation.proto
 	protoc-c --c_out=. tpm2d.proto
 
+$(SRC_FILES): protobuf
+
 libcommon:
 	$(MAKE) -C common libcommon
 
-tpm2d: protobuf libcommon $(SRC_FILES)
+tpm2d: libcommon $(SRC_FILES)
 	$(CC) $(LOCAL_CFLAGS) $(SRC_FILES) -lc -lprotobuf-c -lprotobuf-c-text -libmtss -lcrypto -Lcommon -lcommon -o tpm2d
-
 
 .PHONY: clean
 clean:

--- a/tpm2d/Makefile
+++ b/tpm2d/Makefile
@@ -25,7 +25,8 @@ tss_cflags := \
         -Wall -W -Wmissing-declarations -Wmissing-prototypes -Wnested-externs \
 	-DTPM_POSIX
 
-LOCAL_CFLAGS := -std=gnu99 -I. -I.. -I../include -Icommon -Wextra -Werror $(tss_cflags) -O2
+LOCAL_CFLAGS := -std=gnu99 -I. -I.. -I../include -Icommon $(tss_cflags) -O2
+LOCAL_CFLAGS += -Wextra -Wcast-align -Wformat -Wformat-security -Werror -fstack-protector-all -fstack-clash-protection -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -fpic -pie
 #LOCAL_CFLAGS += -DTPM2D_NVMCRYPT_ONLY
 
 SRC_FILES := \
@@ -55,13 +56,11 @@ protobuf: attestation.proto tpm2d.proto
 	protoc-c --c_out=. attestation.proto
 	protoc-c --c_out=. tpm2d.proto
 
-${SRC_FILES}: protobuf
-
 libcommon:
 	$(MAKE) -C common libcommon
 
-tpm2d: libcommon ${SRC_FILES}
-	${CC} ${LOCAL_CFLAGS} ${SRC_FILES} -lc -lprotobuf-c -lprotobuf-c-text -libmtss -lcrypto -Lcommon -lcommon -o tpm2d
+tpm2d: protobuf libcommon $(SRC_FILES)
+	$(CC) $(LOCAL_CFLAGS) $(SRC_FILES) -lc -lprotobuf-c -lprotobuf-c-text -libmtss -lcrypto -Lcommon -lcommon -o tpm2d
 
 
 .PHONY: clean


### PR DESCRIPTION
This patch targets the build system. It enables:
- stack canaries (-fstack-protector-all)
- stack safe-guard pages that protect against legacy stack-clashing attacks
  (-fstack-clash-protection)
  (https://www.qualys.com/2017/09/26/linux-pie-cve-2017-1000253/cve-2017-1000253.txt)
- full relro to protect against GOT overrides for control flow hijacking
  (-Wl,-z,relro -Wl,z,now)
- position independent compilation and PIE linking. This allows ASLR to
  take effect also on the text segment (useful for throttling ROP)
- compile-time warnings against wrongful casts and incorrect format string
  usage

for all project binaries (control, converter, daemon, logcat,
rattestation, run, sc, service, tmp2_control, tmp2d)