### PR TITLE
Feature: Make userns available for trustx

### DIFF
--- a/common/dir.c
+++ b/common/dir.c
@@ -81,6 +81,7 @@ dir_mkdir_p(const char *path, mode_t mode)
 	int ret = 0;
 
 	//DEBUG("Doing mkdir -p on path %s", p);
+	mode_t old_mask = umask(0);
 
 	if (c[0] == '/') {
 		c++;
@@ -103,6 +104,7 @@ dir_mkdir_p(const char *path, mode_t mode)
 		ret = -1;
 	}
 out:
+	umask(old_mask);
 	mem_free(p);
 	return ret;
 }

--- a/common/proc.c
+++ b/common/proc.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of trust|me
- * Copyright(c) 2013 - 2019 Fraunhofer AISEC
+ * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/common/proc.h
+++ b/common/proc.h
@@ -59,4 +59,7 @@ proc_killall(pid_t ppid, const char *name, int sig);
 pid_t
 proc_find(pid_t ppid, const char *name);
 
+int
+proc_fork_and_execvp(const char *const *argv);
+
 #endif /* PROC_H */

--- a/converter/docker.c
+++ b/converter/docker.c
@@ -29,6 +29,7 @@
 #include "common/dir.h"
 #include "common/list.h"
 #include "common/mem.h"
+#include "common/proc.h"
 
 #include "cJSON/cJSON.h"
 #include "util.h"
