### PR TITLE
cmld: introduce mount type for bind mounting files

### DIFF
--- a/common/file.c
+++ b/common/file.c
@@ -325,3 +325,17 @@ file_get_extension(const char *file)
 		return "";
 	return ext;
 }
+
+int
+file_touch(const char *file)
+{
+	IF_NULL_RETVAL(file, -1);
+
+	int fd = open(file, O_WRONLY | O_CREAT, 00666);
+	if (fd < 0) {
+		DEBUG_ERRNO("Could not touch output file %s", file);
+		return -1;
+	}
+	close(fd);
+	return 0;
+}

--- a/common/file.h
+++ b/common/file.h
@@ -149,4 +149,11 @@ file_size(const char *file);
 char *
 file_get_extension(const char *file);
 
+/**
+ * creates an empty file
+ * @param file The file name
+ */
+int
+file_touch(const char *file);
+
 #endif /* FILE_H */

--- a/daemon/c_vol.h
+++ b/daemon/c_vol.h
@@ -49,6 +49,8 @@ c_vol_free(c_vol_t *vol);
 
 /* Start hooks */
 int
+c_vol_start_pre_clone(const c_vol_t *vol);
+int
 c_vol_start_child(c_vol_t *vol);
 
 void

--- a/daemon/container.c
+++ b/daemon/container.c
@@ -1348,6 +1348,11 @@ container_start(container_t *container)//, const char *key)
 		goto error_pre_clone;
 	}
 
+	if (c_vol_start_pre_clone(container->vol) < 0) {
+		ret = CONTAINER_ERROR_VOL;
+		goto error_pre_clone;
+	}
+
 	// Wifi module?
 
 	/*********************************************************/

--- a/daemon/guestos.proto
+++ b/daemon/guestos.proto
@@ -50,6 +50,8 @@ message GuestOSMount {
 		OVERLAY_RO = 7; // read only overlay images e.g. for system features
 		SHARED_RW = 8; // image shared by all containers of same OS type (writable tmpfs as overlay)
 		OVERLAY_RW = 9; // similar to EMPTY image, however overlayed on given mount_point (writable persitent fs as overlay)
+		BIND_FILE = 10;
+		BIND_FILE_RW = 11;
 	}
 	required Type mount_type = 4;   // type of the image file
 

--- a/daemon/guestos_config.c
+++ b/daemon/guestos_config.c
@@ -109,6 +109,10 @@ guestos_config_mount_type_from_protobuf(GuestOSMount__Type mt)
 		return MOUNT_TYPE_SHARED_RW;
 	case GUEST_OSMOUNT__TYPE__OVERLAY_RW:
 		return MOUNT_TYPE_OVERLAY_RW;
+	case GUEST_OSMOUNT__TYPE__BIND_FILE:
+		return MOUNT_TYPE_BIND_FILE;
+	case GUEST_OSMOUNT__TYPE__BIND_FILE_RW:
+		return MOUNT_TYPE_BIND_FILE_RW;
 	default:
 		FATAL("Invalid protobuf mount type %d.", mt);
 	}

--- a/daemon/mount.h
+++ b/daemon/mount.h
@@ -56,6 +56,8 @@ enum mount_type {
 	MOUNT_TYPE_OVERLAY_RW = 9,  /**< image file is shared by all containers of the operating
 				      system type and an individual writable persitent fs is mounted
 				      as overlay to each container */
+	MOUNT_TYPE_BIND_FILE = 10,     /**< file is bind mounted to container (RO) */
+	MOUNT_TYPE_BIND_FILE_RW = 11,  /**< file is bind mounted to container (RW) */
 };
 
 mount_t *


### PR DESCRIPTION
This could be used to share config files between containers.
e.g. create a guestos with an bind mount rw and another one with bind mount ro:

guestos to provide config
```
mounts {
  image_file: "someconfig.cfg"
  mount_point: "/etc/someconfig.rw"
  fs_type: "none"
  mount_type: BIND_FILE_RW
}
```
guestos to use config:
```
mounts {
  image_file: "someconfig.cfg"
  mount_point: "/etc/someconfig.ro"
  fs_type: "none"
  mount_type: BIND_FILE
}
```