### PR TITLE
Fix missing syntax version

### DIFF
--- a/daemon/crypto.proto
+++ b/daemon/crypto.proto
@@ -21,6 +21,8 @@
  * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
  */
 
+syntax = "proto2";
+
 option java_package = "de.fraunhofer.aisec.trustme";
 
 /* crypto.proto: structures and identifiers related to cryptography


### PR DESCRIPTION
Specify to use proto2 as syntax to fix compiler warning about missing
syntax. Currently proto2 is used as default value for syntax version,
when no syntax is defined.

Fixes #90