@@ -383,7 +384,7 @@ docker_generate_basic_auth(const char *user, const char *password, const char *t
 	char *url = mem_printf("https://%s", host_url);
 
 	const char *const argv[] = { CURL_PATH, "-fsSL", "-H", auth, url, NULL };
-	ret = util_fork_and_execvp(CURL_PATH, argv);
+	ret = proc_fork_and_execvp(CURL_PATH, argv);
 	if (ret == 0) {
 		INFO("Auth OK. Storing access token!");
 		file_printf(token_file, "{ \"token\": \"%s\" }", out);
@@ -406,7 +407,7 @@ docker_get_curl_token_new(char *image_name, char *token_file)
 
 	if (!file_exists(token_file)) {
 		const char *const argv[] = { CURL_PATH, "-fsSL", url, "-o", token_file, NULL };
-		util_fork_and_execvp(CURL_PATH, argv);
+		proc_fork_and_execvp(CURL_PATH, argv);
 	}
 
 	cJSON *jroot = NULL;
@@ -445,10 +446,10 @@ docker_download_manifest_list(const char *curl_token, const char *out_file, cons
 	const char *const argv_bearer[] = { CURL_PATH,  "-fsSL", "-H", auth_bearer, "-H",
 					    acceptlist, url,     "-o", out_file,    NULL };
 
-	int ret = util_fork_and_execvp(CURL_PATH, argv_bearer);
+	int ret = proc_fork_and_execvp(CURL_PATH, argv_bearer);
 	if (ret != 0) {
 		INFO("Bearer auth failed (curl returned %d), trying Basic auth", ret);
-		ret = util_fork_and_execvp(CURL_PATH, argv_basic);
+		ret = proc_fork_and_execvp(CURL_PATH, argv_basic);
 	}
 
 	mem_free(url);
@@ -477,10 +478,10 @@ docker_download_manifest(const char *curl_token, const char *out_file, const cha
 					    "-H",      acceptv2, "-H",     acceptv1,
 					    url,       "-o",     out_file, NULL };
 
-	int ret = util_fork_and_execvp(CURL_PATH, argv_bearer);
+	int ret = proc_fork_and_execvp(CURL_PATH, argv_bearer);
 	if (ret != 0) {
 		INFO("Bearer auth failed (curl returned %d), trying Basic auth", ret);
-		ret = util_fork_and_execvp(CURL_PATH, argv_basic);
+		ret = proc_fork_and_execvp(CURL_PATH, argv_basic);
 	}
 
 	mem_free(url);
@@ -520,9 +521,9 @@ download_docker_remote_file(const char *curl_token, const docker_remote_file_t *
 	const char *const argv_basic[] = { CURL_PATH, "-fSL", "--progress", "-H", auth_basic,
 					   url,       "-o",   out_file,     NULL };
 
-	ret = util_fork_and_execvp(CURL_PATH, argv_bearer);
+	ret = proc_fork_and_execvp(CURL_PATH, argv_bearer);
 	if (ret != 0)
-		ret = util_fork_and_execvp(CURL_PATH, argv_basic);
+		ret = proc_fork_and_execvp(CURL_PATH, argv_basic);
 
 	mem_free(url);
 	mem_free(auth_basic);

--- a/converter/util.h
+++ b/converter/util.h
@@ -36,9 +36,6 @@ b64_ntop(unsigned char const *src, size_t srclength, char *target, size_t targsi
 int
 b64_pton(char const *src, unsigned char *target, size_t targsize);
 
-int
-util_fork_and_execvp(const char *path, const char *const *argv);
-
 char *
 util_hash_sha_image_file_new(const char *image_file);
 

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -1,6 +1,6 @@
 #
 # This file is part of trust|me
-# Copyright(c) 2013 - 2018 Fraunhofer AISEC
+# Copyright(c) 2013 - 2020 Fraunhofer AISEC
 # Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
 #
 # This program is free software; you can redistribute it and/or modify it
@@ -68,6 +68,7 @@ SRC_FILES := main.c \
 	c_service.c \
 	display.c \
 	c_net.c \
+	c_user.c \
 	c_vol.c \
 	common/network.c \
 	common/proc.c \

--- a/daemon/c_user.c
+++ b/daemon/c_user.c
@@ -1,0 +1,405 @@
+/*
+ * This file is part of trust|me
+ * Copyright(c) 2013 - 2020 Fraunhofer AISEC
+ * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 (GPL 2), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * The full GNU General Public License is included in this distribution in
+ * the file called "COPYING".
+ *
+ * Contact Information:
+ * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ */
+
+#include "c_user.h"
+
+#define _GNU_SOURCE
+#include <fcntl.h>
+#include <limits.h>
+#include <sys/mount.h>
+#include <sched.h>
+#include <sys/prctl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "common/macro.h"
+#include "common/mem.h"
+#include "common/file.h"
+#include "common/dir.h"
+#include "container.h"
+
+#define UID_RANGE 10000
+#define UID_RANGES_START 30000
+#define MAX_UID_RANGES ((UINT_MAX - UID_RANGES_START) / UID_RANGE)
+
+/* Paths for controling mappings */
+#define C_USER_UID_MAP_PATH "/proc/%d/uid_map"
+#define C_USER_GID_MAP_PATH "/proc/%d/gid_map"
+
+#define C_USER_MAP_FORMAT "%d %d %d"
+
+#define SHIFTFS_DIR "/tmp/shiftfs"
+
+struct c_user_shift {
+	char *target;
+	char *mark;
+	bool is_root;
+};
+
+/* User structure with specific usernamespace mappings */
+struct c_user {
+	container_t *container; //!< container which the c_user struct is associated to
+	bool ns_usr;		//!< indicates if the c_user structure has an user namespace
+	unsigned int offset;    //!< gives information about the uid mapping to be set
+	int uid_start;		//!< this is the start of uids and gids in the root namespace
+	list_t *marks;		//marks to be mounted in userns
+	int mark_index;
+};
+
+/**
+ * bool array, which globally holds assigend ranges in order to
+ * determine a new offset for a starting container.
+ * uid_offsets[i]==true means that a container holds this offset to get its
+ * specific uid range
+ */
+static bool *uid_offsets = NULL;
+
+/**
+ * sets the offset at the specified position to false.
+ * indicates that a container releases its addresses.
+ */
+static void
+c_user_unset_offset(unsigned int offset)
+{
+	ASSERT(offset < MAX_UID_RANGES);
+	TRACE("UID offset %d released by a container", offset);
+
+	uid_offsets[offset] = false;
+}
+
+/**
+ * determines first free slot and occupies it. Also responsible for allocating the offsets array.
+ * @return failure, return -1, else return first free offset
+ */
+static int
+c_user_set_next_offset(void)
+{
+	if (!uid_offsets) {
+		uid_offsets = mem_new0(bool, MAX_UID_RANGES);
+		uid_offsets[0] = true;
+		TRACE("UID offset 0 ocupied by a container");
+		return 0;
+	}
+
+	for (unsigned int i = 0; i < MAX_UID_RANGES; i++) {
+		if (!uid_offsets[i]) {
+			TRACE("UID offset %d occupied by a container", i);
+			uid_offsets[i] = true;
+			return i;
+		}
+	}
+
+	DEBUG("Unable to provide a valid uid/gid range for c_user");
+	return -1;
+}
+
+/**
+ * This function determines and sets the next available uid range, depending on the container offset.
+ */
+static int
+c_user_set_next_uid_range_start(c_user_t *user)
+{
+	ASSERT(user);
+
+	int offset = c_user_set_next_offset();
+	IF_TRUE_RETVAL((offset < 0), -1);
+
+	user->uid_start = UID_RANGES_START + ((unsigned int)offset) * UID_RANGE;
+
+	if (user->uid_start == 0) {
+		ERROR("failed to get free uid/gid map start");
+		return -1;
+	}
+	DEBUG("next free uid/gid map start is: %u", user->uid_start);
+
+	return 0;
+}
+
+/**
+ * This function allocates a new c_user_t instance, associated to a specific container object.
+ * @return the c_user_t user structure which holds user namespace information for a container.
+ */
+c_user_t *
+c_user_new(container_t *container, bool user_ns)
+{
+	ASSERT(container);
+
+	c_user_t *user = mem_new0(c_user_t, 1);
+	user->container = container;
+	user->ns_usr = user_ns;
+	user->uid_start = 0;
+
+	TRACE("new c_user struct was allocated");
+
+	return user;
+}
+
+/**
+ * Setup mappings for uids and gids
+ */
+static int
+c_user_setup_mapping(const c_user_t *user)
+{
+	ASSERT(user);
+	/* Skip this, if the container doesn't have a user namespace */
+	if (!user->ns_usr)
+		return 0;
+
+	char *uid_mapping = mem_printf(C_USER_MAP_FORMAT, 0, user->uid_start, UID_RANGE - 1);
+	INFO("mapping: '%s'", uid_mapping);
+
+	char *uid_map_path = mem_printf(C_USER_UID_MAP_PATH, container_get_pid(user->container));
+	char *gid_map_path = mem_printf(C_USER_GID_MAP_PATH, container_get_pid(user->container));
+
+	// write mapping to proc
+	if (file_printf(uid_map_path, "%s", uid_mapping) == -1) {
+		ERROR_ERRNO("Failed to write to %s", uid_map_path);
+		goto error;
+	}
+	if (file_printf(gid_map_path, "%s", uid_mapping) == -1) {
+		ERROR_ERRNO("Failed to write to %s", gid_map_path);
+		goto error;
+	}
+
+	INFO("uid/gid mapping '%s' for %s activated", uid_mapping,
+	     container_get_name(user->container));
+
+	mem_free(uid_mapping);
+	mem_free(uid_map_path);
+	mem_free(gid_map_path);
+	return 0;
+error:
+	mem_free(uid_mapping);
+	mem_free(uid_map_path);
+	mem_free(gid_map_path);
+	return -1;
+}
+
+/**
+ * Cleans up the c_user_t struct.
+ */
+void
+c_user_cleanup(c_user_t *user)
+{
+	ASSERT(user);
+
+	/* We can skip this in case the container has no user ns */
+	if (!user->ns_usr)
+		return;
+
+	c_user_unset_offset(user->offset);
+
+	// cleanup shifted mounts in reverse order
+	for (list_t *l = list_tail(user->marks); l != user->marks; l = l->prev) {
+		struct c_user_shift *shift = l->data;
+		if (shift->is_root) {
+			char *dev_dir = mem_printf("%s/dev", shift->target);
+			if (umount(dev_dir) < 0)
+				WARN_ERRNO("Could not umount dev on %s", dev_dir);
+			mem_free(dev_dir);
+		}
+		if (umount(shift->target) < 0)
+			WARN_ERRNO("Could not umount shift target on %s", shift->target);
+		if (umount(shift->mark) < 0)
+			WARN_ERRNO("Could not umount shift mark on %s", shift->mark);
+		mem_free(shift->mark);
+		mem_free(shift->target);
+		mem_free(shift);
+	}
+	list_delete(user->marks);
+	user->marks = NULL;
+}
+
+/**
+ * Frees the c_user_t structure
+ */
+void
+c_user_free(c_user_t *user)
+{
+	ASSERT(user);
+	mem_free(user);
+}
+
+int
+c_user_get_uid(const c_user_t *user)
+{
+	ASSERT(user);
+	return user->uid_start;
+}
+
+/**
+ * Become root in new userns
+ */
+int
+c_user_start_child(UNUSED const c_user_t *user)
+{
+	INFO("uid %d, euid %d", getuid(), geteuid());
+	if (setuid(0) < 0) {
+		ERROR_ERRNO("Could not become root 'setuid(0)' in new userns");
+		return -1;
+	}
+	if (setgid(0) < 0) {
+		ERROR_ERRNO("Could not set gid to '0' in new userns");
+		return -1;
+	}
+	INFO("uid %d, euid %d", getuid(), geteuid());
+	return 0;
+}
+
+/**
+ * Prepares uid/gids of dir using the parent ids for this c_user_t
+ *
+ * Call this before entering the new user_ns.
+ */
+int
+c_user_shift_ids(c_user_t *user, const char *dir, bool is_root)
+{
+	/* We can skip this in case the container has no user ns */
+	if (!user->ns_usr)
+		return 0;
+
+	INFO("uid %d, euid %d", getuid(), geteuid());
+
+	// create mountpoints for lower and upper dev
+	if (dir_mkdir_p(SHIFTFS_DIR, 0777) < 0) {
+		ERROR_ERRNO("Could not mkdir %s", SHIFTFS_DIR);
+		return -1;
+	}
+	if (chmod(SHIFTFS_DIR, 00777) < 0) {
+		ERROR_ERRNO("Could not chmod %s", SHIFTFS_DIR);
+		goto error;
+	}
+
+	struct c_user_shift *shift_mark = mem_new0(struct c_user_shift, 1);
+	shift_mark->target = mem_strdup(dir);
+	shift_mark->mark =
+		mem_printf("%s/%s/mark/%d", SHIFTFS_DIR,
+			   uuid_string(container_get_uuid(user->container)), user->mark_index++);
+	shift_mark->is_root = is_root;
+	if (dir_mkdir_p(shift_mark->mark, 0777) < 0) {
+		ERROR_ERRNO("Could not mkdir shiftfs dir %s", shift_mark->mark);
+		goto error;
+	}
+	if (mount(dir, shift_mark->mark, "shiftfs", 0, "mark") < 0) {
+		ERROR_ERRNO("Could not mark shiftfs origin %s on mark %s", dir, shift_mark->mark);
+		goto error;
+	}
+
+	user->marks = list_append(user->marks, shift_mark);
+
+	INFO("Successfully created new user namespace");
+	return 0;
+error:
+	return -1;
+}
+
+/**
+ * Reserves a mapping for uids and gids of the user namespace in rootns
+ */
+int
+c_user_start_pre_clone(c_user_t *user)
+{
+	ASSERT(user);
+
+	/* Skip this, if the container doesn't have a user namespace */
+	if (!user->ns_usr)
+		return 0;
+
+	// reserve a new mapping
+	if (c_user_set_next_uid_range_start(user)) {
+		ERROR("Reserving uid range for userns");
+		return -1;
+	}
+	return 0;
+}
+
+int
+c_user_start_post_clone(const c_user_t *user)
+{
+	return c_user_setup_mapping(user);
+}
+
+int
+c_user_shift_mounts(const c_user_t *user)
+{
+	char *target_dev, *saved_dev;
+	target_dev = saved_dev = NULL;
+
+	INFO("uid %d, euid %d", getuid(), geteuid());
+	for (list_t *l = user->marks; l; l = l->next) {
+		struct c_user_shift *shift_mark = l->data;
+
+		// save already mounted dev to remount after new rootfs mount
+		if (shift_mark->is_root) {
+			target_dev = mem_printf("%s/dev", shift_mark->target);
+			saved_dev = mem_printf("%s/%s/dev", SHIFTFS_DIR,
+					       uuid_string(container_get_uuid(user->container)));
+			if (dir_mkdir_p(saved_dev, 0777) < 0) {
+				ERROR_ERRNO("Could not mkdir temporary dev dir '%s'", saved_dev);
+				goto error;
+			}
+			if (mount(target_dev, saved_dev, NULL, MS_BIND, NULL) < 0) {
+				ERROR_ERRNO("Could not move dev '%s' to saved_dev '%s'", target_dev,
+					    saved_dev);
+			}
+		}
+
+		// mount the shifted user ids to new root
+		if (mount(shift_mark->mark, shift_mark->target, "shiftfs", 0, NULL) < 0) {
+			ERROR_ERRNO("Could not remount shiftfs mark %s to %s", shift_mark->mark,
+				    shift_mark->target);
+			goto error;
+		} else {
+			INFO("Successfully shifted root uid/gid for userns mount %s",
+			     shift_mark->target);
+		}
+
+		// remount saved dev location at new shifted rootfs
+		if (shift_mark->is_root) {
+			if (mount(saved_dev, target_dev, NULL, MS_BIND, NULL) < 0) {
+				ERROR_ERRNO("Could mount dev '%s' in new root", target_dev);
+			}
+			INFO("Successfully moved dev to shifted rootfs at '%s'", target_dev);
+		}
+		//mem_free(shift_mark->mark);
+		//mem_free(shift_mark->target);
+		//mem_free(shift_mark);
+	}
+
+	//mem_free(dev_mark);
+	//mem_free(dev_target);
+	//mem_free(shift_mark);
+	if (target_dev)
+		mem_free(target_dev);
+	if (saved_dev)
+		mem_free(saved_dev);
+	return 0;
+error:
+	//	mem_free(shift_mark);
+	if (target_dev)
+		mem_free(target_dev);
+	if (saved_dev)
+		mem_free(saved_dev);
+	return -1;
+}

--- a/daemon/c_user.h
+++ b/daemon/c_user.h
@@ -1,0 +1,91 @@
+/*
+ * This file is part of trust|me
+ * Copyright(c) 2013 - 2020 Fraunhofer AISEC
+ * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 (GPL 2), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * The full GNU General Public License is included in this distribution in
+ * the file called "COPYING".
+ *
+ * Contact Information:
+ * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ */
+#ifndef C_USER_H
+#define C_USER_H
+
+#include "container.h"
+
+/**
+ * Opaque c_user_t type for containers with usernamspace
+ */
+typedef struct c_user c_user_t;
+
+/**
+ * This function allocates a new c_user_t instance, associated to a specific container object.
+ * @return the c_user_t user structure which holds user namespace information for a container.
+ */
+c_user_t *
+c_user_new(container_t *container, bool user_ns);
+
+/**
+ * Returns the uid of the root user in the user namspace.
+ */
+int
+c_user_get_uid(const c_user_t *user);
+
+/**
+ * Reserves a mapping for uids and gids of the user namespace in rootns
+ */
+int
+c_user_start_pre_clone(c_user_t *user);
+
+/**
+ * Shifts mount tree using parent ids for shifted ids for this c_user_t
+ *
+ * Call this before entering the new user_ns, this function will spawn the
+ * new user_ns by itself.
+ */
+int
+c_user_start_child(const c_user_t *user);
+
+/**
+ * Setup mapping for uids and gids of the user namespace in rootns
+ */
+int
+c_user_start_post_clone(const c_user_t *user);
+
+/**
+ * Cleans up the c_user_t struct.
+ */
+void
+c_user_cleanup(c_user_t *user);
+
+/**
+ * Frees the c_net_t structure
+ */
+void
+c_user_free(c_user_t *user);
+
+/**
+ * Prepares a directory for mounting with shifted ids for this c_user_t
+ */
+int
+c_user_shift_ids(c_user_t *user, const char *dir, bool is_root);
+
+/**
+ * Mounts all directories with shifted ids for this c_user_t
+ */
+int
+c_user_shift_mounts(const c_user_t *user);
+
+#endif /* C_USER_H */

--- a/daemon/c_vol.c
+++ b/daemon/c_vol.c
@@ -1144,6 +1144,9 @@ c_vol_start_pre_clone(c_vol_t *vol)
 		if (mount(devfstype, dev_mnt, devfstype, devopts, tmpfs_opts) < 0)
 			WARN_ERRNO("Could not mount /dev");
 	}
+	if (container_shift_ids(vol->container, dev_mnt, false) < 0)
+		WARN("Failed to setup ids for %s in user namespace!", dev_mnt);
+
 	mem_free(dev_mnt);
 	mem_free(tmpfs_opts);
 

--- a/daemon/c_vol.h
+++ b/daemon/c_vol.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of trust|me
- * Copyright(c) 2013 - 2017 Fraunhofer AISEC
+ * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -52,7 +52,7 @@ c_vol_is_encrypted(c_vol_t *vol);
 
 /* Start hooks */
 int
-c_vol_start_pre_clone(const c_vol_t *vol);
+c_vol_start_pre_clone(c_vol_t *vol);
 int
 c_vol_start_child(c_vol_t *vol);
 

--- a/daemon/container.c
+++ b/daemon/container.c
@@ -276,7 +276,7 @@ container_new_internal(const uuid_t *uuid, const char *name, container_type_t ty
 	/* initialize exit_status to 0 */
 	container->exit_status = 0;
 
-	container->ns_usr = ns_usr;
+	container->ns_usr = file_exists("/proc/self/ns/user") ? ns_usr : false;
 	container->ns_net = ns_net;
 	container->ns_ipc = hardware_supports_systemv_ipc() ? true : false;
 	container->privileged = privileged;

--- a/daemon/container.h
+++ b/daemon/container.h
@@ -107,7 +107,8 @@ enum container_error {
 	CONTAINER_ERROR_CGROUPS,
 	CONTAINER_ERROR_NET,
 	CONTAINER_ERROR_SERVICE,
-	CONTAINER_ERROR_DEVNS
+	CONTAINER_ERROR_DEVNS,
+	CONTAINER_ERROR_USER
 };
 
 typedef enum {
@@ -642,6 +643,9 @@ container_get_dns_server(const container_t *container);
 bool
 container_has_netns(const container_t *container);
 
+bool
+container_has_userns(const container_t *container);
+
 /**
  * Returns the ip of the first interface set inside the container
  */
@@ -729,5 +733,30 @@ container_device_allow(container_t *container, int major, int minor, bool assign
  */
 int
 container_device_deny(container_t *container, int major, int minor);
+
+/**
+ * Prepares a mount for shifted uid and gids of directory for the container's userns.
+ *
+ * Needs to be called in rootns for each filesystem image which should be mounted
+ * with shifted ids in child.
+ */
+int
+container_shift_ids(const container_t *container, const char *dir, bool is_root);
+
+/**
+ * Mounts all directories with shiftied uid and gids inside the container's userns.
+ *
+ * Needs to be called bevore exec usually in a start_child handler.
+ */
+int
+container_shift_mounts(const container_t *container);
+
+/**
+ * Returns the uid which is mapped to the rootuser inside the container
+ * 
+ * if userns is enabled this whould be a uid grater than 0.
+ */
+int
+container_get_uid(const container_t *container);
 
 #endif /* CONTAINER_H */

--- a/daemon/container.proto
+++ b/daemon/container.proto
@@ -73,6 +73,8 @@ message ContainerConfig {
 
 	repeated string init_env = 8;	// environment variables
 
+	optional bool userns = 10 [default = true];
+
 	// Flags indicating the allows for containers:
 	optional bool allow_autostart = 17 [default = false];
 	// TODO: add further features as necessary

--- a/daemon/container_config.c
+++ b/daemon/container_config.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of trust|me
- * Copyright(c) 2013 - 2019 Fraunhofer AISEC
+ * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/daemon/container_config.c
+++ b/daemon/container_config.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of trust|me
- * Copyright(c) 2013 - 2017 Fraunhofer AISEC
+ * Copyright(c) 2013 - 2019 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -438,6 +438,14 @@ container_config_has_netns(const container_config_t *config)
 	ASSERT(config);
 	ASSERT(config->cfg);
 	return config->cfg->netns;
+}
+
+bool
+container_config_has_userns(const container_config_t *config)
+{
+	ASSERT(config);
+	ASSERT(config->cfg);
+	return config->cfg->userns;
 }
 
 void

--- a/daemon/container_config.h
+++ b/daemon/container_config.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of trust|me
- * Copyright(c) 2013 - 2019 Fraunhofer AISEC
+ * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * This program is free software; you can redistribute it and/or modify it

--- a/daemon/container_config.h
+++ b/daemon/container_config.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of trust|me
- * Copyright(c) 2013 - 2017 Fraunhofer AISEC
+ * Copyright(c) 2013 - 2019 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -208,6 +208,12 @@ container_config_get_dns_server(const container_config_t *config);
  */
 bool
 container_config_has_netns(const container_config_t *config);
+
+/**
+ * Indicates whether the container has an own user namespace
+ */
+bool
+container_config_has_userns(const container_config_t *config);
 
 /**
  * Adds the given interface name to the list of network interfaces assigned to the container


### PR DESCRIPTION
**Main patch is: cmld: activate user namespace for containers** 
This patch activates the user namespace according to the container
configuration file (default = on). A new container submodule c_user
is introduced which handles the uid and gid mappings in the root
namespace. Each container is mapped to a new range of 10000 uids
starting from uid 30000.
The c_user module also provides an interface which is used by c_vol
to shift uids and gids of directories. This feature depends on the
non-mainline shifts.

The rest are fixes and cleanups, see commit messages