### PR TITLE
Feature: private netns for c0

### DIFF
--- a/common/network.c
+++ b/common/network.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of trust|me
- * Copyright(c) 2013 - 2017 Fraunhofer AISEC
+ * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -416,4 +416,23 @@ network_routing_rules_set_all_main(bool flush)
 	const char *const argv2[] = { IP_PATH,  "rule",		  "add", "from", "all",
 				      "lookup", IP_ROUTING_TABLE, NULL };
 	return proc_fork_and_execvp(argv2);
+}
+
+list_t *
+network_get_physical_interfaces_new()
+{
+	struct if_nameindex *if_ni, *i;
+	if_ni = if_nameindex();
+
+	list_t *if_name_list = NULL;
+
+	IF_NULL_RETVAL(if_ni, NULL);
+
+	for (i = if_ni; i->if_index != 0 || i->if_name != NULL; i++) {
+		char *dev_drv_path = mem_printf("/sys/class/net/%s/device/driver", i->if_name);
+		if (file_exists(dev_drv_path))
+			if_name_list = list_append(if_name_list, mem_strdup(i->if_name));
+		mem_free(dev_drv_path);
+	}
+	return if_name_list;
 }

--- a/common/network.h
+++ b/common/network.h
@@ -146,4 +146,10 @@ network_move_link_ns(pid_t src_pid, pid_t dest_pid, const char *interface);
 int
 network_list_link_ns(pid_t pid, list_t **link_list);
 
+/*
+ * Generates a list containing names of all available physical network interfaces
+ */
+list_t *
+network_get_physical_interfaces_new(void);
+
 #endif /* NETWORK_H */

--- a/daemon/c_net.c
+++ b/daemon/c_net.c
@@ -21,9 +21,10 @@
  * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
  */
 
+#define _GNU_SOURCE
+
 #include "c_net.h"
 
-#define _GNU_SOURCE
 #include <sched.h>
 #include <netinet/in.h>
 #include <stdbool.h>

--- a/daemon/c_net.c
+++ b/daemon/c_net.c
@@ -51,6 +51,7 @@
 #include "common/proc.h"
 #include "common/event.h"
 #include "container.h"
+#include "cmld.h"
 #include "hardware.h"
 
 /* Offset for ipv4/mac address allocation, e.g. 127.1.(IPV4_SUBNET_OFFS+x).2
@@ -1027,6 +1028,15 @@ c_net_start_post_clone(c_net_t *net)
 		DEBUG("move phys %s to the ns of this pid: %d", iff_name, pid);
 		if (c_net_move_ifi(iff_name, pid) < 0)
 			return -1;
+	}
+	if (container_is_privileged(net->container)) {
+		for (list_t *l = cmld_get_netif_phys_list(); l; l = l->next) {
+			char *iff_name = l->data;
+
+			DEBUG("move phys %s to the ns of this pid: %d", iff_name, pid);
+			if (c_net_move_ifi(iff_name, pid) < 0)
+				return -1;
+		}
 	}
 
 	for (list_t *l = net->interface_list; l; l = l->next) {

--- a/daemon/c_vol.c
+++ b/daemon/c_vol.c
@@ -1262,7 +1262,7 @@ c_vol_start_child(c_vol_t *vol)
 
 	DEBUG("Mounting /sys");
 	unsigned long sysopts = MS_RELATIME | MS_NOSUID;
-	if (container_has_userns(vol->container) && container_has_netns(vol->container)) {
+	if (container_has_userns(vol->container) && !container_has_netns(vol->container)) {
 		sysopts |= MS_RDONLY;
 	}
 	if (mkdir("/sys", 0755) < 0 && errno != EEXIST)

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -1220,7 +1220,7 @@ cmld_netif_phys_remove_by_name(const char *if_name)
 		}
 	}
 	if (found) {
-		INFO("Removing %s for global available physical netifs", if_name);
+		INFO("Removing '%s' from global available physical netifs", if_name);
 		cmld_netif_phys_list = list_remove(cmld_netif_phys_list, found);
 		return true;
 	}

--- a/daemon/cmld.h
+++ b/daemon/cmld.h
@@ -244,7 +244,7 @@ cmld_get_netif_phys_list(void);
  * Removes the interface from cmld's list of available physical network
  * interfaces. This is used during container config phases, where network
  * interfaces are assigned directly to a container. The remaining physical
- * interfaces are than assigned to the first privileged container with a
+ * interfaces are then assigned to the first privileged container with a
  * private network namespace (usually c0).
  *
  * @param if_name name of the interface which should be removed.

--- a/daemon/cmld.h
+++ b/daemon/cmld.h
@@ -232,4 +232,35 @@ cmld_push_device_cert(control_t *control, uint8_t *cert, size_t cert_len);
 void
 cmld_guestos_delete(const char *guestos_name);
 
+/**
+ * Returns the list of currently available physical network interfaces
+ * not occupied by an application container. Used to assign theses
+ * interfaces to c0 in case of c0 uses a private network namespace.
+ */
+list_t *
+cmld_get_netif_phys_list(void);
+
+/**
+ * Removes the interface from cmld's list of available physical network
+ * interfaces. This is used during container config phases, where network
+ * interfaces are assigned directly to a container. The remaining physical
+ * interfaces are than assigned to the first privileged container with a
+ * private network namespace (usually c0).
+ *
+ * @param if_name name of the interface which should be removed.
+ * @return true if iface was available and removed, false otherwise.
+ */
+bool
+cmld_netif_phys_remove_by_name(const char *if_name);
+
+/**
+ * Adds the given interface to cmld's list of available physical network
+ * interfaces. This is used during runtime if a container releases its
+ * assignment.
+ *
+ * @param if_name name of the interface which should be added.
+ */
+void
+cmld_netif_phys_add_by_name(const char *if_name);
+
 #endif /* CMLD_H */

--- a/daemon/container.c
+++ b/daemon/container.c
@@ -2166,12 +2166,13 @@ container_add_net_iface(container_t *container, const char *iface, bool persiste
 	pid_t pid = container_get_pid(container);
 	pid_t pid_a0 = container_get_pid(cmld_containers_get_a0());
 
-	/* if c0 is running the interfaces is occupied by c0, thus we have
-	 * to take it bake to cml first.
+	/* if c0 is running the interface is occupied by c0, thus we have
+	 * to take it back to cml first.
 	 */
 	container_state_t state_a0 = container_get_state(cmld_containers_get_a0());
 	int res = 0;
-	if (state_a0 == CONTAINER_STATE_RUNNING || state_a0 == CONTAINER_STATE_BOOTING)
+	if (state_a0 == CONTAINER_STATE_RUNNING || state_a0 == CONTAINER_STATE_BOOTING ||
+	    state_a0 == CONTAINER_STATE_SETUP)
 		res = c_net_remove_ifi(iface, pid_a0);
 
 	res |= c_net_move_ifi(iface, pid);


### PR DESCRIPTION
Main patches: 

1. **cmld: Move all physical network interfaces to c0 if private netns.** 
This patch allows to unshare the network name space of c0, while
maintaining the behaviour of accessing all physical network interfaces.
Thus, c0 can act as unprivileged router for containers even without
having access to the root network namespace. This is also necessary
to run c0 inside a user namespace. Since, if user namespace is enabled,
the container has no privileges in the shared root network namespace.
2. **daemon/c_net: Move all veth endpoints to netns of c0**
This patch also moves the veth endpoints of configured interfaces to
the netns of c0. However, also the configuration of those endpoints
have to be done in the target namespace. We do this by forking a
helper process of cmld and join the c0 netns using setns.

