### PR TITLE
Fixed: Missing java_package in some protobuf files

### DIFF
--- a/daemon/device.proto
+++ b/daemon/device.proto
@@ -23,6 +23,8 @@
 
 syntax = "proto2";
 
+option java_package = "de.fraunhofer.aisec.trustme";
+
 message DeviceConfig {
 	// unique uuid. may change due to user change.
 	// may be generated if no uuid is available.

--- a/tpm2d/attestation.proto
+++ b/tpm2d/attestation.proto
@@ -23,6 +23,8 @@
 
 syntax = "proto2";
 
+option java_package = "de.fraunhofer.aisec.trustme";
+
 // type of attestation in the IDS context
 enum IdsAttestationType {
   // kernel + core container (PCR 0 to 10)

--- a/tpm2d/tpm2d.proto
+++ b/tpm2d/tpm2d.proto
@@ -23,6 +23,8 @@
 
 syntax = "proto2";
 
+option java_package = "de.fraunhofer.aisec.trustme";
+
 import "attestation.proto";
 
 message ControllerToTpm {


### PR DESCRIPTION
This commit fixes Github issue #80 opend by Heosuabi:
"
The following protobuf files don't have a java_package option:

    ./tpm2d/attestation.proto
    ./tpm2d/tpm2d.proto
    ./daemon/device.proto

Without the java_package option the default package is . after compiling.
This can be problematic depending on the application and the environment.
"