### PR TITLE
daemon/uevent.c: fixed device node creation and runtime net if handling

### DIFF
--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -1286,5 +1286,11 @@ cmld_netif_phys_remove_by_name(const char *if_name)
 void
 cmld_netif_phys_add_by_name(const char *if_name)
 {
+	for (list_t *l = cmld_netif_phys_list; l; l = l->next) {
+		char *cmld_if_name = l->data;
+		if (0 == strcmp(if_name, cmld_if_name)) {
+			return;
+		}
+	}
 	cmld_netif_phys_list = list_append(cmld_netif_phys_list, mem_strdup(if_name));
 }

--- a/daemon/control.c
+++ b/daemon/control.c
@@ -480,8 +480,7 @@ control_send_message(control_message_t message, int fd)
 		break;
 
 	case CONTROL_RESPONSE_GUESTOS_MGR_INSTALL_WAITING:
-		out.response =
-			DAEMON_TO_CONTROLLER__RESPONSE__GUESTOS_MGR_INSTALL_WAITING;
+		out.response = DAEMON_TO_CONTROLLER__RESPONSE__GUESTOS_MGR_INSTALL_WAITING;
 		break;
 
 	case CONTROL_RESPONSE_GUESTOS_MGR_INSTALL_COMPLETED:
@@ -552,8 +551,7 @@ control_handle_cmd_push_guestos_configs(const ControllerToDaemon *msg, int fd)
 					msg->guestos_config_signature.data,
 					msg->guestos_config_signature.len,
 					msg->guestos_config_certificate.data,
-					msg->guestos_config_certificate.len,
-					fd);
+					msg->guestos_config_certificate.len, fd);
 	}
 }
 

--- a/daemon/guestos_mgr.c
+++ b/daemon/guestos_mgr.c
@@ -398,7 +398,8 @@ push_config_verify_buf_cb(smartcard_crypto_verify_result_t verify_result, unsign
 	// 4. trigger image download if os is used by a container or a fresh install
 	if (guestos_mgr_is_guestos_used_by_containers(os_name) || !old_os || cml_update) {
 		INFO("%s: %s", GUESTOS_MGR_UPDATE_TITLE, GUESTOS_MGR_UPDATE_DOWNLOAD);
-		if (control_send_message(CONTROL_RESPONSE_GUESTOS_MGR_INSTALL_STARTED, *resp_fd) < 0)
+		if (control_send_message(CONTROL_RESPONSE_GUESTOS_MGR_INSTALL_STARTED, *resp_fd) <
+		    0)
 			WARN("Could not send response to fd=%d", *resp_fd);
 		guestos_mgr_download_latest(os_name, *resp_fd);
 	}


### PR DESCRIPTION
bugfix 1:
Basename may modifiy the input string. Thus, we have to duplicate
the path string before use of basename.

bugfix 2:
fixes issue #100:
