### PR TITLE
device.proto: update the default c0 OS to 'trustx-coreos'

### DIFF
--- a/daemon/device.proto
+++ b/daemon/device.proto
@@ -44,8 +44,8 @@ message DeviceConfig {
 	// flag which decides led blinking
 	optional bool should_led_blink = 6 [default = false];
 
-	// configure os if the management container
-	optional string c0os = 7 [default = "a0os"];
+	// configure os of the management container
+	optional string c0os = 7 [default = "trustx-coreos"];
 
 	// configure network
 	optional string host_addr = 8 [default = ""];


### PR DESCRIPTION
Patches the default c0os to "trustx-coeros". This patch is related to 
patches in trustme_build and meta-trustx. Together they aim to allow a user to not build any c0 but rather supply it manually without the system entering a bootloop.