### PR TITLE
[WIP] enable usage of usbtoken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ out
 cscope.out
 *.swp
 tags
+*~

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ cscope.out
 *.swp
 tags
 *~
+*.o
+*.a

--- a/common/mem.c
+++ b/common/mem.c
@@ -83,6 +83,16 @@ mem_strndup(const char *str, size_t len)
 	return p;
 }
 
+unsigned char *
+mem_memcpy(const unsigned char *mem, size_t size)
+{	
+	ASSERT(mem);
+	unsigned char *p = mem_alloc0(size);
+	ASSERT(p);
+	memcpy(p, mem, size);
+	return p;
+}
+
 char *
 mem_vprintf(const char *fmt, va_list ap)
 {

--- a/common/mem.h
+++ b/common/mem.h
@@ -89,6 +89,18 @@ char *
 mem_strndup(const char *str, size_t len);
 
 /**
+ * Duplicates an array of unsigned char, but copies at most size bytes.
+ * Allocates sufficient memory.
+ * This is a wrapper for memcpy(3).
+ *
+ * @param mem The memory to duplicate.
+ * @param size The size of the memory.
+ * @return Pointer to the new array.
+ */
+unsigned char *
+mem_memcpy(const unsigned char *mem, size_t size);
+
+/**
  * Prints to a string allocated by this function.
  * This is a wrapper for vasprintf(3) which aborts if the function fails.
  *

--- a/converter/cJSON/cJSON.c
+++ b/converter/cJSON/cJSON.c
@@ -23,19 +23,34 @@
 /* cJSON */
 /* JSON parser in C. */
 
+/* disable warnings about old C89 functions in MSVC */
+#if !defined(_CRT_SECURE_NO_DEPRECATE) && defined(_MSC_VER)
+#define _CRT_SECURE_NO_DEPRECATE
+#endif
+
 #ifdef __GNUC__
 #pragma GCC visibility push(default)
+#endif
+#if defined(_MSC_VER)
+#pragma warning (push)
+/* disable warning about single line comments in system headers */
+#pragma warning (disable : 4001)
 #endif
 
 #include <string.h>
 #include <stdio.h>
 #include <math.h>
 #include <stdlib.h>
-#include <float.h>
 #include <limits.h>
 #include <ctype.h>
-#include <locale.h>
 
+#ifdef ENABLE_LOCALES
+#include <locale.h>
+#endif
+
+#if defined(_MSC_VER)
+#pragma warning (pop)
+#endif
 #ifdef __GNUC__
 #pragma GCC visibility pop
 #endif
@@ -43,2301 +58,2941 @@
 #include "cJSON.h"
 
 /* define our own boolean type */
-#define true((cJSON_bool)1)
-#define false((cJSON_bool)0)
+#ifdef true
+#undef true
+#endif
+#define true ((cJSON_bool)1)
+
+#ifdef false
+#undef false
+#endif
+#define false ((cJSON_bool)0)
 
 typedef struct {
-	const unsigned char *json;
-	size_t position;
+    const unsigned char *json;
+    size_t position;
 } error;
 static error global_error = { NULL, 0 };
 
 CJSON_PUBLIC(const char *) cJSON_GetErrorPtr(void)
 {
-	return (const char *)(global_error.json + global_error.position);
+    return (const char*) (global_error.json + global_error.position);
+}
+
+CJSON_PUBLIC(char *) cJSON_GetStringValue(const cJSON * const item) {
+    if (!cJSON_IsString(item)) {
+        return NULL;
+    }
+
+    return item->valuestring;
 }
 
 /* This is a safeguard to prevent copy-pasters from using incompatible C and header files */
-#if (CJSON_VERSION_MAJOR != 1) || (CJSON_VERSION_MINOR != 5) || (CJSON_VERSION_PATCH != 2)
-#error cJSON.h and cJSON.c have different versions. Make sure that both have the same.
+#if (CJSON_VERSION_MAJOR != 1) || (CJSON_VERSION_MINOR != 7) || (CJSON_VERSION_PATCH != 12)
+    #error cJSON.h and cJSON.c have different versions. Make sure that both have the same.
 #endif
 
-CJSON_PUBLIC(const char *) cJSON_Version(void)
+CJSON_PUBLIC(const char*) cJSON_Version(void)
 {
-	static char version[15];
-	sprintf(version, "%i.%i.%i", CJSON_VERSION_MAJOR, CJSON_VERSION_MINOR, CJSON_VERSION_PATCH);
+    static char version[15];
+    sprintf(version, "%i.%i.%i", CJSON_VERSION_MAJOR, CJSON_VERSION_MINOR, CJSON_VERSION_PATCH);
 
-	return version;
+    return version;
 }
 
 /* Case insensitive string comparison, doesn't consider two NULL pointers equal though */
-static int
-case_insensitive_strcmp(const unsigned char *string1, const unsigned char *string2)
+static int case_insensitive_strcmp(const unsigned char *string1, const unsigned char *string2)
 {
-	if ((string1 == NULL) || (string2 == NULL)) {
-		return 1;
-	}
+    if ((string1 == NULL) || (string2 == NULL))
+    {
+        return 1;
+    }
 
-	if (string1 == string2) {
-		return 0;
-	}
+    if (string1 == string2)
+    {
+        return 0;
+    }
 
-	for (; tolower(*string1) == tolower(*string2); (void)string1++, string2++) {
-		if (*string1 == '\0') {
-			return 0;
-		}
-	}
+    for(; tolower(*string1) == tolower(*string2); (void)string1++, string2++)
+    {
+        if (*string1 == '\0')
+        {
+            return 0;
+        }
+    }
 
-	return tolower(*string1) - tolower(*string2);
+    return tolower(*string1) - tolower(*string2);
 }
 
-typedef struct internal_hooks {
-	void *(*allocate)(size_t size);
-	void (*deallocate)(void *pointer);
-	void *(*reallocate)(void *pointer, size_t size);
+typedef struct internal_hooks
+{
+    void *(CJSON_CDECL *allocate)(size_t size);
+    void (CJSON_CDECL *deallocate)(void *pointer);
+    void *(CJSON_CDECL *reallocate)(void *pointer, size_t size);
 } internal_hooks;
 
-static internal_hooks global_hooks = { malloc, free, realloc };
-
-static unsigned char *
-cJSON_strdup(const unsigned char *string, const internal_hooks *const hooks)
+#if defined(_MSC_VER)
+/* work around MSVC error C2322: '...' address of dllimport '...' is not static */
+static void * CJSON_CDECL internal_malloc(size_t size)
 {
-	size_t length = 0;
-	unsigned char *copy = NULL;
+    return malloc(size);
+}
+static void CJSON_CDECL internal_free(void *pointer)
+{
+    free(pointer);
+}
+static void * CJSON_CDECL internal_realloc(void *pointer, size_t size)
+{
+    return realloc(pointer, size);
+}
+#else
+#define internal_malloc malloc
+#define internal_free free
+#define internal_realloc realloc
+#endif
 
-	if (string == NULL) {
-		return NULL;
-	}
+/* strlen of character literals resolved at compile time */
+#define static_strlen(string_literal) (sizeof(string_literal) - sizeof(""))
 
-	length = strlen((const char *)string) + sizeof("");
-	if (!(copy = (unsigned char *)hooks->allocate(length))) {
-		return NULL;
-	}
-	memcpy(copy, string, length);
+static internal_hooks global_hooks = { internal_malloc, internal_free, internal_realloc };
 
-	return copy;
+static unsigned char* cJSON_strdup(const unsigned char* string, const internal_hooks * const hooks)
+{
+    size_t length = 0;
+    unsigned char *copy = NULL;
+
+    if (string == NULL)
+    {
+        return NULL;
+    }
+
+    length = strlen((const char*)string) + sizeof("");
+    copy = (unsigned char*)hooks->allocate(length);
+    if (copy == NULL)
+    {
+        return NULL;
+    }
+    memcpy(copy, string, length);
+
+    return copy;
 }
 
-CJSON_PUBLIC(void) cJSON_InitHooks(cJSON_Hooks *hooks)
+CJSON_PUBLIC(void) cJSON_InitHooks(cJSON_Hooks* hooks)
 {
-	if (hooks == NULL) {
-		/* Reset hooks */
-		global_hooks.allocate = malloc;
-		global_hooks.deallocate = free;
-		global_hooks.reallocate = realloc;
-		return;
-	}
+    if (hooks == NULL)
+    {
+        /* Reset hooks */
+        global_hooks.allocate = malloc;
+        global_hooks.deallocate = free;
+        global_hooks.reallocate = realloc;
+        return;
+    }
 
-	global_hooks.allocate = malloc;
-	if (hooks->malloc_fn != NULL) {
-		global_hooks.allocate = hooks->malloc_fn;
-	}
+    global_hooks.allocate = malloc;
+    if (hooks->malloc_fn != NULL)
+    {
+        global_hooks.allocate = hooks->malloc_fn;
+    }
 
-	global_hooks.deallocate = free;
-	if (hooks->free_fn != NULL) {
-		global_hooks.deallocate = hooks->free_fn;
-	}
+    global_hooks.deallocate = free;
+    if (hooks->free_fn != NULL)
+    {
+        global_hooks.deallocate = hooks->free_fn;
+    }
 
-	/* use realloc only if both free and malloc are used */
-	global_hooks.reallocate = NULL;
-	if ((global_hooks.allocate == malloc) && (global_hooks.deallocate == free)) {
-		global_hooks.reallocate = realloc;
-	}
+    /* use realloc only if both free and malloc are used */
+    global_hooks.reallocate = NULL;
+    if ((global_hooks.allocate == malloc) && (global_hooks.deallocate == free))
+    {
+        global_hooks.reallocate = realloc;
+    }
 }
 
 /* Internal constructor. */
-static cJSON *
-cJSON_New_Item(const internal_hooks *const hooks)
+static cJSON *cJSON_New_Item(const internal_hooks * const hooks)
 {
-	cJSON *node = (cJSON *)hooks->allocate(sizeof(cJSON));
-	if (node) {
-		memset(node, '\0', sizeof(cJSON));
-	}
+    cJSON* node = (cJSON*)hooks->allocate(sizeof(cJSON));
+    if (node)
+    {
+        memset(node, '\0', sizeof(cJSON));
+    }
 
-	return node;
+    return node;
 }
 
 /* Delete a cJSON structure. */
 CJSON_PUBLIC(void) cJSON_Delete(cJSON *item)
 {
-	cJSON *next = NULL;
-	while (item != NULL) {
-		next = item->next;
-		if (!(item->type & cJSON_IsReference) && (item->child != NULL)) {
-			cJSON_Delete(item->child);
-		}
-		if (!(item->type & cJSON_IsReference) && (item->valuestring != NULL)) {
-			global_hooks.deallocate(item->valuestring);
-		}
-		if (!(item->type & cJSON_StringIsConst) && (item->string != NULL)) {
-			global_hooks.deallocate(item->string);
-		}
-		global_hooks.deallocate(item);
-		item = next;
-	}
+    cJSON *next = NULL;
+    while (item != NULL)
+    {
+        next = item->next;
+        if (!(item->type & cJSON_IsReference) && (item->child != NULL))
+        {
+            cJSON_Delete(item->child);
+        }
+        if (!(item->type & cJSON_IsReference) && (item->valuestring != NULL))
+        {
+            global_hooks.deallocate(item->valuestring);
+        }
+        if (!(item->type & cJSON_StringIsConst) && (item->string != NULL))
+        {
+            global_hooks.deallocate(item->string);
+        }
+        global_hooks.deallocate(item);
+        item = next;
+    }
 }
 
 /* get the decimal point character of the current locale */
-static unsigned char
-get_decimal_point(void)
+static unsigned char get_decimal_point(void)
 {
-	struct lconv *lconv = localeconv();
-	return (unsigned char)lconv->decimal_point[0];
+#ifdef ENABLE_LOCALES
+    struct lconv *lconv = localeconv();
+    return (unsigned char) lconv->decimal_point[0];
+#else
+    return '.';
+#endif
 }
 
-typedef struct {
-	const unsigned char *content;
-	size_t length;
-	size_t offset;
-	size_t depth; /* How deeply nested (in arrays/objects) is the input at the current offset. */
-	internal_hooks hooks;
+typedef struct
+{
+    const unsigned char *content;
+    size_t length;
+    size_t offset;
+    size_t depth; /* How deeply nested (in arrays/objects) is the input at the current offset. */
+    internal_hooks hooks;
 } parse_buffer;
 
 /* check if the given size is left to read in a given parse buffer (starting with 1) */
 #define can_read(buffer, size) ((buffer != NULL) && (((buffer)->offset + size) <= (buffer)->length))
-#define cannot_read(buffer, size) (!can_read(buffer, size))
 /* check if the buffer can be accessed at the given index (starting with 0) */
-#define can_access_at_index(buffer, index)                                                         \
-	((buffer != NULL) && (((buffer)->offset + index) < (buffer)->length))
+#define can_access_at_index(buffer, index) ((buffer != NULL) && (((buffer)->offset + index) < (buffer)->length))
 #define cannot_access_at_index(buffer, index) (!can_access_at_index(buffer, index))
 /* get a pointer to the buffer at the position */
 #define buffer_at_offset(buffer) ((buffer)->content + (buffer)->offset)
 
 /* Parse the input text to generate a number, and populate the result into item. */
-static cJSON_bool
-parse_number(cJSON *const item, parse_buffer *const input_buffer)
+static cJSON_bool parse_number(cJSON * const item, parse_buffer * const input_buffer)
 {
-	double number = 0;
-	unsigned char *after_end = NULL;
-	unsigned char number_c_string[64];
-	unsigned char decimal_point = get_decimal_point();
-	size_t i = 0;
+    double number = 0;
+    unsigned char *after_end = NULL;
+    unsigned char number_c_string[64];
+    unsigned char decimal_point = get_decimal_point();
+    size_t i = 0;
 
-	if ((input_buffer == NULL) || (input_buffer->content == NULL)) {
-		return false;
-	}
+    if ((input_buffer == NULL) || (input_buffer->content == NULL))
+    {
+        return false;
+    }
 
-	/* copy the number into a temporary buffer and replace '.' with the decimal point
+    /* copy the number into a temporary buffer and replace '.' with the decimal point
      * of the current locale (for strtod)
      * This also takes care of '\0' not necessarily being available for marking the end of the input */
-	for (i = 0; (i < (sizeof(number_c_string) - 1)) && can_access_at_index(input_buffer, i);
-	     i++) {
-		switch (buffer_at_offset(input_buffer)[i]) {
-		case '0':
-		case '1':
-		case '2':
-		case '3':
-		case '4':
-		case '5':
-		case '6':
-		case '7':
-		case '8':
-		case '9':
-		case '+':
-		case '-':
-		case 'e':
-		case 'E':
-			number_c_string[i] = buffer_at_offset(input_buffer)[i];
-			break;
+    for (i = 0; (i < (sizeof(number_c_string) - 1)) && can_access_at_index(input_buffer, i); i++)
+    {
+        switch (buffer_at_offset(input_buffer)[i])
+        {
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+            case '+':
+            case '-':
+            case 'e':
+            case 'E':
+                number_c_string[i] = buffer_at_offset(input_buffer)[i];
+                break;
 
-		case '.':
-			number_c_string[i] = decimal_point;
-			break;
+            case '.':
+                number_c_string[i] = decimal_point;
+                break;
 
-		default:
-			goto loop_end;
-		}
-	}
+            default:
+                goto loop_end;
+        }
+    }
 loop_end:
-	number_c_string[i] = '\0';
+    number_c_string[i] = '\0';
 
-	number = strtod((const char *)number_c_string, (char **)&after_end);
-	if (number_c_string == after_end) {
-		return false; /* parse_error */
-	}
+    number = strtod((const char*)number_c_string, (char**)&after_end);
+    if (number_c_string == after_end)
+    {
+        return false; /* parse_error */
+    }
 
-	item->valuedouble = number;
+    item->valuedouble = number;
 
-	/* use saturation in case of overflow */
-	if (number >= INT_MAX) {
-		item->valueint = INT_MAX;
-	} else if (number <= INT_MIN) {
-		item->valueint = INT_MIN;
-	} else {
-		item->valueint = (int)number;
-	}
+    /* use saturation in case of overflow */
+    if (number >= INT_MAX)
+    {
+        item->valueint = INT_MAX;
+    }
+    else if (number <= (double)INT_MIN)
+    {
+        item->valueint = INT_MIN;
+    }
+    else
+    {
+        item->valueint = (int)number;
+    }
 
-	item->type = cJSON_Number;
+    item->type = cJSON_Number;
 
-	input_buffer->offset += (size_t)(after_end - number_c_string);
-	return true;
+    input_buffer->offset += (size_t)(after_end - number_c_string);
+    return true;
 }
 
 /* don't ask me, but the original cJSON_SetNumberValue returns an integer or double */
 CJSON_PUBLIC(double) cJSON_SetNumberHelper(cJSON *object, double number)
 {
-	if (number >= INT_MAX) {
-		object->valueint = INT_MAX;
-	} else if (number <= INT_MIN) {
-		object->valueint = INT_MIN;
-	} else {
-		object->valueint = (int)number;
-	}
+    if (number >= INT_MAX)
+    {
+        object->valueint = INT_MAX;
+    }
+    else if (number <= (double)INT_MIN)
+    {
+        object->valueint = INT_MIN;
+    }
+    else
+    {
+        object->valueint = (int)number;
+    }
 
-	return object->valuedouble = number;
+    return object->valuedouble = number;
 }
 
-typedef struct {
-	unsigned char *buffer;
-	size_t length;
-	size_t offset;
-	size_t depth; /* current nesting depth (for formatted printing) */
-	cJSON_bool noalloc;
-	cJSON_bool format; /* is this print a formatted print */
-	internal_hooks hooks;
+typedef struct
+{
+    unsigned char *buffer;
+    size_t length;
+    size_t offset;
+    size_t depth; /* current nesting depth (for formatted printing) */
+    cJSON_bool noalloc;
+    cJSON_bool format; /* is this print a formatted print */
+    internal_hooks hooks;
 } printbuffer;
 
 /* realloc printbuffer if necessary to have at least "needed" bytes more */
-static unsigned char *
-ensure(printbuffer *const p, size_t needed)
+static unsigned char* ensure(printbuffer * const p, size_t needed)
 {
-	unsigned char *newbuffer = NULL;
-	size_t newsize = 0;
+    unsigned char *newbuffer = NULL;
+    size_t newsize = 0;
 
-	if ((p == NULL) || (p->buffer == NULL)) {
-		return NULL;
-	}
+    if ((p == NULL) || (p->buffer == NULL))
+    {
+        return NULL;
+    }
 
-	if ((p->length > 0) && (p->offset >= p->length)) {
-		/* make sure that offset is valid */
-		return NULL;
-	}
+    if ((p->length > 0) && (p->offset >= p->length))
+    {
+        /* make sure that offset is valid */
+        return NULL;
+    }
 
-	if (needed > INT_MAX) {
-		/* sizes bigger than INT_MAX are currently not supported */
-		return NULL;
-	}
+    if (needed > INT_MAX)
+    {
+        /* sizes bigger than INT_MAX are currently not supported */
+        return NULL;
+    }
 
-	needed += p->offset + 1;
-	if (needed <= p->length) {
-		return p->buffer + p->offset;
-	}
+    needed += p->offset + 1;
+    if (needed <= p->length)
+    {
+        return p->buffer + p->offset;
+    }
 
-	if (p->noalloc) {
-		return NULL;
-	}
+    if (p->noalloc) {
+        return NULL;
+    }
 
-	/* calculate new buffer size */
-	if (needed > (INT_MAX / 2)) {
-		/* overflow of int, use INT_MAX if possible */
-		if (needed <= INT_MAX) {
-			newsize = INT_MAX;
-		} else {
-			return NULL;
-		}
-	} else {
-		newsize = needed * 2;
-	}
+    /* calculate new buffer size */
+    if (needed > (INT_MAX / 2))
+    {
+        /* overflow of int, use INT_MAX if possible */
+        if (needed <= INT_MAX)
+        {
+            newsize = INT_MAX;
+        }
+        else
+        {
+            return NULL;
+        }
+    }
+    else
+    {
+        newsize = needed * 2;
+    }
 
-	if (p->hooks.reallocate != NULL) {
-		/* reallocate with realloc if available */
-		newbuffer = (unsigned char *)p->hooks.reallocate(p->buffer, newsize);
-	} else {
-		/* otherwise reallocate manually */
-		newbuffer = (unsigned char *)p->hooks.allocate(newsize);
-		if (!newbuffer) {
-			p->hooks.deallocate(p->buffer);
-			p->length = 0;
-			p->buffer = NULL;
+    if (p->hooks.reallocate != NULL)
+    {
+        /* reallocate with realloc if available */
+        newbuffer = (unsigned char*)p->hooks.reallocate(p->buffer, newsize);
+        if (newbuffer == NULL)
+        {
+            p->hooks.deallocate(p->buffer);
+            p->length = 0;
+            p->buffer = NULL;
 
-			return NULL;
-		}
-		if (newbuffer) {
-			memcpy(newbuffer, p->buffer, p->offset + 1);
-		}
-		p->hooks.deallocate(p->buffer);
-	}
-	p->length = newsize;
-	p->buffer = newbuffer;
+            return NULL;
+        }
+    }
+    else
+    {
+        /* otherwise reallocate manually */
+        newbuffer = (unsigned char*)p->hooks.allocate(newsize);
+        if (!newbuffer)
+        {
+            p->hooks.deallocate(p->buffer);
+            p->length = 0;
+            p->buffer = NULL;
 
-	return newbuffer + p->offset;
+            return NULL;
+        }
+        if (newbuffer)
+        {
+            memcpy(newbuffer, p->buffer, p->offset + 1);
+        }
+        p->hooks.deallocate(p->buffer);
+    }
+    p->length = newsize;
+    p->buffer = newbuffer;
+
+    return newbuffer + p->offset;
 }
 
 /* calculate the new length of the string in a printbuffer and update the offset */
-static void
-update_offset(printbuffer *const buffer)
+static void update_offset(printbuffer * const buffer)
 {
-	const unsigned char *buffer_pointer = NULL;
-	if ((buffer == NULL) || (buffer->buffer == NULL)) {
-		return;
-	}
-	buffer_pointer = buffer->buffer + buffer->offset;
+    const unsigned char *buffer_pointer = NULL;
+    if ((buffer == NULL) || (buffer->buffer == NULL))
+    {
+        return;
+    }
+    buffer_pointer = buffer->buffer + buffer->offset;
 
-	buffer->offset += strlen((const char *)buffer_pointer);
+    buffer->offset += strlen((const char*)buffer_pointer);
+}
+
+/* securely comparison of floating-point variables */
+static cJSON_bool compare_double(double a, double b)
+{
+    return (fabs(a - b) <= CJSON_DOUBLE_PRECISION);
 }
 
 /* Render the number nicely from the given item into a string. */
-static cJSON_bool
-print_number(const cJSON *const item, printbuffer *const output_buffer)
+static cJSON_bool print_number(const cJSON * const item, printbuffer * const output_buffer)
 {
-	unsigned char *output_pointer = NULL;
-	double d = item->valuedouble;
-	int length = 0;
-	size_t i = 0;
-	unsigned char number_buffer[26]; /* temporary buffer to print the number into */
-	unsigned char decimal_point = get_decimal_point();
-	double test;
+    unsigned char *output_pointer = NULL;
+    double d = item->valuedouble;
+    int length = 0;
+    size_t i = 0;
+    unsigned char number_buffer[26] = {0}; /* temporary buffer to print the number into */
+    unsigned char decimal_point = get_decimal_point();
+    double test = 0.0;
 
-	if (output_buffer == NULL) {
-		return false;
-	}
+    if (output_buffer == NULL)
+    {
+        return false;
+    }
 
-	/* This checks for NaN and Infinity */
-	if ((d * 0) != 0) {
-		length = sprintf((char *)number_buffer, "null");
-	} else {
-		/* Try 15 decimal places of precision to avoid nonsignificant nonzero digits */
-		length = sprintf((char *)number_buffer, "%1.15g", d);
+    /* This checks for NaN and Infinity */
+    if ((d * 0) != 0)
+    {
+        length = sprintf((char*)number_buffer, "null");
+    }
+    else
+    {
+        /* Try 15 decimal places of precision to avoid nonsignificant nonzero digits */
+        length = sprintf((char*)number_buffer, "%1.15g", d);
 
-		/* Check whether the original double can be recovered */
-		if ((sscanf((char *)number_buffer, "%lg", &test) != 1) || ((double)test != d)) {
-			/* If not, print with 17 decimal places of precision */
-			length = sprintf((char *)number_buffer, "%1.17g", d);
-		}
-	}
+        /* Check whether the original double can be recovered */
+        if ((sscanf((char*)number_buffer, "%lg", &test) != 1) || !compare_double((double)test, d))
+        {
+            /* If not, print with 17 decimal places of precision */
+            length = sprintf((char*)number_buffer, "%1.17g", d);
+        }
+    }
 
-	/* sprintf failed or buffer overrun occured */
-	if ((length < 0) || (length > (int)(sizeof(number_buffer) - 1))) {
-		return false;
-	}
+    /* sprintf failed or buffer overrun occurred */
+    if ((length < 0) || (length > (int)(sizeof(number_buffer) - 1)))
+    {
+        return false;
+    }
 
-	/* reserve appropriate space in the output */
-	output_pointer = ensure(output_buffer, (size_t)length);
-	if (output_pointer == NULL) {
-		return false;
-	}
+    /* reserve appropriate space in the output */
+    output_pointer = ensure(output_buffer, (size_t)length + sizeof(""));
+    if (output_pointer == NULL)
+    {
+        return false;
+    }
 
-	/* copy the printed number to the output and replace locale
+    /* copy the printed number to the output and replace locale
      * dependent decimal point with '.' */
-	for (i = 0; i < ((size_t)length); i++) {
-		if (number_buffer[i] == decimal_point) {
-			output_pointer[i] = '.';
-			continue;
-		}
+    for (i = 0; i < ((size_t)length); i++)
+    {
+        if (number_buffer[i] == decimal_point)
+        {
+            output_pointer[i] = '.';
+            continue;
+        }
 
-		output_pointer[i] = number_buffer[i];
-	}
-	output_pointer[i] = '\0';
+        output_pointer[i] = number_buffer[i];
+    }
+    output_pointer[i] = '\0';
 
-	output_buffer->offset += (size_t)length;
+    output_buffer->offset += (size_t)length;
 
-	return true;
+    return true;
 }
 
 /* parse 4 digit hexadecimal number */
-static unsigned
-parse_hex4(const unsigned char *const input)
+static unsigned parse_hex4(const unsigned char * const input)
 {
-	unsigned int h = 0;
-	size_t i = 0;
+    unsigned int h = 0;
+    size_t i = 0;
 
-	for (i = 0; i < 4; i++) {
-		/* parse digit */
-		if ((input[i] >= '0') && (input[i] <= '9')) {
-			h += (unsigned int)input[i] - '0';
-		} else if ((input[i] >= 'A') && (input[i] <= 'F')) {
-			h += (unsigned int)10 + input[i] - 'A';
-		} else if ((input[i] >= 'a') && (input[i] <= 'f')) {
-			h += (unsigned int)10 + input[i] - 'a';
-		} else /* invalid */
-		{
-			return 0;
-		}
+    for (i = 0; i < 4; i++)
+    {
+        /* parse digit */
+        if ((input[i] >= '0') && (input[i] <= '9'))
+        {
+            h += (unsigned int) input[i] - '0';
+        }
+        else if ((input[i] >= 'A') && (input[i] <= 'F'))
+        {
+            h += (unsigned int) 10 + input[i] - 'A';
+        }
+        else if ((input[i] >= 'a') && (input[i] <= 'f'))
+        {
+            h += (unsigned int) 10 + input[i] - 'a';
+        }
+        else /* invalid */
+        {
+            return 0;
+        }
 
-		if (i < 3) {
-			/* shift left to make place for the next nibble */
-			h = h << 4;
-		}
-	}
+        if (i < 3)
+        {
+            /* shift left to make place for the next nibble */
+            h = h << 4;
+        }
+    }
 
-	return h;
+    return h;
 }
 
 /* converts a UTF-16 literal to UTF-8
  * A literal can be one or two sequences of the form \uXXXX */
-static unsigned char
-utf16_literal_to_utf8(const unsigned char *const input_pointer,
-		      const unsigned char *const input_end, unsigned char **output_pointer)
+static unsigned char utf16_literal_to_utf8(const unsigned char * const input_pointer, const unsigned char * const input_end, unsigned char **output_pointer)
 {
-	long unsigned int codepoint = 0;
-	unsigned int first_code = 0;
-	const unsigned char *first_sequence = input_pointer;
-	unsigned char utf8_length = 0;
-	unsigned char utf8_position = 0;
-	unsigned char sequence_length = 0;
-	unsigned char first_byte_mark = 0;
+    long unsigned int codepoint = 0;
+    unsigned int first_code = 0;
+    const unsigned char *first_sequence = input_pointer;
+    unsigned char utf8_length = 0;
+    unsigned char utf8_position = 0;
+    unsigned char sequence_length = 0;
+    unsigned char first_byte_mark = 0;
 
-	if ((input_end - first_sequence) < 6) {
-		/* input ends unexpectedly */
-		goto fail;
-	}
+    if ((input_end - first_sequence) < 6)
+    {
+        /* input ends unexpectedly */
+        goto fail;
+    }
 
-	/* get the first utf16 sequence */
-	first_code = parse_hex4(first_sequence + 2);
+    /* get the first utf16 sequence */
+    first_code = parse_hex4(first_sequence + 2);
 
-	/* check that the code is valid */
-	if (((first_code >= 0xDC00) && (first_code <= 0xDFFF))) {
-		goto fail;
-	}
+    /* check that the code is valid */
+    if (((first_code >= 0xDC00) && (first_code <= 0xDFFF)))
+    {
+        goto fail;
+    }
 
-	/* UTF16 surrogate pair */
-	if ((first_code >= 0xD800) && (first_code <= 0xDBFF)) {
-		const unsigned char *second_sequence = first_sequence + 6;
-		unsigned int second_code = 0;
-		sequence_length = 12; /* \uXXXX\uXXXX */
+    /* UTF16 surrogate pair */
+    if ((first_code >= 0xD800) && (first_code <= 0xDBFF))
+    {
+        const unsigned char *second_sequence = first_sequence + 6;
+        unsigned int second_code = 0;
+        sequence_length = 12; /* \uXXXX\uXXXX */
 
-		if ((input_end - second_sequence) < 6) {
-			/* input ends unexpectedly */
-			goto fail;
-		}
+        if ((input_end - second_sequence) < 6)
+        {
+            /* input ends unexpectedly */
+            goto fail;
+        }
 
-		if ((second_sequence[0] != '\\') || (second_sequence[1] != 'u')) {
-			/* missing second half of the surrogate pair */
-			goto fail;
-		}
+        if ((second_sequence[0] != '\\') || (second_sequence[1] != 'u'))
+        {
+            /* missing second half of the surrogate pair */
+            goto fail;
+        }
 
-		/* get the second utf16 sequence */
-		second_code = parse_hex4(second_sequence + 2);
-		/* check that the code is valid */
-		if ((second_code < 0xDC00) || (second_code > 0xDFFF)) {
-			/* invalid second half of the surrogate pair */
-			goto fail;
-		}
+        /* get the second utf16 sequence */
+        second_code = parse_hex4(second_sequence + 2);
+        /* check that the code is valid */
+        if ((second_code < 0xDC00) || (second_code > 0xDFFF))
+        {
+            /* invalid second half of the surrogate pair */
+            goto fail;
+        }
 
-		/* calculate the unicode codepoint from the surrogate pair */
-		codepoint = 0x10000 + (((first_code & 0x3FF) << 10) | (second_code & 0x3FF));
-	} else {
-		sequence_length = 6; /* \uXXXX */
-		codepoint = first_code;
-	}
 
-	/* encode as UTF-8
+        /* calculate the unicode codepoint from the surrogate pair */
+        codepoint = 0x10000 + (((first_code & 0x3FF) << 10) | (second_code & 0x3FF));
+    }
+    else
+    {
+        sequence_length = 6; /* \uXXXX */
+        codepoint = first_code;
+    }
+
+    /* encode as UTF-8
      * takes at maximum 4 bytes to encode:
      * 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx */
-	if (codepoint < 0x80) {
-		/* normal ascii, encoding 0xxxxxxx */
-		utf8_length = 1;
-	} else if (codepoint < 0x800) {
-		/* two bytes, encoding 110xxxxx 10xxxxxx */
-		utf8_length = 2;
-		first_byte_mark = 0xC0; /* 11000000 */
-	} else if (codepoint < 0x10000) {
-		/* three bytes, encoding 1110xxxx 10xxxxxx 10xxxxxx */
-		utf8_length = 3;
-		first_byte_mark = 0xE0; /* 11100000 */
-	} else if (codepoint <= 0x10FFFF) {
-		/* four bytes, encoding 1110xxxx 10xxxxxx 10xxxxxx 10xxxxxx */
-		utf8_length = 4;
-		first_byte_mark = 0xF0; /* 11110000 */
-	} else {
-		/* invalid unicode codepoint */
-		goto fail;
-	}
+    if (codepoint < 0x80)
+    {
+        /* normal ascii, encoding 0xxxxxxx */
+        utf8_length = 1;
+    }
+    else if (codepoint < 0x800)
+    {
+        /* two bytes, encoding 110xxxxx 10xxxxxx */
+        utf8_length = 2;
+        first_byte_mark = 0xC0; /* 11000000 */
+    }
+    else if (codepoint < 0x10000)
+    {
+        /* three bytes, encoding 1110xxxx 10xxxxxx 10xxxxxx */
+        utf8_length = 3;
+        first_byte_mark = 0xE0; /* 11100000 */
+    }
+    else if (codepoint <= 0x10FFFF)
+    {
+        /* four bytes, encoding 1110xxxx 10xxxxxx 10xxxxxx 10xxxxxx */
+        utf8_length = 4;
+        first_byte_mark = 0xF0; /* 11110000 */
+    }
+    else
+    {
+        /* invalid unicode codepoint */
+        goto fail;
+    }
 
-	/* encode as utf8 */
-	for (utf8_position = (unsigned char)(utf8_length - 1); utf8_position > 0; utf8_position--) {
-		/* 10xxxxxx */
-		(*output_pointer)[utf8_position] = (unsigned char)((codepoint | 0x80) & 0xBF);
-		codepoint >>= 6;
-	}
-	/* encode first byte */
-	if (utf8_length > 1) {
-		(*output_pointer)[0] = (unsigned char)((codepoint | first_byte_mark) & 0xFF);
-	} else {
-		(*output_pointer)[0] = (unsigned char)(codepoint & 0x7F);
-	}
+    /* encode as utf8 */
+    for (utf8_position = (unsigned char)(utf8_length - 1); utf8_position > 0; utf8_position--)
+    {
+        /* 10xxxxxx */
+        (*output_pointer)[utf8_position] = (unsigned char)((codepoint | 0x80) & 0xBF);
+        codepoint >>= 6;
+    }
+    /* encode first byte */
+    if (utf8_length > 1)
+    {
+        (*output_pointer)[0] = (unsigned char)((codepoint | first_byte_mark) & 0xFF);
+    }
+    else
+    {
+        (*output_pointer)[0] = (unsigned char)(codepoint & 0x7F);
+    }
 
-	*output_pointer += utf8_length;
+    *output_pointer += utf8_length;
 
-	return sequence_length;
+    return sequence_length;
 
 fail:
-	return 0;
+    return 0;
 }
 
 /* Parse the input text into an unescaped cinput, and populate item. */
-static cJSON_bool
-parse_string(cJSON *const item, parse_buffer *const input_buffer)
+static cJSON_bool parse_string(cJSON * const item, parse_buffer * const input_buffer)
 {
-	const unsigned char *input_pointer = buffer_at_offset(input_buffer) + 1;
-	const unsigned char *input_end = buffer_at_offset(input_buffer) + 1;
-	unsigned char *output_pointer = NULL;
-	unsigned char *output = NULL;
+    const unsigned char *input_pointer = buffer_at_offset(input_buffer) + 1;
+    const unsigned char *input_end = buffer_at_offset(input_buffer) + 1;
+    unsigned char *output_pointer = NULL;
+    unsigned char *output = NULL;
 
-	/* not a string */
-	if (buffer_at_offset(input_buffer)[0] != '\"') {
-		goto fail;
-	}
+    /* not a string */
+    if (buffer_at_offset(input_buffer)[0] != '\"')
+    {
+        goto fail;
+    }
 
-	{
-		/* calculate approximate size of the output (overestimate) */
-		size_t allocation_length = 0;
-		size_t skipped_bytes = 0;
-		while (((size_t)(input_end - input_buffer->content) < input_buffer->length) &&
-		       (*input_end != '\"')) {
-			/* is escape sequence */
-			if (input_end[0] == '\\') {
-				if ((size_t)(input_end + 1 - input_buffer->content) >=
-				    input_buffer->length) {
-					/* prevent buffer overflow when last input character is a backslash */
-					goto fail;
-				}
-				skipped_bytes++;
-				input_end++;
-			}
-			input_end++;
-		}
-		if (((size_t)(input_end - input_buffer->content) >= input_buffer->length) ||
-		    (*input_end != '\"')) {
-			goto fail; /* string ended unexpectedly */
-		}
+    {
+        /* calculate approximate size of the output (overestimate) */
+        size_t allocation_length = 0;
+        size_t skipped_bytes = 0;
+        while (((size_t)(input_end - input_buffer->content) < input_buffer->length) && (*input_end != '\"'))
+        {
+            /* is escape sequence */
+            if (input_end[0] == '\\')
+            {
+                if ((size_t)(input_end + 1 - input_buffer->content) >= input_buffer->length)
+                {
+                    /* prevent buffer overflow when last input character is a backslash */
+                    goto fail;
+                }
+                skipped_bytes++;
+                input_end++;
+            }
+            input_end++;
+        }
+        if (((size_t)(input_end - input_buffer->content) >= input_buffer->length) || (*input_end != '\"'))
+        {
+            goto fail; /* string ended unexpectedly */
+        }
 
-		/* This is at most how much we need for the output */
-		allocation_length =
-			(size_t)(input_end - buffer_at_offset(input_buffer)) - skipped_bytes;
-		output = (unsigned char *)input_buffer->hooks.allocate(allocation_length +
-								       sizeof(""));
-		if (output == NULL) {
-			goto fail; /* allocation failure */
-		}
-	}
+        /* This is at most how much we need for the output */
+        allocation_length = (size_t) (input_end - buffer_at_offset(input_buffer)) - skipped_bytes;
+        output = (unsigned char*)input_buffer->hooks.allocate(allocation_length + sizeof(""));
+        if (output == NULL)
+        {
+            goto fail; /* allocation failure */
+        }
+    }
 
-	output_pointer = output;
-	/* loop through the string literal */
-	while (input_pointer < input_end) {
-		if (*input_pointer != '\\') {
-			*output_pointer++ = *input_pointer++;
-		}
-		/* escape sequence */
-		else {
-			unsigned char sequence_length = 2;
-			if ((input_end - input_pointer) < 1) {
-				goto fail;
-			}
+    output_pointer = output;
+    /* loop through the string literal */
+    while (input_pointer < input_end)
+    {
+        if (*input_pointer != '\\')
+        {
+            *output_pointer++ = *input_pointer++;
+        }
+        /* escape sequence */
+        else
+        {
+            unsigned char sequence_length = 2;
+            if ((input_end - input_pointer) < 1)
+            {
+                goto fail;
+            }
 
-			switch (input_pointer[1]) {
-			case 'b':
-				*output_pointer++ = '\b';
-				break;
-			case 'f':
-				*output_pointer++ = '\f';
-				break;
-			case 'n':
-				*output_pointer++ = '\n';
-				break;
-			case 'r':
-				*output_pointer++ = '\r';
-				break;
-			case 't':
-				*output_pointer++ = '\t';
-				break;
-			case '\"':
-			case '\\':
-			case '/':
-				*output_pointer++ = input_pointer[1];
-				break;
+            switch (input_pointer[1])
+            {
+                case 'b':
+                    *output_pointer++ = '\b';
+                    break;
+                case 'f':
+                    *output_pointer++ = '\f';
+                    break;
+                case 'n':
+                    *output_pointer++ = '\n';
+                    break;
+                case 'r':
+                    *output_pointer++ = '\r';
+                    break;
+                case 't':
+                    *output_pointer++ = '\t';
+                    break;
+                case '\"':
+                case '\\':
+                case '/':
+                    *output_pointer++ = input_pointer[1];
+                    break;
 
-			/* UTF-16 literal */
-			case 'u':
-				sequence_length = utf16_literal_to_utf8(input_pointer, input_end,
-									&output_pointer);
-				if (sequence_length == 0) {
-					/* failed to convert UTF16-literal to UTF-8 */
-					goto fail;
-				}
-				break;
+                /* UTF-16 literal */
+                case 'u':
+                    sequence_length = utf16_literal_to_utf8(input_pointer, input_end, &output_pointer);
+                    if (sequence_length == 0)
+                    {
+                        /* failed to convert UTF16-literal to UTF-8 */
+                        goto fail;
+                    }
+                    break;
 
-			default:
-				goto fail;
-			}
-			input_pointer += sequence_length;
-		}
-	}
+                default:
+                    goto fail;
+            }
+            input_pointer += sequence_length;
+        }
+    }
 
-	/* zero terminate the output */
-	*output_pointer = '\0';
+    /* zero terminate the output */
+    *output_pointer = '\0';
 
-	item->type = cJSON_String;
-	item->valuestring = (char *)output;
+    item->type = cJSON_String;
+    item->valuestring = (char*)output;
 
-	input_buffer->offset = (size_t)(input_end - input_buffer->content);
-	input_buffer->offset++;
+    input_buffer->offset = (size_t) (input_end - input_buffer->content);
+    input_buffer->offset++;
 
-	return true;
+    return true;
 
 fail:
-	if (output != NULL) {
-		input_buffer->hooks.deallocate(output);
-	}
+    if (output != NULL)
+    {
+        input_buffer->hooks.deallocate(output);
+    }
 
-	if (input_pointer != NULL) {
-		input_buffer->offset = (size_t)(input_pointer - input_buffer->content);
-	}
+    if (input_pointer != NULL)
+    {
+        input_buffer->offset = (size_t)(input_pointer - input_buffer->content);
+    }
 
-	return false;
+    return false;
 }
 
 /* Render the cstring provided to an escaped version that can be printed. */
-static cJSON_bool
-print_string_ptr(const unsigned char *const input, printbuffer *const output_buffer)
+static cJSON_bool print_string_ptr(const unsigned char * const input, printbuffer * const output_buffer)
 {
-	const unsigned char *input_pointer = NULL;
-	unsigned char *output = NULL;
-	unsigned char *output_pointer = NULL;
-	size_t output_length = 0;
-	/* numbers of additional characters needed for escaping */
-	size_t escape_characters = 0;
+    const unsigned char *input_pointer = NULL;
+    unsigned char *output = NULL;
+    unsigned char *output_pointer = NULL;
+    size_t output_length = 0;
+    /* numbers of additional characters needed for escaping */
+    size_t escape_characters = 0;
 
-	if (output_buffer == NULL) {
-		return false;
-	}
+    if (output_buffer == NULL)
+    {
+        return false;
+    }
 
-	/* empty string */
-	if (input == NULL) {
-		output = ensure(output_buffer, sizeof("\"\""));
-		if (output == NULL) {
-			return false;
-		}
-		strcpy((char *)output, "\"\"");
+    /* empty string */
+    if (input == NULL)
+    {
+        output = ensure(output_buffer, sizeof("\"\""));
+        if (output == NULL)
+        {
+            return false;
+        }
+        strcpy((char*)output, "\"\"");
 
-		return true;
-	}
+        return true;
+    }
 
-	/* set "flag" to 1 if something needs to be escaped */
-	for (input_pointer = input; *input_pointer; input_pointer++) {
-		switch (*input_pointer) {
-		case '\"':
-		case '\\':
-		case '\b':
-		case '\f':
-		case '\n':
-		case '\r':
-		case '\t':
-			/* one character escape sequence */
-			escape_characters++;
-			break;
-		default:
-			if (*input_pointer < 32) {
-				/* UTF-16 escape sequence uXXXX */
-				escape_characters += 5;
-			}
-			break;
-		}
-	}
-	output_length = (size_t)(input_pointer - input) + escape_characters;
+    /* set "flag" to 1 if something needs to be escaped */
+    for (input_pointer = input; *input_pointer; input_pointer++)
+    {
+        switch (*input_pointer)
+        {
+            case '\"':
+            case '\\':
+            case '\b':
+            case '\f':
+            case '\n':
+            case '\r':
+            case '\t':
+                /* one character escape sequence */
+                escape_characters++;
+                break;
+            default:
+                if (*input_pointer < 32)
+                {
+                    /* UTF-16 escape sequence uXXXX */
+                    escape_characters += 5;
+                }
+                break;
+        }
+    }
+    output_length = (size_t)(input_pointer - input) + escape_characters;
 
-	output = ensure(output_buffer, output_length + sizeof("\"\""));
-	if (output == NULL) {
-		return false;
-	}
+    output = ensure(output_buffer, output_length + sizeof("\"\""));
+    if (output == NULL)
+    {
+        return false;
+    }
 
-	/* no characters have to be escaped */
-	if (escape_characters == 0) {
-		output[0] = '\"';
-		memcpy(output + 1, input, output_length);
-		output[output_length + 1] = '\"';
-		output[output_length + 2] = '\0';
+    /* no characters have to be escaped */
+    if (escape_characters == 0)
+    {
+        output[0] = '\"';
+        memcpy(output + 1, input, output_length);
+        output[output_length + 1] = '\"';
+        output[output_length + 2] = '\0';
 
-		return true;
-	}
+        return true;
+    }
 
-	output[0] = '\"';
-	output_pointer = output + 1;
-	/* copy the string */
-	for (input_pointer = input; *input_pointer != '\0';
-	     (void)input_pointer++, output_pointer++) {
-		if ((*input_pointer > 31) && (*input_pointer != '\"') && (*input_pointer != '\\')) {
-			/* normal character, copy */
-			*output_pointer = *input_pointer;
-		} else {
-			/* character needs to be escaped */
-			*output_pointer++ = '\\';
-			switch (*input_pointer) {
-			case '\\':
-				*output_pointer = '\\';
-				break;
-			case '\"':
-				*output_pointer = '\"';
-				break;
-			case '\b':
-				*output_pointer = 'b';
-				break;
-			case '\f':
-				*output_pointer = 'f';
-				break;
-			case '\n':
-				*output_pointer = 'n';
-				break;
-			case '\r':
-				*output_pointer = 'r';
-				break;
-			case '\t':
-				*output_pointer = 't';
-				break;
-			default:
-				/* escape and print as unicode codepoint */
-				sprintf((char *)output_pointer, "u%04x", *input_pointer);
-				output_pointer += 4;
-				break;
-			}
-		}
-	}
-	output[output_length + 1] = '\"';
-	output[output_length + 2] = '\0';
+    output[0] = '\"';
+    output_pointer = output + 1;
+    /* copy the string */
+    for (input_pointer = input; *input_pointer != '\0'; (void)input_pointer++, output_pointer++)
+    {
+        if ((*input_pointer > 31) && (*input_pointer != '\"') && (*input_pointer != '\\'))
+        {
+            /* normal character, copy */
+            *output_pointer = *input_pointer;
+        }
+        else
+        {
+            /* character needs to be escaped */
+            *output_pointer++ = '\\';
+            switch (*input_pointer)
+            {
+                case '\\':
+                    *output_pointer = '\\';
+                    break;
+                case '\"':
+                    *output_pointer = '\"';
+                    break;
+                case '\b':
+                    *output_pointer = 'b';
+                    break;
+                case '\f':
+                    *output_pointer = 'f';
+                    break;
+                case '\n':
+                    *output_pointer = 'n';
+                    break;
+                case '\r':
+                    *output_pointer = 'r';
+                    break;
+                case '\t':
+                    *output_pointer = 't';
+                    break;
+                default:
+                    /* escape and print as unicode codepoint */
+                    sprintf((char*)output_pointer, "u%04x", *input_pointer);
+                    output_pointer += 4;
+                    break;
+            }
+        }
+    }
+    output[output_length + 1] = '\"';
+    output[output_length + 2] = '\0';
 
-	return true;
+    return true;
 }
 
 /* Invoke print_string_ptr (which is useful) on an item. */
-static cJSON_bool
-print_string(const cJSON *const item, printbuffer *const p)
+static cJSON_bool print_string(const cJSON * const item, printbuffer * const p)
 {
-	return print_string_ptr((unsigned char *)item->valuestring, p);
+    return print_string_ptr((unsigned char*)item->valuestring, p);
 }
 
 /* Predeclare these prototypes. */
-static cJSON_bool
-parse_value(cJSON *const item, parse_buffer *const input_buffer);
-static cJSON_bool
-print_value(const cJSON *const item, printbuffer *const output_buffer);
-static cJSON_bool
-parse_array(cJSON *const item, parse_buffer *const input_buffer);
-static cJSON_bool
-print_array(const cJSON *const item, printbuffer *const output_buffer);
-static cJSON_bool
-parse_object(cJSON *const item, parse_buffer *const input_buffer);
-static cJSON_bool
-print_object(const cJSON *const item, printbuffer *const output_buffer);
+static cJSON_bool parse_value(cJSON * const item, parse_buffer * const input_buffer);
+static cJSON_bool print_value(const cJSON * const item, printbuffer * const output_buffer);
+static cJSON_bool parse_array(cJSON * const item, parse_buffer * const input_buffer);
+static cJSON_bool print_array(const cJSON * const item, printbuffer * const output_buffer);
+static cJSON_bool parse_object(cJSON * const item, parse_buffer * const input_buffer);
+static cJSON_bool print_object(const cJSON * const item, printbuffer * const output_buffer);
 
 /* Utility to jump whitespace and cr/lf */
-static parse_buffer *
-buffer_skip_whitespace(parse_buffer *const buffer)
+static parse_buffer *buffer_skip_whitespace(parse_buffer * const buffer)
 {
-	if ((buffer == NULL) || (buffer->content == NULL)) {
-		return NULL;
-	}
+    if ((buffer == NULL) || (buffer->content == NULL))
+    {
+        return NULL;
+    }
 
-	while (can_access_at_index(buffer, 0) && (buffer_at_offset(buffer)[0] <= 32)) {
-		buffer->offset++;
-	}
+    while (can_access_at_index(buffer, 0) && (buffer_at_offset(buffer)[0] <= 32))
+    {
+       buffer->offset++;
+    }
 
-	if (buffer->offset == buffer->length) {
-		buffer->offset--;
-	}
+    if (buffer->offset == buffer->length)
+    {
+        buffer->offset--;
+    }
 
-	return buffer;
+    return buffer;
+}
+
+/* skip the UTF-8 BOM (byte order mark) if it is at the beginning of a buffer */
+static parse_buffer *skip_utf8_bom(parse_buffer * const buffer)
+{
+    if ((buffer == NULL) || (buffer->content == NULL) || (buffer->offset != 0))
+    {
+        return NULL;
+    }
+
+    if (can_access_at_index(buffer, 4) && (strncmp((const char*)buffer_at_offset(buffer), "\xEF\xBB\xBF", 3) == 0))
+    {
+        buffer->offset += 3;
+    }
+
+    return buffer;
 }
 
 /* Parse an object - create a new root, and populate. */
-CJSON_PUBLIC(cJSON *)
-cJSON_ParseWithOpts(const char *value, const char **return_parse_end,
-		    cJSON_bool require_null_terminated)
+CJSON_PUBLIC(cJSON *) cJSON_ParseWithOpts(const char *value, const char **return_parse_end, cJSON_bool require_null_terminated)
 {
-	parse_buffer buffer = { 0, 0, 0, 0, { 0, 0, 0 } };
-	cJSON *item = NULL;
+    parse_buffer buffer = { 0, 0, 0, 0, { 0, 0, 0 } };
+    cJSON *item = NULL;
 
-	/* reset error position */
-	global_error.json = NULL;
-	global_error.position = 0;
+    /* reset error position */
+    global_error.json = NULL;
+    global_error.position = 0;
 
-	if (value == NULL) {
-		goto fail;
-	}
+    if (value == NULL)
+    {
+        goto fail;
+    }
 
-	buffer.content = (const unsigned char *)value;
-	buffer.length = strlen((const char *)value) + sizeof("");
-	buffer.offset = 0;
-	buffer.hooks = global_hooks;
+    buffer.content = (const unsigned char*)value;
+    buffer.length = strlen((const char*)value) + sizeof("");
+    buffer.offset = 0;
+    buffer.hooks = global_hooks;
 
-	item = cJSON_New_Item(&global_hooks);
-	if (item == NULL) /* memory fail */
-	{
-		goto fail;
-	}
+    item = cJSON_New_Item(&global_hooks);
+    if (item == NULL) /* memory fail */
+    {
+        goto fail;
+    }
 
-	if (!parse_value(item, buffer_skip_whitespace(&buffer))) {
-		/* parse failure. ep is set. */
-		goto fail;
-	}
+    if (!parse_value(item, buffer_skip_whitespace(skip_utf8_bom(&buffer))))
+    {
+        /* parse failure. ep is set. */
+        goto fail;
+    }
 
-	/* if we require null-terminated JSON without appended garbage, skip and then check for a null terminator */
-	if (require_null_terminated) {
-		buffer_skip_whitespace(&buffer);
-		if ((buffer.offset >= buffer.length) || buffer_at_offset(&buffer)[0] != '\0') {
-			goto fail;
-		}
-	}
-	if (return_parse_end) {
-		*return_parse_end = (const char *)buffer_at_offset(&buffer);
-	}
+    /* if we require null-terminated JSON without appended garbage, skip and then check for a null terminator */
+    if (require_null_terminated)
+    {
+        buffer_skip_whitespace(&buffer);
+        if ((buffer.offset >= buffer.length) || buffer_at_offset(&buffer)[0] != '\0')
+        {
+            goto fail;
+        }
+    }
+    if (return_parse_end)
+    {
+        *return_parse_end = (const char*)buffer_at_offset(&buffer);
+    }
 
-	return item;
+    return item;
 
 fail:
-	if (item != NULL) {
-		cJSON_Delete(item);
-	}
+    if (item != NULL)
+    {
+        cJSON_Delete(item);
+    }
 
-	if (value != NULL) {
-		error local_error;
-		local_error.json = (const unsigned char *)value;
-		local_error.position = 0;
+    if (value != NULL)
+    {
+        error local_error;
+        local_error.json = (const unsigned char*)value;
+        local_error.position = 0;
 
-		if (buffer.offset < buffer.length) {
-			local_error.position = buffer.offset;
-		} else if (buffer.length > 0) {
-			local_error.position = buffer.length - 1;
-		}
+        if (buffer.offset < buffer.length)
+        {
+            local_error.position = buffer.offset;
+        }
+        else if (buffer.length > 0)
+        {
+            local_error.position = buffer.length - 1;
+        }
 
-		if (return_parse_end != NULL) {
-			*return_parse_end = (const char *)local_error.json + local_error.position;
-		} else {
-			global_error = local_error;
-		}
-	}
+        if (return_parse_end != NULL)
+        {
+            *return_parse_end = (const char*)local_error.json + local_error.position;
+        }
 
-	return NULL;
+        global_error = local_error;
+    }
+
+    return NULL;
 }
 
 /* Default options for cJSON_Parse */
 CJSON_PUBLIC(cJSON *) cJSON_Parse(const char *value)
 {
-	return cJSON_ParseWithOpts(value, 0, 0);
+    return cJSON_ParseWithOpts(value, 0, 0);
 }
 
 #define cjson_min(a, b) ((a < b) ? a : b)
 
-static unsigned char *
-print(const cJSON *const item, cJSON_bool format, const internal_hooks *const hooks)
+static unsigned char *print(const cJSON * const item, cJSON_bool format, const internal_hooks * const hooks)
 {
-	printbuffer buffer[1];
-	unsigned char *printed = NULL;
+    static const size_t default_buffer_size = 256;
+    printbuffer buffer[1];
+    unsigned char *printed = NULL;
 
-	memset(buffer, 0, sizeof(buffer));
+    memset(buffer, 0, sizeof(buffer));
 
-	/* create buffer */
-	buffer->buffer = (unsigned char *)hooks->allocate(256);
-	buffer->format = format;
-	buffer->hooks = *hooks;
-	if (buffer->buffer == NULL) {
-		goto fail;
-	}
+    /* create buffer */
+    buffer->buffer = (unsigned char*) hooks->allocate(default_buffer_size);
+    buffer->length = default_buffer_size;
+    buffer->format = format;
+    buffer->hooks = *hooks;
+    if (buffer->buffer == NULL)
+    {
+        goto fail;
+    }
 
-	/* print the value */
-	if (!print_value(item, buffer)) {
-		goto fail;
-	}
-	update_offset(buffer);
+    /* print the value */
+    if (!print_value(item, buffer))
+    {
+        goto fail;
+    }
+    update_offset(buffer);
 
-	/* check if reallocate is available */
-	if (hooks->reallocate != NULL) {
-		printed = (unsigned char *)hooks->reallocate(buffer->buffer, buffer->length);
-		buffer->buffer = NULL;
-		if (printed == NULL) {
-			goto fail;
-		}
-	} else /* otherwise copy the JSON over to a new buffer */
-	{
-		printed = (unsigned char *)hooks->allocate(buffer->offset + 1);
-		if (printed == NULL) {
-			goto fail;
-		}
-		memcpy(printed, buffer->buffer, cjson_min(buffer->length, buffer->offset + 1));
-		printed[buffer->offset] = '\0'; /* just to be sure */
+    /* check if reallocate is available */
+    if (hooks->reallocate != NULL)
+    {
+        printed = (unsigned char*) hooks->reallocate(buffer->buffer, buffer->offset + 1);
+        if (printed == NULL) {
+            goto fail;
+        }
+        buffer->buffer = NULL;
+    }
+    else /* otherwise copy the JSON over to a new buffer */
+    {
+        printed = (unsigned char*) hooks->allocate(buffer->offset + 1);
+        if (printed == NULL)
+        {
+            goto fail;
+        }
+        memcpy(printed, buffer->buffer, cjson_min(buffer->length, buffer->offset + 1));
+        printed[buffer->offset] = '\0'; /* just to be sure */
 
-		/* free the buffer */
-		hooks->deallocate(buffer->buffer);
-	}
+        /* free the buffer */
+        hooks->deallocate(buffer->buffer);
+    }
 
-	return printed;
+    return printed;
 
 fail:
-	if (buffer->buffer != NULL) {
-		hooks->deallocate(buffer->buffer);
-	}
+    if (buffer->buffer != NULL)
+    {
+        hooks->deallocate(buffer->buffer);
+    }
 
-	if (printed != NULL) {
-		hooks->deallocate(printed);
-	}
+    if (printed != NULL)
+    {
+        hooks->deallocate(printed);
+    }
 
-	return NULL;
+    return NULL;
 }
 
 /* Render a cJSON item/entity/structure to text. */
 CJSON_PUBLIC(char *) cJSON_Print(const cJSON *item)
 {
-	return (char *)print(item, true, &global_hooks);
+    return (char*)print(item, true, &global_hooks);
 }
 
 CJSON_PUBLIC(char *) cJSON_PrintUnformatted(const cJSON *item)
 {
-	return (char *)print(item, false, &global_hooks);
+    return (char*)print(item, false, &global_hooks);
 }
 
 CJSON_PUBLIC(char *) cJSON_PrintBuffered(const cJSON *item, int prebuffer, cJSON_bool fmt)
 {
-	printbuffer p = { 0, 0, 0, 0, 0, 0, { 0, 0, 0 } };
+    printbuffer p = { 0, 0, 0, 0, 0, 0, { 0, 0, 0 } };
 
-	if (prebuffer < 0) {
-		return NULL;
-	}
+    if (prebuffer < 0)
+    {
+        return NULL;
+    }
 
-	p.buffer = (unsigned char *)global_hooks.allocate((size_t)prebuffer);
-	if (!p.buffer) {
-		return NULL;
-	}
+    p.buffer = (unsigned char*)global_hooks.allocate((size_t)prebuffer);
+    if (!p.buffer)
+    {
+        return NULL;
+    }
 
-	p.length = (size_t)prebuffer;
-	p.offset = 0;
-	p.noalloc = false;
-	p.format = fmt;
-	p.hooks = global_hooks;
+    p.length = (size_t)prebuffer;
+    p.offset = 0;
+    p.noalloc = false;
+    p.format = fmt;
+    p.hooks = global_hooks;
 
-	if (!print_value(item, &p)) {
-		return NULL;
-	}
+    if (!print_value(item, &p))
+    {
+        global_hooks.deallocate(p.buffer);
+        return NULL;
+    }
 
-	return (char *)p.buffer;
+    return (char*)p.buffer;
 }
 
-CJSON_PUBLIC(cJSON_bool)
-cJSON_PrintPreallocated(cJSON *item, char *buf, const int len, const cJSON_bool fmt)
+CJSON_PUBLIC(cJSON_bool) cJSON_PrintPreallocated(cJSON *item, char *buffer, const int length, const cJSON_bool format)
 {
-	printbuffer p = { 0, 0, 0, 0, 0, 0, { 0, 0, 0 } };
+    printbuffer p = { 0, 0, 0, 0, 0, 0, { 0, 0, 0 } };
 
-	if (len < 0) {
-		return false;
-	}
+    if ((length < 0) || (buffer == NULL))
+    {
+        return false;
+    }
 
-	p.buffer = (unsigned char *)buf;
-	p.length = (size_t)len;
-	p.offset = 0;
-	p.noalloc = true;
-	p.format = fmt;
-	p.hooks = global_hooks;
+    p.buffer = (unsigned char*)buffer;
+    p.length = (size_t)length;
+    p.offset = 0;
+    p.noalloc = true;
+    p.format = format;
+    p.hooks = global_hooks;
 
-	return print_value(item, &p);
+    return print_value(item, &p);
 }
 
 /* Parser core - when encountering text, process appropriately. */
-static cJSON_bool
-parse_value(cJSON *const item, parse_buffer *const input_buffer)
+static cJSON_bool parse_value(cJSON * const item, parse_buffer * const input_buffer)
 {
-	if ((input_buffer == NULL) || (input_buffer->content == NULL)) {
-		return false; /* no input */
-	}
+    if ((input_buffer == NULL) || (input_buffer->content == NULL))
+    {
+        return false; /* no input */
+    }
 
-	/* parse the different types of values */
-	/* null */
-	if (can_read(input_buffer, 4) &&
-	    (strncmp((const char *)buffer_at_offset(input_buffer), "null", 4) == 0)) {
-		item->type = cJSON_NULL;
-		input_buffer->offset += 4;
-		return true;
-	}
-	/* false */
-	if (can_read(input_buffer, 5) &&
-	    (strncmp((const char *)buffer_at_offset(input_buffer), "false", 5) == 0)) {
-		item->type = cJSON_False;
-		input_buffer->offset += 5;
-		return true;
-	}
-	/* true */
-	if (can_read(input_buffer, 4) &&
-	    (strncmp((const char *)buffer_at_offset(input_buffer), "true", 4) == 0)) {
-		item->type = cJSON_True;
-		item->valueint = 1;
-		input_buffer->offset += 4;
-		return true;
-	}
-	/* string */
-	if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '\"')) {
-		return parse_string(item, input_buffer);
-	}
-	/* number */
-	if (can_access_at_index(input_buffer, 0) &&
-	    ((buffer_at_offset(input_buffer)[0] == '-') ||
-	     ((buffer_at_offset(input_buffer)[0] >= '0') &&
-	      (buffer_at_offset(input_buffer)[0] <= '9')))) {
-		return parse_number(item, input_buffer);
-	}
-	/* array */
-	if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '[')) {
-		return parse_array(item, input_buffer);
-	}
-	/* object */
-	if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '{')) {
-		return parse_object(item, input_buffer);
-	}
+    /* parse the different types of values */
+    /* null */
+    if (can_read(input_buffer, 4) && (strncmp((const char*)buffer_at_offset(input_buffer), "null", 4) == 0))
+    {
+        item->type = cJSON_NULL;
+        input_buffer->offset += 4;
+        return true;
+    }
+    /* false */
+    if (can_read(input_buffer, 5) && (strncmp((const char*)buffer_at_offset(input_buffer), "false", 5) == 0))
+    {
+        item->type = cJSON_False;
+        input_buffer->offset += 5;
+        return true;
+    }
+    /* true */
+    if (can_read(input_buffer, 4) && (strncmp((const char*)buffer_at_offset(input_buffer), "true", 4) == 0))
+    {
+        item->type = cJSON_True;
+        item->valueint = 1;
+        input_buffer->offset += 4;
+        return true;
+    }
+    /* string */
+    if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '\"'))
+    {
+        return parse_string(item, input_buffer);
+    }
+    /* number */
+    if (can_access_at_index(input_buffer, 0) && ((buffer_at_offset(input_buffer)[0] == '-') || ((buffer_at_offset(input_buffer)[0] >= '0') && (buffer_at_offset(input_buffer)[0] <= '9'))))
+    {
+        return parse_number(item, input_buffer);
+    }
+    /* array */
+    if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '['))
+    {
+        return parse_array(item, input_buffer);
+    }
+    /* object */
+    if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '{'))
+    {
+        return parse_object(item, input_buffer);
+    }
 
-	return false;
+    return false;
 }
 
 /* Render a value to text. */
-static cJSON_bool
-print_value(const cJSON *const item, printbuffer *const output_buffer)
+static cJSON_bool print_value(const cJSON * const item, printbuffer * const output_buffer)
 {
-	unsigned char *output = NULL;
+    unsigned char *output = NULL;
 
-	if ((item == NULL) || (output_buffer == NULL)) {
-		return false;
-	}
+    if ((item == NULL) || (output_buffer == NULL))
+    {
+        return false;
+    }
 
-	switch ((item->type) & 0xFF) {
-	case cJSON_NULL:
-		output = ensure(output_buffer, 5);
-		if (output == NULL) {
-			return false;
-		}
-		strcpy((char *)output, "null");
-		return true;
+    switch ((item->type) & 0xFF)
+    {
+        case cJSON_NULL:
+            output = ensure(output_buffer, 5);
+            if (output == NULL)
+            {
+                return false;
+            }
+            strcpy((char*)output, "null");
+            return true;
 
-	case cJSON_False:
-		output = ensure(output_buffer, 6);
-		if (output == NULL) {
-			return false;
-		}
-		strcpy((char *)output, "false");
-		return true;
+        case cJSON_False:
+            output = ensure(output_buffer, 6);
+            if (output == NULL)
+            {
+                return false;
+            }
+            strcpy((char*)output, "false");
+            return true;
 
-	case cJSON_True:
-		output = ensure(output_buffer, 5);
-		if (output == NULL) {
-			return false;
-		}
-		strcpy((char *)output, "true");
-		return true;
+        case cJSON_True:
+            output = ensure(output_buffer, 5);
+            if (output == NULL)
+            {
+                return false;
+            }
+            strcpy((char*)output, "true");
+            return true;
 
-	case cJSON_Number:
-		return print_number(item, output_buffer);
+        case cJSON_Number:
+            return print_number(item, output_buffer);
 
-	case cJSON_Raw: {
-		size_t raw_length = 0;
-		if (item->valuestring == NULL) {
-			if (!output_buffer->noalloc) {
-				output_buffer->hooks.deallocate(output_buffer->buffer);
-			}
-			return false;
-		}
+        case cJSON_Raw:
+        {
+            size_t raw_length = 0;
+            if (item->valuestring == NULL)
+            {
+                return false;
+            }
 
-		raw_length = strlen(item->valuestring) + sizeof("");
-		output = ensure(output_buffer, raw_length);
-		if (output == NULL) {
-			return false;
-		}
-		memcpy(output, item->valuestring, raw_length);
-		return true;
-	}
+            raw_length = strlen(item->valuestring) + sizeof("");
+            output = ensure(output_buffer, raw_length);
+            if (output == NULL)
+            {
+                return false;
+            }
+            memcpy(output, item->valuestring, raw_length);
+            return true;
+        }
 
-	case cJSON_String:
-		return print_string(item, output_buffer);
+        case cJSON_String:
+            return print_string(item, output_buffer);
 
-	case cJSON_Array:
-		return print_array(item, output_buffer);
+        case cJSON_Array:
+            return print_array(item, output_buffer);
 
-	case cJSON_Object:
-		return print_object(item, output_buffer);
+        case cJSON_Object:
+            return print_object(item, output_buffer);
 
-	default:
-		return false;
-	}
+        default:
+            return false;
+    }
 }
 
 /* Build an array from input text. */
-static cJSON_bool
-parse_array(cJSON *const item, parse_buffer *const input_buffer)
+static cJSON_bool parse_array(cJSON * const item, parse_buffer * const input_buffer)
 {
-	cJSON *head = NULL; /* head of the linked list */
-	cJSON *current_item = NULL;
+    cJSON *head = NULL; /* head of the linked list */
+    cJSON *current_item = NULL;
 
-	if (input_buffer->depth >= CJSON_NESTING_LIMIT) {
-		return false; /* to deeply nested */
-	}
-	input_buffer->depth++;
+    if (input_buffer->depth >= CJSON_NESTING_LIMIT)
+    {
+        return false; /* to deeply nested */
+    }
+    input_buffer->depth++;
 
-	if (buffer_at_offset(input_buffer)[0] != '[') {
-		/* not an array */
-		goto fail;
-	}
+    if (buffer_at_offset(input_buffer)[0] != '[')
+    {
+        /* not an array */
+        goto fail;
+    }
 
-	input_buffer->offset++;
-	buffer_skip_whitespace(input_buffer);
-	if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == ']')) {
-		/* empty array */
-		goto success;
-	}
+    input_buffer->offset++;
+    buffer_skip_whitespace(input_buffer);
+    if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == ']'))
+    {
+        /* empty array */
+        goto success;
+    }
 
-	/* check if we skipped to the end of the buffer */
-	if (cannot_access_at_index(input_buffer, 0)) {
-		input_buffer->offset--;
-		goto fail;
-	}
+    /* check if we skipped to the end of the buffer */
+    if (cannot_access_at_index(input_buffer, 0))
+    {
+        input_buffer->offset--;
+        goto fail;
+    }
 
-	/* step back to character in front of the first element */
-	input_buffer->offset--;
-	/* loop through the comma separated array elements */
-	do {
-		/* allocate next item */
-		cJSON *new_item = cJSON_New_Item(&(input_buffer->hooks));
-		if (new_item == NULL) {
-			goto fail; /* allocation failure */
-		}
+    /* step back to character in front of the first element */
+    input_buffer->offset--;
+    /* loop through the comma separated array elements */
+    do
+    {
+        /* allocate next item */
+        cJSON *new_item = cJSON_New_Item(&(input_buffer->hooks));
+        if (new_item == NULL)
+        {
+            goto fail; /* allocation failure */
+        }
 
-		/* attach next item to list */
-		if (head == NULL) {
-			/* start the linked list */
-			current_item = head = new_item;
-		} else {
-			/* add to the end and advance */
-			current_item->next = new_item;
-			new_item->prev = current_item;
-			current_item = new_item;
-		}
+        /* attach next item to list */
+        if (head == NULL)
+        {
+            /* start the linked list */
+            current_item = head = new_item;
+        }
+        else
+        {
+            /* add to the end and advance */
+            current_item->next = new_item;
+            new_item->prev = current_item;
+            current_item = new_item;
+        }
 
-		/* parse next value */
-		input_buffer->offset++;
-		buffer_skip_whitespace(input_buffer);
-		if (!parse_value(current_item, input_buffer)) {
-			goto fail; /* failed to parse value */
-		}
-		buffer_skip_whitespace(input_buffer);
-	} while (can_access_at_index(input_buffer, 0) &&
-		 (buffer_at_offset(input_buffer)[0] == ','));
+        /* parse next value */
+        input_buffer->offset++;
+        buffer_skip_whitespace(input_buffer);
+        if (!parse_value(current_item, input_buffer))
+        {
+            goto fail; /* failed to parse value */
+        }
+        buffer_skip_whitespace(input_buffer);
+    }
+    while (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == ','));
 
-	if (cannot_access_at_index(input_buffer, 0) || buffer_at_offset(input_buffer)[0] != ']') {
-		goto fail; /* expected end of array */
-	}
+    if (cannot_access_at_index(input_buffer, 0) || buffer_at_offset(input_buffer)[0] != ']')
+    {
+        goto fail; /* expected end of array */
+    }
 
 success:
-	input_buffer->depth--;
+    input_buffer->depth--;
 
-	item->type = cJSON_Array;
-	item->child = head;
+    item->type = cJSON_Array;
+    item->child = head;
 
-	input_buffer->offset++;
+    input_buffer->offset++;
 
-	return true;
+    return true;
 
 fail:
-	if (head != NULL) {
-		cJSON_Delete(head);
-	}
+    if (head != NULL)
+    {
+        cJSON_Delete(head);
+    }
 
-	return false;
+    return false;
 }
 
 /* Render an array to text */
-static cJSON_bool
-print_array(const cJSON *const item, printbuffer *const output_buffer)
+static cJSON_bool print_array(const cJSON * const item, printbuffer * const output_buffer)
 {
-	unsigned char *output_pointer = NULL;
-	size_t length = 0;
-	cJSON *current_element = item->child;
+    unsigned char *output_pointer = NULL;
+    size_t length = 0;
+    cJSON *current_element = item->child;
 
-	if (output_buffer == NULL) {
-		return false;
-	}
+    if (output_buffer == NULL)
+    {
+        return false;
+    }
 
-	/* Compose the output array. */
-	/* opening square bracket */
-	output_pointer = ensure(output_buffer, 1);
-	if (output_pointer == NULL) {
-		return false;
-	}
+    /* Compose the output array. */
+    /* opening square bracket */
+    output_pointer = ensure(output_buffer, 1);
+    if (output_pointer == NULL)
+    {
+        return false;
+    }
 
-	*output_pointer = '[';
-	output_buffer->offset++;
-	output_buffer->depth++;
+    *output_pointer = '[';
+    output_buffer->offset++;
+    output_buffer->depth++;
 
-	while (current_element != NULL) {
-		if (!print_value(current_element, output_buffer)) {
-			return false;
-		}
-		update_offset(output_buffer);
-		if (current_element->next) {
-			length = (size_t)(output_buffer->format ? 2 : 1);
-			output_pointer = ensure(output_buffer, length + 1);
-			if (output_pointer == NULL) {
-				return false;
-			}
-			*output_pointer++ = ',';
-			if (output_buffer->format) {
-				*output_pointer++ = ' ';
-			}
-			*output_pointer = '\0';
-			output_buffer->offset += length;
-		}
-		current_element = current_element->next;
-	}
+    while (current_element != NULL)
+    {
+        if (!print_value(current_element, output_buffer))
+        {
+            return false;
+        }
+        update_offset(output_buffer);
+        if (current_element->next)
+        {
+            length = (size_t) (output_buffer->format ? 2 : 1);
+            output_pointer = ensure(output_buffer, length + 1);
+            if (output_pointer == NULL)
+            {
+                return false;
+            }
+            *output_pointer++ = ',';
+            if(output_buffer->format)
+            {
+                *output_pointer++ = ' ';
+            }
+            *output_pointer = '\0';
+            output_buffer->offset += length;
+        }
+        current_element = current_element->next;
+    }
 
-	output_pointer = ensure(output_buffer, 2);
-	if (output_pointer == NULL) {
-		return false;
-	}
-	*output_pointer++ = ']';
-	*output_pointer = '\0';
-	output_buffer->depth--;
+    output_pointer = ensure(output_buffer, 2);
+    if (output_pointer == NULL)
+    {
+        return false;
+    }
+    *output_pointer++ = ']';
+    *output_pointer = '\0';
+    output_buffer->depth--;
 
-	return true;
+    return true;
 }
 
 /* Build an object from the text. */
-static cJSON_bool
-parse_object(cJSON *const item, parse_buffer *const input_buffer)
+static cJSON_bool parse_object(cJSON * const item, parse_buffer * const input_buffer)
 {
-	cJSON *head = NULL; /* linked list head */
-	cJSON *current_item = NULL;
+    cJSON *head = NULL; /* linked list head */
+    cJSON *current_item = NULL;
 
-	if (input_buffer->depth >= CJSON_NESTING_LIMIT) {
-		return false; /* to deeply nested */
-	}
-	input_buffer->depth++;
+    if (input_buffer->depth >= CJSON_NESTING_LIMIT)
+    {
+        return false; /* to deeply nested */
+    }
+    input_buffer->depth++;
 
-	if (cannot_access_at_index(input_buffer, 0) || (buffer_at_offset(input_buffer)[0] != '{')) {
-		goto fail; /* not an object */
-	}
+    if (cannot_access_at_index(input_buffer, 0) || (buffer_at_offset(input_buffer)[0] != '{'))
+    {
+        goto fail; /* not an object */
+    }
 
-	input_buffer->offset++;
-	buffer_skip_whitespace(input_buffer);
-	if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '}')) {
-		goto success; /* empty object */
-	}
+    input_buffer->offset++;
+    buffer_skip_whitespace(input_buffer);
+    if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '}'))
+    {
+        goto success; /* empty object */
+    }
 
-	/* check if we skipped to the end of the buffer */
-	if (cannot_access_at_index(input_buffer, 0)) {
-		input_buffer->offset--;
-		goto fail;
-	}
+    /* check if we skipped to the end of the buffer */
+    if (cannot_access_at_index(input_buffer, 0))
+    {
+        input_buffer->offset--;
+        goto fail;
+    }
 
-	/* step back to character in front of the first element */
-	input_buffer->offset--;
-	/* loop through the comma separated array elements */
-	do {
-		/* allocate next item */
-		cJSON *new_item = cJSON_New_Item(&(input_buffer->hooks));
-		if (new_item == NULL) {
-			goto fail; /* allocation failure */
-		}
+    /* step back to character in front of the first element */
+    input_buffer->offset--;
+    /* loop through the comma separated array elements */
+    do
+    {
+        /* allocate next item */
+        cJSON *new_item = cJSON_New_Item(&(input_buffer->hooks));
+        if (new_item == NULL)
+        {
+            goto fail; /* allocation failure */
+        }
 
-		/* attach next item to list */
-		if (head == NULL) {
-			/* start the linked list */
-			current_item = head = new_item;
-		} else {
-			/* add to the end and advance */
-			current_item->next = new_item;
-			new_item->prev = current_item;
-			current_item = new_item;
-		}
+        /* attach next item to list */
+        if (head == NULL)
+        {
+            /* start the linked list */
+            current_item = head = new_item;
+        }
+        else
+        {
+            /* add to the end and advance */
+            current_item->next = new_item;
+            new_item->prev = current_item;
+            current_item = new_item;
+        }
 
-		/* parse the name of the child */
-		input_buffer->offset++;
-		buffer_skip_whitespace(input_buffer);
-		if (!parse_string(current_item, input_buffer)) {
-			goto fail; /* faile to parse name */
-		}
-		buffer_skip_whitespace(input_buffer);
+        /* parse the name of the child */
+        input_buffer->offset++;
+        buffer_skip_whitespace(input_buffer);
+        if (!parse_string(current_item, input_buffer))
+        {
+            goto fail; /* failed to parse name */
+        }
+        buffer_skip_whitespace(input_buffer);
 
-		/* swap valuestring and string, because we parsed the name */
-		current_item->string = current_item->valuestring;
-		current_item->valuestring = NULL;
+        /* swap valuestring and string, because we parsed the name */
+        current_item->string = current_item->valuestring;
+        current_item->valuestring = NULL;
 
-		if (cannot_access_at_index(input_buffer, 0) ||
-		    (buffer_at_offset(input_buffer)[0] != ':')) {
-			goto fail; /* invalid object */
-		}
+        if (cannot_access_at_index(input_buffer, 0) || (buffer_at_offset(input_buffer)[0] != ':'))
+        {
+            goto fail; /* invalid object */
+        }
 
-		/* parse the value */
-		input_buffer->offset++;
-		buffer_skip_whitespace(input_buffer);
-		if (!parse_value(current_item, input_buffer)) {
-			goto fail; /* failed to parse value */
-		}
-		buffer_skip_whitespace(input_buffer);
-	} while (can_access_at_index(input_buffer, 0) &&
-		 (buffer_at_offset(input_buffer)[0] == ','));
+        /* parse the value */
+        input_buffer->offset++;
+        buffer_skip_whitespace(input_buffer);
+        if (!parse_value(current_item, input_buffer))
+        {
+            goto fail; /* failed to parse value */
+        }
+        buffer_skip_whitespace(input_buffer);
+    }
+    while (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == ','));
 
-	if (cannot_access_at_index(input_buffer, 0) || (buffer_at_offset(input_buffer)[0] != '}')) {
-		goto fail; /* expected end of object */
-	}
+    if (cannot_access_at_index(input_buffer, 0) || (buffer_at_offset(input_buffer)[0] != '}'))
+    {
+        goto fail; /* expected end of object */
+    }
 
 success:
-	input_buffer->depth--;
+    input_buffer->depth--;
 
-	item->type = cJSON_Object;
-	item->child = head;
+    item->type = cJSON_Object;
+    item->child = head;
 
-	input_buffer->offset++;
-	return true;
+    input_buffer->offset++;
+    return true;
 
 fail:
-	if (head != NULL) {
-		cJSON_Delete(head);
-	}
+    if (head != NULL)
+    {
+        cJSON_Delete(head);
+    }
 
-	return false;
+    return false;
 }
 
 /* Render an object to text. */
-static cJSON_bool
-print_object(const cJSON *const item, printbuffer *const output_buffer)
+static cJSON_bool print_object(const cJSON * const item, printbuffer * const output_buffer)
 {
-	unsigned char *output_pointer = NULL;
-	size_t length = 0;
-	cJSON *current_item = item->child;
+    unsigned char *output_pointer = NULL;
+    size_t length = 0;
+    cJSON *current_item = item->child;
 
-	if (output_buffer == NULL) {
-		return false;
-	}
+    if (output_buffer == NULL)
+    {
+        return false;
+    }
 
-	/* Compose the output: */
-	length = (size_t)(output_buffer->format ? 2 : 1); /* fmt: {\n */
-	output_pointer = ensure(output_buffer, length + 1);
-	if (output_pointer == NULL) {
-		return false;
-	}
+    /* Compose the output: */
+    length = (size_t) (output_buffer->format ? 2 : 1); /* fmt: {\n */
+    output_pointer = ensure(output_buffer, length + 1);
+    if (output_pointer == NULL)
+    {
+        return false;
+    }
 
-	*output_pointer++ = '{';
-	output_buffer->depth++;
-	if (output_buffer->format) {
-		*output_pointer++ = '\n';
-	}
-	output_buffer->offset += length;
+    *output_pointer++ = '{';
+    output_buffer->depth++;
+    if (output_buffer->format)
+    {
+        *output_pointer++ = '\n';
+    }
+    output_buffer->offset += length;
 
-	while (current_item) {
-		if (output_buffer->format) {
-			size_t i;
-			output_pointer = ensure(output_buffer, output_buffer->depth);
-			if (output_pointer == NULL) {
-				return false;
-			}
-			for (i = 0; i < output_buffer->depth; i++) {
-				*output_pointer++ = '\t';
-			}
-			output_buffer->offset += output_buffer->depth;
-		}
+    while (current_item)
+    {
+        if (output_buffer->format)
+        {
+            size_t i;
+            output_pointer = ensure(output_buffer, output_buffer->depth);
+            if (output_pointer == NULL)
+            {
+                return false;
+            }
+            for (i = 0; i < output_buffer->depth; i++)
+            {
+                *output_pointer++ = '\t';
+            }
+            output_buffer->offset += output_buffer->depth;
+        }
 
-		/* print key */
-		if (!print_string_ptr((unsigned char *)current_item->string, output_buffer)) {
-			return false;
-		}
-		update_offset(output_buffer);
+        /* print key */
+        if (!print_string_ptr((unsigned char*)current_item->string, output_buffer))
+        {
+            return false;
+        }
+        update_offset(output_buffer);
 
-		length = (size_t)(output_buffer->format ? 2 : 1);
-		output_pointer = ensure(output_buffer, length);
-		if (output_pointer == NULL) {
-			return false;
-		}
-		*output_pointer++ = ':';
-		if (output_buffer->format) {
-			*output_pointer++ = '\t';
-		}
-		output_buffer->offset += length;
+        length = (size_t) (output_buffer->format ? 2 : 1);
+        output_pointer = ensure(output_buffer, length);
+        if (output_pointer == NULL)
+        {
+            return false;
+        }
+        *output_pointer++ = ':';
+        if (output_buffer->format)
+        {
+            *output_pointer++ = '\t';
+        }
+        output_buffer->offset += length;
 
-		/* print value */
-		if (!print_value(current_item, output_buffer)) {
-			return false;
-		}
-		update_offset(output_buffer);
+        /* print value */
+        if (!print_value(current_item, output_buffer))
+        {
+            return false;
+        }
+        update_offset(output_buffer);
 
-		/* print comma if not last */
-		length = (size_t)((output_buffer->format ? 1 : 0) + (current_item->next ? 1 : 0));
-		output_pointer = ensure(output_buffer, length + 1);
-		if (output_pointer == NULL) {
-			return false;
-		}
-		if (current_item->next) {
-			*output_pointer++ = ',';
-		}
+        /* print comma if not last */
+        length = ((size_t)(output_buffer->format ? 1 : 0) + (size_t)(current_item->next ? 1 : 0));
+        output_pointer = ensure(output_buffer, length + 1);
+        if (output_pointer == NULL)
+        {
+            return false;
+        }
+        if (current_item->next)
+        {
+            *output_pointer++ = ',';
+        }
 
-		if (output_buffer->format) {
-			*output_pointer++ = '\n';
-		}
-		*output_pointer = '\0';
-		output_buffer->offset += length;
+        if (output_buffer->format)
+        {
+            *output_pointer++ = '\n';
+        }
+        *output_pointer = '\0';
+        output_buffer->offset += length;
 
-		current_item = current_item->next;
-	}
+        current_item = current_item->next;
+    }
 
-	output_pointer =
-		ensure(output_buffer, output_buffer->format ? (output_buffer->depth + 1) : 2);
-	if (output_pointer == NULL) {
-		return false;
-	}
-	if (output_buffer->format) {
-		size_t i;
-		for (i = 0; i < (output_buffer->depth - 1); i++) {
-			*output_pointer++ = '\t';
-		}
-	}
-	*output_pointer++ = '}';
-	*output_pointer = '\0';
-	output_buffer->depth--;
+    output_pointer = ensure(output_buffer, output_buffer->format ? (output_buffer->depth + 1) : 2);
+    if (output_pointer == NULL)
+    {
+        return false;
+    }
+    if (output_buffer->format)
+    {
+        size_t i;
+        for (i = 0; i < (output_buffer->depth - 1); i++)
+        {
+            *output_pointer++ = '\t';
+        }
+    }
+    *output_pointer++ = '}';
+    *output_pointer = '\0';
+    output_buffer->depth--;
 
-	return true;
+    return true;
 }
 
 /* Get Array size/item / object item. */
 CJSON_PUBLIC(int) cJSON_GetArraySize(const cJSON *array)
 {
-	cJSON *c = array->child;
-	size_t i = 0;
-	while (c) {
-		i++;
-		c = c->next;
-	}
+    cJSON *child = NULL;
+    size_t size = 0;
 
-	/* FIXME: Can overflow here. Cannot be fixed without breaking the API */
+    if (array == NULL)
+    {
+        return 0;
+    }
 
-	return (int)i;
+    child = array->child;
+
+    while(child != NULL)
+    {
+        size++;
+        child = child->next;
+    }
+
+    /* FIXME: Can overflow here. Cannot be fixed without breaking the API */
+
+    return (int)size;
 }
 
-static cJSON *
-get_array_item(const cJSON *array, size_t index)
+static cJSON* get_array_item(const cJSON *array, size_t index)
 {
-	cJSON *current_child = NULL;
+    cJSON *current_child = NULL;
 
-	if (array == NULL) {
-		return NULL;
-	}
+    if (array == NULL)
+    {
+        return NULL;
+    }
 
-	current_child = array->child;
-	while ((current_child != NULL) && (index > 0)) {
-		index--;
-		current_child = current_child->next;
-	}
+    current_child = array->child;
+    while ((current_child != NULL) && (index > 0))
+    {
+        index--;
+        current_child = current_child->next;
+    }
 
-	return current_child;
+    return current_child;
 }
 
 CJSON_PUBLIC(cJSON *) cJSON_GetArrayItem(const cJSON *array, int index)
 {
-	if (index < 0) {
-		return NULL;
-	}
+    if (index < 0)
+    {
+        return NULL;
+    }
 
-	return get_array_item(array, (size_t)index);
+    return get_array_item(array, (size_t)index);
 }
 
-static cJSON *
-get_object_item(const cJSON *const object, const char *const name, const cJSON_bool case_sensitive)
+static cJSON *get_object_item(const cJSON * const object, const char * const name, const cJSON_bool case_sensitive)
 {
-	cJSON *current_element = NULL;
+    cJSON *current_element = NULL;
 
-	if ((object == NULL) || (name == NULL)) {
-		return NULL;
-	}
+    if ((object == NULL) || (name == NULL))
+    {
+        return NULL;
+    }
 
-	current_element = object->child;
-	if (case_sensitive) {
-		while ((current_element != NULL) && (strcmp(name, current_element->string) != 0)) {
-			current_element = current_element->next;
-		}
-	} else {
-		while ((current_element != NULL) &&
-		       (case_insensitive_strcmp((const unsigned char *)name,
-						(const unsigned char *)(current_element->string)) !=
-			0)) {
-			current_element = current_element->next;
-		}
-	}
+    current_element = object->child;
+    if (case_sensitive)
+    {
+        while ((current_element != NULL) && (current_element->string != NULL) && (strcmp(name, current_element->string) != 0))
+        {
+            current_element = current_element->next;
+        }
+    }
+    else
+    {
+        while ((current_element != NULL) && (case_insensitive_strcmp((const unsigned char*)name, (const unsigned char*)(current_element->string)) != 0))
+        {
+            current_element = current_element->next;
+        }
+    }
 
-	return current_element;
+    if ((current_element == NULL) || (current_element->string == NULL)) {
+        return NULL;
+    }
+
+    return current_element;
 }
 
-CJSON_PUBLIC(cJSON *) cJSON_GetObjectItem(const cJSON *const object, const char *const string)
+CJSON_PUBLIC(cJSON *) cJSON_GetObjectItem(const cJSON * const object, const char * const string)
 {
-	return get_object_item(object, string, false);
+    return get_object_item(object, string, false);
 }
 
-CJSON_PUBLIC(cJSON *)
-cJSON_GetObjectItemCaseSensitive(const cJSON *const object, const char *const string)
+CJSON_PUBLIC(cJSON *) cJSON_GetObjectItemCaseSensitive(const cJSON * const object, const char * const string)
 {
-	return get_object_item(object, string, true);
+    return get_object_item(object, string, true);
 }
 
 CJSON_PUBLIC(cJSON_bool) cJSON_HasObjectItem(const cJSON *object, const char *string)
 {
-	return cJSON_GetObjectItem(object, string) ? 1 : 0;
+    return cJSON_GetObjectItem(object, string) ? 1 : 0;
 }
 
 /* Utility for array list handling. */
-static void
-suffix_object(cJSON *prev, cJSON *item)
+static void suffix_object(cJSON *prev, cJSON *item)
 {
-	prev->next = item;
-	item->prev = prev;
+    prev->next = item;
+    item->prev = prev;
 }
 
 /* Utility for handling references. */
-static cJSON *
-create_reference(const cJSON *item, const internal_hooks *const hooks)
+static cJSON *create_reference(const cJSON *item, const internal_hooks * const hooks)
 {
-	cJSON *ref = cJSON_New_Item(hooks);
-	if (!ref) {
-		return NULL;
-	}
-	memcpy(ref, item, sizeof(cJSON));
-	ref->string = NULL;
-	ref->type |= cJSON_IsReference;
-	ref->next = ref->prev = NULL;
-	return ref;
+    cJSON *reference = NULL;
+    if (item == NULL)
+    {
+        return NULL;
+    }
+
+    reference = cJSON_New_Item(hooks);
+    if (reference == NULL)
+    {
+        return NULL;
+    }
+
+    memcpy(reference, item, sizeof(cJSON));
+    reference->string = NULL;
+    reference->type |= cJSON_IsReference;
+    reference->next = reference->prev = NULL;
+    return reference;
+}
+
+static cJSON_bool add_item_to_array(cJSON *array, cJSON *item)
+{
+    cJSON *child = NULL;
+
+    if ((item == NULL) || (array == NULL))
+    {
+        return false;
+    }
+
+    child = array->child;
+    /*
+     * To find the last item int array quickly, we use prev in array
+     */
+    if (child == NULL)
+    {
+        /* list is empty, start new one */
+        array->child = item;
+        item->prev = item;
+        item->next = NULL;
+    }
+    else
+    {
+        /* append to the end */
+        if (child->prev)
+        {
+            suffix_object(child->prev, item);
+            array->child->prev = item;
+        }
+        else
+        {
+            while (child->next)
+            {
+                child = child->next;
+            }
+            suffix_object(child, item);
+            array->child->prev = item;
+        }
+    }
+    return true;
 }
 
 /* Add item to array/object. */
 CJSON_PUBLIC(void) cJSON_AddItemToArray(cJSON *array, cJSON *item)
 {
-	cJSON *child = NULL;
-
-	if ((item == NULL) || (array == NULL)) {
-		return;
-	}
-
-	child = array->child;
-
-	if (child == NULL) {
-		/* list is empty, start new one */
-		array->child = item;
-	} else {
-		/* append to the end */
-		while (child->next) {
-			child = child->next;
-		}
-		suffix_object(child, item);
-	}
+    add_item_to_array(array, item);
 }
 
-CJSON_PUBLIC(void) cJSON_AddItemToObject(cJSON *object, const char *string, cJSON *item)
-{
-	/* call cJSON_AddItemToObjectCS for code reuse */
-	cJSON_AddItemToObjectCS(
-		object, (char *)cJSON_strdup((const unsigned char *)string, &global_hooks), item);
-	/* remove cJSON_StringIsConst flag */
-	item->type &= ~cJSON_StringIsConst;
-}
-
-#if defined(__clang__) ||                                                                          \
-	((__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 5))))
-#pragma GCC diagnostic push
+#if defined(__clang__) || (defined(__GNUC__)  && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 5))))
+    #pragma GCC diagnostic push
 #endif
 #ifdef __GNUC__
 #pragma GCC diagnostic ignored "-Wcast-qual"
 #endif
+/* helper function to cast away const */
+static void* cast_away_const(const void* string)
+{
+    return (void*)string;
+}
+#if defined(__clang__) || (defined(__GNUC__)  && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 5))))
+    #pragma GCC diagnostic pop
+#endif
+
+
+static cJSON_bool add_item_to_object(cJSON * const object, const char * const string, cJSON * const item, const internal_hooks * const hooks, const cJSON_bool constant_key)
+{
+    char *new_key = NULL;
+    int new_type = cJSON_Invalid;
+
+    if ((object == NULL) || (string == NULL) || (item == NULL))
+    {
+        return false;
+    }
+
+    if (constant_key)
+    {
+        new_key = (char*)cast_away_const(string);
+        new_type = item->type | cJSON_StringIsConst;
+    }
+    else
+    {
+        new_key = (char*)cJSON_strdup((const unsigned char*)string, hooks);
+        if (new_key == NULL)
+        {
+            return false;
+        }
+
+        new_type = item->type & ~cJSON_StringIsConst;
+    }
+
+    if (!(item->type & cJSON_StringIsConst) && (item->string != NULL))
+    {
+        hooks->deallocate(item->string);
+    }
+
+    item->string = new_key;
+    item->type = new_type;
+
+    return add_item_to_array(object, item);
+}
+
+CJSON_PUBLIC(void) cJSON_AddItemToObject(cJSON *object, const char *string, cJSON *item)
+{
+    add_item_to_object(object, string, item, &global_hooks, false);
+}
 
 /* Add an item to an object with constant string as key */
 CJSON_PUBLIC(void) cJSON_AddItemToObjectCS(cJSON *object, const char *string, cJSON *item)
 {
-	if (!item) {
-		return;
-	}
-	if (!(item->type & cJSON_StringIsConst) && item->string) {
-		global_hooks.deallocate(item->string);
-	}
-	item->string = (char *)string;
-	item->type |= cJSON_StringIsConst;
-	cJSON_AddItemToArray(object, item);
+    add_item_to_object(object, string, item, &global_hooks, true);
 }
-#if defined(__clang__) ||                                                                          \
-	((__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 5))))
-#pragma GCC diagnostic pop
-#endif
 
 CJSON_PUBLIC(void) cJSON_AddItemReferenceToArray(cJSON *array, cJSON *item)
 {
-	cJSON_AddItemToArray(array, create_reference(item, &global_hooks));
+    if (array == NULL)
+    {
+        return;
+    }
+
+    add_item_to_array(array, create_reference(item, &global_hooks));
 }
 
 CJSON_PUBLIC(void) cJSON_AddItemReferenceToObject(cJSON *object, const char *string, cJSON *item)
 {
-	cJSON_AddItemToObject(object, string, create_reference(item, &global_hooks));
+    if ((object == NULL) || (string == NULL))
+    {
+        return;
+    }
+
+    add_item_to_object(object, string, create_reference(item, &global_hooks), &global_hooks, false);
 }
 
-CJSON_PUBLIC(cJSON *) cJSON_DetachItemViaPointer(cJSON *parent, cJSON *const item)
+CJSON_PUBLIC(cJSON*) cJSON_AddNullToObject(cJSON * const object, const char * const name)
 {
-	if ((parent == NULL) || (item == NULL)) {
-		return NULL;
-	}
+    cJSON *null = cJSON_CreateNull();
+    if (add_item_to_object(object, name, null, &global_hooks, false))
+    {
+        return null;
+    }
 
-	if (item->prev != NULL) {
-		/* not the first element */
-		item->prev->next = item->next;
-	}
-	if (item->next != NULL) {
-		/* not the last element */
-		item->next->prev = item->prev;
-	}
+    cJSON_Delete(null);
+    return NULL;
+}
 
-	if (item == parent->child) {
-		/* first element */
-		parent->child = item->next;
-	}
-	/* make sure the detached item doesn't point anywhere anymore */
-	item->prev = NULL;
-	item->next = NULL;
+CJSON_PUBLIC(cJSON*) cJSON_AddTrueToObject(cJSON * const object, const char * const name)
+{
+    cJSON *true_item = cJSON_CreateTrue();
+    if (add_item_to_object(object, name, true_item, &global_hooks, false))
+    {
+        return true_item;
+    }
 
-	return item;
+    cJSON_Delete(true_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddFalseToObject(cJSON * const object, const char * const name)
+{
+    cJSON *false_item = cJSON_CreateFalse();
+    if (add_item_to_object(object, name, false_item, &global_hooks, false))
+    {
+        return false_item;
+    }
+
+    cJSON_Delete(false_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddBoolToObject(cJSON * const object, const char * const name, const cJSON_bool boolean)
+{
+    cJSON *bool_item = cJSON_CreateBool(boolean);
+    if (add_item_to_object(object, name, bool_item, &global_hooks, false))
+    {
+        return bool_item;
+    }
+
+    cJSON_Delete(bool_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddNumberToObject(cJSON * const object, const char * const name, const double number)
+{
+    cJSON *number_item = cJSON_CreateNumber(number);
+    if (add_item_to_object(object, name, number_item, &global_hooks, false))
+    {
+        return number_item;
+    }
+
+    cJSON_Delete(number_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddStringToObject(cJSON * const object, const char * const name, const char * const string)
+{
+    cJSON *string_item = cJSON_CreateString(string);
+    if (add_item_to_object(object, name, string_item, &global_hooks, false))
+    {
+        return string_item;
+    }
+
+    cJSON_Delete(string_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddRawToObject(cJSON * const object, const char * const name, const char * const raw)
+{
+    cJSON *raw_item = cJSON_CreateRaw(raw);
+    if (add_item_to_object(object, name, raw_item, &global_hooks, false))
+    {
+        return raw_item;
+    }
+
+    cJSON_Delete(raw_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddObjectToObject(cJSON * const object, const char * const name)
+{
+    cJSON *object_item = cJSON_CreateObject();
+    if (add_item_to_object(object, name, object_item, &global_hooks, false))
+    {
+        return object_item;
+    }
+
+    cJSON_Delete(object_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddArrayToObject(cJSON * const object, const char * const name)
+{
+    cJSON *array = cJSON_CreateArray();
+    if (add_item_to_object(object, name, array, &global_hooks, false))
+    {
+        return array;
+    }
+
+    cJSON_Delete(array);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemViaPointer(cJSON *parent, cJSON * const item)
+{
+    if ((parent == NULL) || (item == NULL))
+    {
+        return NULL;
+    }
+
+    if (item->prev != NULL)
+    {
+        /* not the first element */
+        item->prev->next = item->next;
+    }
+    if (item->next != NULL)
+    {
+        /* not the last element */
+        item->next->prev = item->prev;
+    }
+
+    if (item == parent->child)
+    {
+        /* first element */
+        parent->child = item->next;
+    }
+    /* make sure the detached item doesn't point anywhere anymore */
+    item->prev = NULL;
+    item->next = NULL;
+
+    return item;
 }
 
 CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromArray(cJSON *array, int which)
 {
-	if (which < 0) {
-		return NULL;
-	}
+    if (which < 0)
+    {
+        return NULL;
+    }
 
-	return cJSON_DetachItemViaPointer(array, get_array_item(array, (size_t)which));
+    return cJSON_DetachItemViaPointer(array, get_array_item(array, (size_t)which));
 }
 
 CJSON_PUBLIC(void) cJSON_DeleteItemFromArray(cJSON *array, int which)
 {
-	cJSON_Delete(cJSON_DetachItemFromArray(array, which));
+    cJSON_Delete(cJSON_DetachItemFromArray(array, which));
 }
 
 CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromObject(cJSON *object, const char *string)
 {
-	cJSON *to_detach = cJSON_GetObjectItem(object, string);
+    cJSON *to_detach = cJSON_GetObjectItem(object, string);
 
-	return cJSON_DetachItemViaPointer(object, to_detach);
+    return cJSON_DetachItemViaPointer(object, to_detach);
 }
 
 CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromObjectCaseSensitive(cJSON *object, const char *string)
 {
-	cJSON *to_detach = cJSON_GetObjectItemCaseSensitive(object, string);
+    cJSON *to_detach = cJSON_GetObjectItemCaseSensitive(object, string);
 
-	return cJSON_DetachItemViaPointer(object, to_detach);
+    return cJSON_DetachItemViaPointer(object, to_detach);
 }
 
 CJSON_PUBLIC(void) cJSON_DeleteItemFromObject(cJSON *object, const char *string)
 {
-	cJSON_Delete(cJSON_DetachItemFromObject(object, string));
+    cJSON_Delete(cJSON_DetachItemFromObject(object, string));
 }
 
 CJSON_PUBLIC(void) cJSON_DeleteItemFromObjectCaseSensitive(cJSON *object, const char *string)
 {
-	cJSON_Delete(cJSON_DetachItemFromObjectCaseSensitive(object, string));
+    cJSON_Delete(cJSON_DetachItemFromObjectCaseSensitive(object, string));
 }
 
 /* Replace array/object items with new ones. */
 CJSON_PUBLIC(void) cJSON_InsertItemInArray(cJSON *array, int which, cJSON *newitem)
 {
-	cJSON *after_inserted = NULL;
+    cJSON *after_inserted = NULL;
 
-	if (which < 0) {
-		return;
-	}
+    if (which < 0)
+    {
+        return;
+    }
 
-	after_inserted = get_array_item(array, (size_t)which);
-	if (after_inserted == NULL) {
-		cJSON_AddItemToArray(array, newitem);
-		return;
-	}
+    after_inserted = get_array_item(array, (size_t)which);
+    if (after_inserted == NULL)
+    {
+        add_item_to_array(array, newitem);
+        return;
+    }
 
-	newitem->next = after_inserted;
-	newitem->prev = after_inserted->prev;
-	after_inserted->prev = newitem;
-	if (after_inserted == array->child) {
-		array->child = newitem;
-	} else {
-		newitem->prev->next = newitem;
-	}
+    newitem->next = after_inserted;
+    newitem->prev = after_inserted->prev;
+    after_inserted->prev = newitem;
+    if (after_inserted == array->child)
+    {
+        array->child = newitem;
+    }
+    else
+    {
+        newitem->prev->next = newitem;
+    }
 }
 
-CJSON_PUBLIC(cJSON_bool)
-cJSON_ReplaceItemViaPointer(cJSON *const parent, cJSON *const item, cJSON *replacement)
+CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemViaPointer(cJSON * const parent, cJSON * const item, cJSON * replacement)
 {
-	if ((parent == NULL) || (replacement == NULL)) {
-		return false;
-	}
+    if ((parent == NULL) || (replacement == NULL) || (item == NULL))
+    {
+        return false;
+    }
 
-	if (replacement == item) {
-		return true;
-	}
+    if (replacement == item)
+    {
+        return true;
+    }
 
-	replacement->next = item->next;
-	replacement->prev = item->prev;
+    replacement->next = item->next;
+    replacement->prev = item->prev;
 
-	if (replacement->next != NULL) {
-		replacement->next->prev = replacement;
-	}
-	if (replacement->prev != NULL) {
-		replacement->prev->next = replacement;
-	}
-	if (parent->child == item) {
-		parent->child = replacement;
-	}
+    if (replacement->next != NULL)
+    {
+        replacement->next->prev = replacement;
+    }
 
-	item->next = NULL;
-	item->prev = NULL;
-	cJSON_Delete(item);
+    if (parent->child == item)
+    {
+        parent->child = replacement;
+    }
+    else
+    {   /*
+         * To find the last item int array quickly, we use prev in array.
+         * We can't modify the last item's next pointer where this item was the parent's child
+         */
+        if (replacement->prev != NULL)
+        {
+            replacement->prev->next = replacement;
+        }
+    }
 
-	return true;
+    item->next = NULL;
+    item->prev = NULL;
+    cJSON_Delete(item);
+
+    return true;
 }
 
 CJSON_PUBLIC(void) cJSON_ReplaceItemInArray(cJSON *array, int which, cJSON *newitem)
 {
-	if (which < 0) {
-		return;
-	}
+    if (which < 0)
+    {
+        return;
+    }
 
-	cJSON_ReplaceItemViaPointer(array, get_array_item(array, (size_t)which), newitem);
+    cJSON_ReplaceItemViaPointer(array, get_array_item(array, (size_t)which), newitem);
+}
+
+static cJSON_bool replace_item_in_object(cJSON *object, const char *string, cJSON *replacement, cJSON_bool case_sensitive)
+{
+    if ((replacement == NULL) || (string == NULL))
+    {
+        return false;
+    }
+
+    /* replace the name in the replacement */
+    if (!(replacement->type & cJSON_StringIsConst) && (replacement->string != NULL))
+    {
+        cJSON_free(replacement->string);
+    }
+    replacement->string = (char*)cJSON_strdup((const unsigned char*)string, &global_hooks);
+    replacement->type &= ~cJSON_StringIsConst;
+
+    cJSON_ReplaceItemViaPointer(object, get_object_item(object, string, case_sensitive), replacement);
+
+    return true;
 }
 
 CJSON_PUBLIC(void) cJSON_ReplaceItemInObject(cJSON *object, const char *string, cJSON *newitem)
 {
-	cJSON_ReplaceItemViaPointer(object, cJSON_GetObjectItem(object, string), newitem);
+    replace_item_in_object(object, string, newitem, false);
 }
 
-CJSON_PUBLIC(void)
-cJSON_ReplaceItemInObjectCaseSensitive(cJSON *object, const char *string, cJSON *newitem)
+CJSON_PUBLIC(void) cJSON_ReplaceItemInObjectCaseSensitive(cJSON *object, const char *string, cJSON *newitem)
 {
-	cJSON_ReplaceItemViaPointer(object, cJSON_GetObjectItemCaseSensitive(object, string),
-				    newitem);
+    replace_item_in_object(object, string, newitem, true);
 }
 
 /* Create basic types: */
 CJSON_PUBLIC(cJSON *) cJSON_CreateNull(void)
 {
-	cJSON *item = cJSON_New_Item(&global_hooks);
-	if (item) {
-		item->type = cJSON_NULL;
-	}
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type = cJSON_NULL;
+    }
 
-	return item;
+    return item;
 }
 
 CJSON_PUBLIC(cJSON *) cJSON_CreateTrue(void)
 {
-	cJSON *item = cJSON_New_Item(&global_hooks);
-	if (item) {
-		item->type = cJSON_True;
-	}
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type = cJSON_True;
+    }
 
-	return item;
+    return item;
 }
 
 CJSON_PUBLIC(cJSON *) cJSON_CreateFalse(void)
 {
-	cJSON *item = cJSON_New_Item(&global_hooks);
-	if (item) {
-		item->type = cJSON_False;
-	}
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type = cJSON_False;
+    }
 
-	return item;
+    return item;
 }
 
-CJSON_PUBLIC(cJSON *) cJSON_CreateBool(cJSON_bool b)
+CJSON_PUBLIC(cJSON *) cJSON_CreateBool(cJSON_bool boolean)
 {
-	cJSON *item = cJSON_New_Item(&global_hooks);
-	if (item) {
-		item->type = b ? cJSON_True : cJSON_False;
-	}
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type = boolean ? cJSON_True : cJSON_False;
+    }
 
-	return item;
+    return item;
 }
 
 CJSON_PUBLIC(cJSON *) cJSON_CreateNumber(double num)
 {
-	cJSON *item = cJSON_New_Item(&global_hooks);
-	if (item) {
-		item->type = cJSON_Number;
-		item->valuedouble = num;
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type = cJSON_Number;
+        item->valuedouble = num;
 
-		/* use saturation in case of overflow */
-		if (num >= INT_MAX) {
-			item->valueint = INT_MAX;
-		} else if (num <= INT_MIN) {
-			item->valueint = INT_MIN;
-		} else {
-			item->valueint = (int)num;
-		}
-	}
+        /* use saturation in case of overflow */
+        if (num >= INT_MAX)
+        {
+            item->valueint = INT_MAX;
+        }
+        else if (num <= (double)INT_MIN)
+        {
+            item->valueint = INT_MIN;
+        }
+        else
+        {
+            item->valueint = (int)num;
+        }
+    }
 
-	return item;
+    return item;
 }
 
 CJSON_PUBLIC(cJSON *) cJSON_CreateString(const char *string)
 {
-	cJSON *item = cJSON_New_Item(&global_hooks);
-	if (item) {
-		item->type = cJSON_String;
-		item->valuestring =
-			(char *)cJSON_strdup((const unsigned char *)string, &global_hooks);
-		if (!item->valuestring) {
-			cJSON_Delete(item);
-			return NULL;
-		}
-	}
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type = cJSON_String;
+        item->valuestring = (char*)cJSON_strdup((const unsigned char*)string, &global_hooks);
+        if(!item->valuestring)
+        {
+            cJSON_Delete(item);
+            return NULL;
+        }
+    }
 
-	return item;
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateStringReference(const char *string)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if (item != NULL)
+    {
+        item->type = cJSON_String | cJSON_IsReference;
+        item->valuestring = (char*)cast_away_const(string);
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateObjectReference(const cJSON *child)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if (item != NULL) {
+        item->type = cJSON_Object | cJSON_IsReference;
+        item->child = (cJSON*)cast_away_const(child);
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateArrayReference(const cJSON *child) {
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if (item != NULL) {
+        item->type = cJSON_Array | cJSON_IsReference;
+        item->child = (cJSON*)cast_away_const(child);
+    }
+
+    return item;
 }
 
 CJSON_PUBLIC(cJSON *) cJSON_CreateRaw(const char *raw)
 {
-	cJSON *item = cJSON_New_Item(&global_hooks);
-	if (item) {
-		item->type = cJSON_Raw;
-		item->valuestring = (char *)cJSON_strdup((const unsigned char *)raw, &global_hooks);
-		if (!item->valuestring) {
-			cJSON_Delete(item);
-			return NULL;
-		}
-	}
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type = cJSON_Raw;
+        item->valuestring = (char*)cJSON_strdup((const unsigned char*)raw, &global_hooks);
+        if(!item->valuestring)
+        {
+            cJSON_Delete(item);
+            return NULL;
+        }
+    }
 
-	return item;
+    return item;
 }
 
 CJSON_PUBLIC(cJSON *) cJSON_CreateArray(void)
 {
-	cJSON *item = cJSON_New_Item(&global_hooks);
-	if (item) {
-		item->type = cJSON_Array;
-	}
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type=cJSON_Array;
+    }
 
-	return item;
+    return item;
 }
 
 CJSON_PUBLIC(cJSON *) cJSON_CreateObject(void)
 {
-	cJSON *item = cJSON_New_Item(&global_hooks);
-	if (item) {
-		item->type = cJSON_Object;
-	}
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if (item)
+    {
+        item->type = cJSON_Object;
+    }
 
-	return item;
+    return item;
 }
 
 /* Create Arrays: */
 CJSON_PUBLIC(cJSON *) cJSON_CreateIntArray(const int *numbers, int count)
 {
-	size_t i = 0;
-	cJSON *n = NULL;
-	cJSON *p = NULL;
-	cJSON *a = NULL;
+    size_t i = 0;
+    cJSON *n = NULL;
+    cJSON *p = NULL;
+    cJSON *a = NULL;
 
-	if (count < 0) {
-		return NULL;
-	}
+    if ((count < 0) || (numbers == NULL))
+    {
+        return NULL;
+    }
 
-	a = cJSON_CreateArray();
-	for (i = 0; a && (i < (size_t)count); i++) {
-		n = cJSON_CreateNumber(numbers[i]);
-		if (!n) {
-			cJSON_Delete(a);
-			return NULL;
-		}
-		if (!i) {
-			a->child = n;
-		} else {
-			suffix_object(p, n);
-		}
-		p = n;
-	}
+    a = cJSON_CreateArray();
+    for(i = 0; a && (i < (size_t)count); i++)
+    {
+        n = cJSON_CreateNumber(numbers[i]);
+        if (!n)
+        {
+            cJSON_Delete(a);
+            return NULL;
+        }
+        if(!i)
+        {
+            a->child = n;
+        }
+        else
+        {
+            suffix_object(p, n);
+        }
+        p = n;
+    }
 
-	return a;
+    return a;
 }
 
 CJSON_PUBLIC(cJSON *) cJSON_CreateFloatArray(const float *numbers, int count)
 {
-	size_t i = 0;
-	cJSON *n = NULL;
-	cJSON *p = NULL;
-	cJSON *a = NULL;
+    size_t i = 0;
+    cJSON *n = NULL;
+    cJSON *p = NULL;
+    cJSON *a = NULL;
 
-	if (count < 0) {
-		return NULL;
-	}
+    if ((count < 0) || (numbers == NULL))
+    {
+        return NULL;
+    }
 
-	a = cJSON_CreateArray();
+    a = cJSON_CreateArray();
 
-	for (i = 0; a && (i < (size_t)count); i++) {
-		n = cJSON_CreateNumber((double)numbers[i]);
-		if (!n) {
-			cJSON_Delete(a);
-			return NULL;
-		}
-		if (!i) {
-			a->child = n;
-		} else {
-			suffix_object(p, n);
-		}
-		p = n;
-	}
+    for(i = 0; a && (i < (size_t)count); i++)
+    {
+        n = cJSON_CreateNumber((double)numbers[i]);
+        if(!n)
+        {
+            cJSON_Delete(a);
+            return NULL;
+        }
+        if(!i)
+        {
+            a->child = n;
+        }
+        else
+        {
+            suffix_object(p, n);
+        }
+        p = n;
+    }
 
-	return a;
+    return a;
 }
 
 CJSON_PUBLIC(cJSON *) cJSON_CreateDoubleArray(const double *numbers, int count)
 {
-	size_t i = 0;
-	cJSON *n = NULL;
-	cJSON *p = NULL;
-	cJSON *a = NULL;
+    size_t i = 0;
+    cJSON *n = NULL;
+    cJSON *p = NULL;
+    cJSON *a = NULL;
 
-	if (count < 0) {
-		return NULL;
-	}
+    if ((count < 0) || (numbers == NULL))
+    {
+        return NULL;
+    }
 
-	a = cJSON_CreateArray();
+    a = cJSON_CreateArray();
 
-	for (i = 0; a && (i < (size_t)count); i++) {
-		n = cJSON_CreateNumber(numbers[i]);
-		if (!n) {
-			cJSON_Delete(a);
-			return NULL;
-		}
-		if (!i) {
-			a->child = n;
-		} else {
-			suffix_object(p, n);
-		}
-		p = n;
-	}
+    for(i = 0;a && (i < (size_t)count); i++)
+    {
+        n = cJSON_CreateNumber(numbers[i]);
+        if(!n)
+        {
+            cJSON_Delete(a);
+            return NULL;
+        }
+        if(!i)
+        {
+            a->child = n;
+        }
+        else
+        {
+            suffix_object(p, n);
+        }
+        p = n;
+    }
 
-	return a;
+    return a;
 }
 
-CJSON_PUBLIC(cJSON *) cJSON_CreateStringArray(const char **strings, int count)
+CJSON_PUBLIC(cJSON *) cJSON_CreateStringArray(const char *const *strings, int count)
 {
-	size_t i = 0;
-	cJSON *n = NULL;
-	cJSON *p = NULL;
-	cJSON *a = NULL;
+    size_t i = 0;
+    cJSON *n = NULL;
+    cJSON *p = NULL;
+    cJSON *a = NULL;
 
-	if (count < 0) {
-		return NULL;
-	}
+    if ((count < 0) || (strings == NULL))
+    {
+        return NULL;
+    }
 
-	a = cJSON_CreateArray();
+    a = cJSON_CreateArray();
 
-	for (i = 0; a && (i < (size_t)count); i++) {
-		n = cJSON_CreateString(strings[i]);
-		if (!n) {
-			cJSON_Delete(a);
-			return NULL;
-		}
-		if (!i) {
-			a->child = n;
-		} else {
-			suffix_object(p, n);
-		}
-		p = n;
-	}
+    for (i = 0; a && (i < (size_t)count); i++)
+    {
+        n = cJSON_CreateString(strings[i]);
+        if(!n)
+        {
+            cJSON_Delete(a);
+            return NULL;
+        }
+        if(!i)
+        {
+            a->child = n;
+        }
+        else
+        {
+            suffix_object(p,n);
+        }
+        p = n;
+    }
 
-	return a;
+    return a;
 }
 
 /* Duplication */
 CJSON_PUBLIC(cJSON *) cJSON_Duplicate(const cJSON *item, cJSON_bool recurse)
 {
-	cJSON *newitem = NULL;
-	cJSON *child = NULL;
-	cJSON *next = NULL;
-	cJSON *newchild = NULL;
+    cJSON *newitem = NULL;
+    cJSON *child = NULL;
+    cJSON *next = NULL;
+    cJSON *newchild = NULL;
 
-	/* Bail on bad ptr */
-	if (!item) {
-		goto fail;
-	}
-	/* Create new item */
-	newitem = cJSON_New_Item(&global_hooks);
-	if (!newitem) {
-		goto fail;
-	}
-	/* Copy over all vars */
-	newitem->type = item->type & (~cJSON_IsReference);
-	newitem->valueint = item->valueint;
-	newitem->valuedouble = item->valuedouble;
-	if (item->valuestring) {
-		newitem->valuestring =
-			(char *)cJSON_strdup((unsigned char *)item->valuestring, &global_hooks);
-		if (!newitem->valuestring) {
-			goto fail;
-		}
-	}
-	if (item->string) {
-		newitem->string =
-			(item->type & cJSON_StringIsConst) ?
-				item->string :
-				(char *)cJSON_strdup((unsigned char *)item->string, &global_hooks);
-		if (!newitem->string) {
-			goto fail;
-		}
-	}
-	/* If non-recursive, then we're done! */
-	if (!recurse) {
-		return newitem;
-	}
-	/* Walk the ->next chain for the child. */
-	child = item->child;
-	while (child != NULL) {
-		newchild = cJSON_Duplicate(
-			child, true); /* Duplicate (with recurse) each item in the ->next chain */
-		if (!newchild) {
-			goto fail;
-		}
-		if (next != NULL) {
-			/* If newitem->child already set, then crosswire ->prev and ->next and move on */
-			next->next = newchild;
-			newchild->prev = next;
-			next = newchild;
-		} else {
-			/* Set newitem->child and move to it */
-			newitem->child = newchild;
-			next = newchild;
-		}
-		child = child->next;
-	}
+    /* Bail on bad ptr */
+    if (!item)
+    {
+        goto fail;
+    }
+    /* Create new item */
+    newitem = cJSON_New_Item(&global_hooks);
+    if (!newitem)
+    {
+        goto fail;
+    }
+    /* Copy over all vars */
+    newitem->type = item->type & (~cJSON_IsReference);
+    newitem->valueint = item->valueint;
+    newitem->valuedouble = item->valuedouble;
+    if (item->valuestring)
+    {
+        newitem->valuestring = (char*)cJSON_strdup((unsigned char*)item->valuestring, &global_hooks);
+        if (!newitem->valuestring)
+        {
+            goto fail;
+        }
+    }
+    if (item->string)
+    {
+        newitem->string = (item->type&cJSON_StringIsConst) ? item->string : (char*)cJSON_strdup((unsigned char*)item->string, &global_hooks);
+        if (!newitem->string)
+        {
+            goto fail;
+        }
+    }
+    /* If non-recursive, then we're done! */
+    if (!recurse)
+    {
+        return newitem;
+    }
+    /* Walk the ->next chain for the child. */
+    child = item->child;
+    while (child != NULL)
+    {
+        newchild = cJSON_Duplicate(child, true); /* Duplicate (with recurse) each item in the ->next chain */
+        if (!newchild)
+        {
+            goto fail;
+        }
+        if (next != NULL)
+        {
+            /* If newitem->child already set, then crosswire ->prev and ->next and move on */
+            next->next = newchild;
+            newchild->prev = next;
+            next = newchild;
+        }
+        else
+        {
+            /* Set newitem->child and move to it */
+            newitem->child = newchild;
+            next = newchild;
+        }
+        child = child->next;
+    }
 
-	return newitem;
+    return newitem;
 
 fail:
-	if (newitem != NULL) {
-		cJSON_Delete(newitem);
-	}
+    if (newitem != NULL)
+    {
+        cJSON_Delete(newitem);
+    }
 
-	return NULL;
+    return NULL;
+}
+
+static void skip_oneline_comment(char **input)
+{
+    *input += static_strlen("//");
+
+    for (; (*input)[0] != '\0'; ++(*input))
+    {
+        if ((*input)[0] == '\n') {
+            *input += static_strlen("\n");
+            return;
+        }
+    }
+}
+
+static void skip_multiline_comment(char **input)
+{
+    *input += static_strlen("/*");
+
+    for (; (*input)[0] != '\0'; ++(*input))
+    {
+        if (((*input)[0] == '*') && ((*input)[1] == '/'))
+        {
+            *input += static_strlen("*/");
+            return;
+        }
+    }
+}
+
+static void minify_string(char **input, char **output) {
+    (*output)[0] = (*input)[0];
+    *input += static_strlen("\"");
+    *output += static_strlen("\"");
+
+
+    for (; (*input)[0] != '\0'; (void)++(*input), ++(*output)) {
+        (*output)[0] = (*input)[0];
+
+        if ((*input)[0] == '\"') {
+            (*output)[0] = '\"';
+            *input += static_strlen("\"");
+            *output += static_strlen("\"");
+            return;
+        } else if (((*input)[0] == '\\') && ((*input)[1] == '\"')) {
+            (*output)[1] = (*input)[1];
+            *input += static_strlen("\"");
+            *output += static_strlen("\"");
+        }
+    }
 }
 
 CJSON_PUBLIC(void) cJSON_Minify(char *json)
 {
-	unsigned char *into = (unsigned char *)json;
-	while (*json) {
-		if (*json == ' ') {
-			json++;
-		} else if (*json == '\t') {
-			/* Whitespace characters. */
-			json++;
-		} else if (*json == '\r') {
-			json++;
-		} else if (*json == '\n') {
-			json++;
-		} else if ((*json == '/') && (json[1] == '/')) {
-			/* double-slash comments, to end of line. */
-			while (*json && (*json != '\n')) {
-				json++;
-			}
-		} else if ((*json == '/') && (json[1] == '*')) {
-			/* multiline comments. */
-			while (*json && !((*json == '*') && (json[1] == '/'))) {
-				json++;
-			}
-			json += 2;
-		} else if (*json == '\"') {
-			/* string literals, which are \" sensitive. */
-			*into++ = (unsigned char)*json++;
-			while (*json && (*json != '\"')) {
-				if (*json == '\\') {
-					*into++ = (unsigned char)*json++;
-				}
-				*into++ = (unsigned char)*json++;
-			}
-			*into++ = (unsigned char)*json++;
-		} else {
-			/* All other characters. */
-			*into++ = (unsigned char)*json++;
-		}
-	}
+    char *into = json;
 
-	/* and null-terminate. */
-	*into = '\0';
+    if (json == NULL)
+    {
+        return;
+    }
+
+    while (json[0] != '\0')
+    {
+        switch (json[0])
+        {
+            case ' ':
+            case '\t':
+            case '\r':
+            case '\n':
+                json++;
+                break;
+
+            case '/':
+                if (json[1] == '/')
+                {
+                    skip_oneline_comment(&json);
+                }
+                else if (json[1] == '*')
+                {
+                    skip_multiline_comment(&json);
+                } else {
+                    json++;
+                }
+                break;
+
+            case '\"':
+                minify_string(&json, (char**)&into);
+                break;
+
+            default:
+                into[0] = json[0];
+                json++;
+                into++;
+        }
+    }
+
+    /* and null-terminate. */
+    *into = '\0';
 }
 
-CJSON_PUBLIC(cJSON_bool) cJSON_IsInvalid(const cJSON *const item)
+CJSON_PUBLIC(cJSON_bool) cJSON_IsInvalid(const cJSON * const item)
 {
-	if (item == NULL) {
-		return false;
-	}
+    if (item == NULL)
+    {
+        return false;
+    }
 
-	return (item->type & 0xFF) == cJSON_Invalid;
+    return (item->type & 0xFF) == cJSON_Invalid;
 }
 
-CJSON_PUBLIC(cJSON_bool) cJSON_IsFalse(const cJSON *const item)
+CJSON_PUBLIC(cJSON_bool) cJSON_IsFalse(const cJSON * const item)
 {
-	if (item == NULL) {
-		return false;
-	}
+    if (item == NULL)
+    {
+        return false;
+    }
 
-	return (item->type & 0xFF) == cJSON_False;
+    return (item->type & 0xFF) == cJSON_False;
 }
 
-CJSON_PUBLIC(cJSON_bool) cJSON_IsTrue(const cJSON *const item)
+CJSON_PUBLIC(cJSON_bool) cJSON_IsTrue(const cJSON * const item)
 {
-	if (item == NULL) {
-		return false;
-	}
+    if (item == NULL)
+    {
+        return false;
+    }
 
-	return (item->type & 0xff) == cJSON_True;
+    return (item->type & 0xff) == cJSON_True;
 }
 
-CJSON_PUBLIC(cJSON_bool) cJSON_IsBool(const cJSON *const item)
-{
-	if (item == NULL) {
-		return false;
-	}
 
-	return (item->type & (cJSON_True | cJSON_False)) != 0;
+CJSON_PUBLIC(cJSON_bool) cJSON_IsBool(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & (cJSON_True | cJSON_False)) != 0;
 }
-CJSON_PUBLIC(cJSON_bool) cJSON_IsNull(const cJSON *const item)
+CJSON_PUBLIC(cJSON_bool) cJSON_IsNull(const cJSON * const item)
 {
-	if (item == NULL) {
-		return false;
-	}
+    if (item == NULL)
+    {
+        return false;
+    }
 
-	return (item->type & 0xFF) == cJSON_NULL;
-}
-
-CJSON_PUBLIC(cJSON_bool) cJSON_IsNumber(const cJSON *const item)
-{
-	if (item == NULL) {
-		return false;
-	}
-
-	return (item->type & 0xFF) == cJSON_Number;
+    return (item->type & 0xFF) == cJSON_NULL;
 }
 
-CJSON_PUBLIC(cJSON_bool) cJSON_IsString(const cJSON *const item)
+CJSON_PUBLIC(cJSON_bool) cJSON_IsNumber(const cJSON * const item)
 {
-	if (item == NULL) {
-		return false;
-	}
+    if (item == NULL)
+    {
+        return false;
+    }
 
-	return (item->type & 0xFF) == cJSON_String;
+    return (item->type & 0xFF) == cJSON_Number;
 }
 
-CJSON_PUBLIC(cJSON_bool) cJSON_IsArray(const cJSON *const item)
+CJSON_PUBLIC(cJSON_bool) cJSON_IsString(const cJSON * const item)
 {
-	if (item == NULL) {
-		return false;
-	}
+    if (item == NULL)
+    {
+        return false;
+    }
 
-	return (item->type & 0xFF) == cJSON_Array;
+    return (item->type & 0xFF) == cJSON_String;
 }
 
-CJSON_PUBLIC(cJSON_bool) cJSON_IsObject(const cJSON *const item)
+CJSON_PUBLIC(cJSON_bool) cJSON_IsArray(const cJSON * const item)
 {
-	if (item == NULL) {
-		return false;
-	}
+    if (item == NULL)
+    {
+        return false;
+    }
 
-	return (item->type & 0xFF) == cJSON_Object;
+    return (item->type & 0xFF) == cJSON_Array;
 }
 
-CJSON_PUBLIC(cJSON_bool) cJSON_IsRaw(const cJSON *const item)
+CJSON_PUBLIC(cJSON_bool) cJSON_IsObject(const cJSON * const item)
 {
-	if (item == NULL) {
-		return false;
-	}
+    if (item == NULL)
+    {
+        return false;
+    }
 
-	return (item->type & 0xFF) == cJSON_Raw;
+    return (item->type & 0xFF) == cJSON_Object;
 }
 
-CJSON_PUBLIC(cJSON_bool)
-cJSON_Compare(const cJSON *const a, const cJSON *const b, const cJSON_bool case_sensitive)
+CJSON_PUBLIC(cJSON_bool) cJSON_IsRaw(const cJSON * const item)
 {
-	if ((a == NULL) || (b == NULL) || ((a->type & 0xFF) != (b->type & 0xFF)) ||
-	    cJSON_IsInvalid(a)) {
-		return false;
-	}
+    if (item == NULL)
+    {
+        return false;
+    }
 
-	/* check if type is valid */
-	switch (a->type & 0xFF) {
-	case cJSON_False:
-	case cJSON_True:
-	case cJSON_NULL:
-	case cJSON_Number:
-	case cJSON_String:
-	case cJSON_Raw:
-	case cJSON_Array:
-	case cJSON_Object:
-		break;
+    return (item->type & 0xFF) == cJSON_Raw;
+}
 
-	default:
-		return false;
-	}
+CJSON_PUBLIC(cJSON_bool) cJSON_Compare(const cJSON * const a, const cJSON * const b, const cJSON_bool case_sensitive)
+{
+    if ((a == NULL) || (b == NULL) || ((a->type & 0xFF) != (b->type & 0xFF)) || cJSON_IsInvalid(a))
+    {
+        return false;
+    }
 
-	/* identical objects are equal */
-	if (a == b) {
-		return true;
-	}
+    /* check if type is valid */
+    switch (a->type & 0xFF)
+    {
+        case cJSON_False:
+        case cJSON_True:
+        case cJSON_NULL:
+        case cJSON_Number:
+        case cJSON_String:
+        case cJSON_Raw:
+        case cJSON_Array:
+        case cJSON_Object:
+            break;
 
-	switch (a->type & 0xFF) {
-	/* in these cases and equal type is enough */
-	case cJSON_False:
-	case cJSON_True:
-	case cJSON_NULL:
-		return true;
+        default:
+            return false;
+    }
 
-	case cJSON_Number:
-		if (a->valuedouble == b->valuedouble) {
-			return true;
-		}
-		return false;
+    /* identical objects are equal */
+    if (a == b)
+    {
+        return true;
+    }
 
-	case cJSON_String:
-	case cJSON_Raw:
-		if ((a->valuestring == NULL) || (b->valuestring == NULL)) {
-			return false;
-		}
-		if (strcmp(a->valuestring, b->valuestring) == 0) {
-			return true;
-		}
+    switch (a->type & 0xFF)
+    {
+        /* in these cases and equal type is enough */
+        case cJSON_False:
+        case cJSON_True:
+        case cJSON_NULL:
+            return true;
 
-		return false;
+        case cJSON_Number:
+            if (compare_double(a->valuedouble, b->valuedouble))
+            {
+                return true;
+            }
+            return false;
 
-	case cJSON_Array: {
-		cJSON *a_element = a->child;
-		cJSON *b_element = b->child;
+        case cJSON_String:
+        case cJSON_Raw:
+            if ((a->valuestring == NULL) || (b->valuestring == NULL))
+            {
+                return false;
+            }
+            if (strcmp(a->valuestring, b->valuestring) == 0)
+            {
+                return true;
+            }
 
-		for (; (a_element != NULL) && (b_element != NULL);) {
-			if (!cJSON_Compare(a_element, b_element, case_sensitive)) {
-				return false;
-			}
+            return false;
 
-			a_element = a_element->next;
-			b_element = b_element->next;
-		}
+        case cJSON_Array:
+        {
+            cJSON *a_element = a->child;
+            cJSON *b_element = b->child;
 
-		return true;
-	}
+            for (; (a_element != NULL) && (b_element != NULL);)
+            {
+                if (!cJSON_Compare(a_element, b_element, case_sensitive))
+                {
+                    return false;
+                }
 
-	case cJSON_Object: {
-		cJSON *a_element = NULL;
-		cJSON_ArrayForEach(a_element, a)
-		{
-			/* TODO This has O(n^2) runtime, which is horrible! */
-			cJSON *b_element = get_object_item(b, a_element->string, case_sensitive);
-			if (b_element == NULL) {
-				return false;
-			}
+                a_element = a_element->next;
+                b_element = b_element->next;
+            }
 
-			if (!cJSON_Compare(a_element, b_element, case_sensitive)) {
-				return false;
-			}
-		}
+            /* one of the arrays is longer than the other */
+            if (a_element != b_element) {
+                return false;
+            }
 
-		return true;
-	}
+            return true;
+        }
 
-	default:
-		return false;
-	}
+        case cJSON_Object:
+        {
+            cJSON *a_element = NULL;
+            cJSON *b_element = NULL;
+            cJSON_ArrayForEach(a_element, a)
+            {
+                /* TODO This has O(n^2) runtime, which is horrible! */
+                b_element = get_object_item(b, a_element->string, case_sensitive);
+                if (b_element == NULL)
+                {
+                    return false;
+                }
+
+                if (!cJSON_Compare(a_element, b_element, case_sensitive))
+                {
+                    return false;
+                }
+            }
+
+            /* doing this twice, once on a and b to prevent true comparison if a subset of b
+             * TODO: Do this the proper way, this is just a fix for now */
+            cJSON_ArrayForEach(b_element, b)
+            {
+                a_element = get_object_item(a, b_element->string, case_sensitive);
+                if (a_element == NULL)
+                {
+                    return false;
+                }
+
+                if (!cJSON_Compare(b_element, a_element, case_sensitive))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        default:
+            return false;
+    }
 }
 
 CJSON_PUBLIC(void *) cJSON_malloc(size_t size)
 {
-	return global_hooks.allocate(size);
+    return global_hooks.allocate(size);
 }
 
 CJSON_PUBLIC(void) cJSON_free(void *object)
 {
-	global_hooks.deallocate(object);
+    global_hooks.deallocate(object);
 }

--- a/converter/cJSON/cJSON.h
+++ b/converter/cJSON/cJSON.h
@@ -24,66 +24,17 @@
 #define cJSON__h
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-/* project version */
-#define CJSON_VERSION_MAJOR 1
-#define CJSON_VERSION_MINOR 5
-#define CJSON_VERSION_PATCH 2
-
-#include <stddef.h>
-
-/* cJSON Types: */
-#define cJSON_Invalid (0)
-#define cJSON_False (1 << 0)
-#define cJSON_True (1 << 1)
-#define cJSON_NULL (1 << 2)
-#define cJSON_Number (1 << 3)
-#define cJSON_String (1 << 4)
-#define cJSON_Array (1 << 5)
-#define cJSON_Object (1 << 6)
-#define cJSON_Raw (1 << 7) /* raw json */
-
-#define cJSON_IsReference 256
-#define cJSON_StringIsConst 512
-
-/* The cJSON structure: */
-typedef struct cJSON {
-	/* next/prev allow you to walk array/object chains. Alternatively, use GetArraySize/GetArrayItem/GetObjectItem */
-	struct cJSON *next;
-	struct cJSON *prev;
-	/* An array or object item will have a child pointer pointing to a chain of the items in the array/object. */
-	struct cJSON *child;
-
-	/* The type of the item, as above. */
-	int type;
-
-	/* The item's string, if type==cJSON_String  and type == cJSON_Raw */
-	char *valuestring;
-	/* writing to valueint is DEPRECATED, use cJSON_SetNumberValue instead */
-	int valueint;
-	/* The item's number, if type==cJSON_Number */
-	double valuedouble;
-
-	/* The item's name string, if this item is the child of, or is in the list of subitems of an object. */
-	char *string;
-} cJSON;
-
-typedef struct cJSON_Hooks {
-	void *(*malloc_fn)(size_t sz);
-	void (*free_fn)(void *ptr);
-} cJSON_Hooks;
-
-typedef int cJSON_bool;
-
-#if !defined(__WINDOWS__) &&                                                                       \
-	(defined(WIN32) || defined(WIN64) || defined(_MSC_VER) || defined(_WIN32))
+#if !defined(__WINDOWS__) && (defined(WIN32) || defined(WIN64) || defined(_MSC_VER) || defined(_WIN32))
 #define __WINDOWS__
 #endif
+
 #ifdef __WINDOWS__
 
-/* When compiling for windows, we specify a specific calling convention to avoid issues where we are being called from a project with a different default calling convention.  For windows you have 2 define options:
+/* When compiling for windows, we specify a specific calling convention to avoid issues where we are being called from a project with a different default calling convention.  For windows you have 3 define options:
 
 CJSON_HIDE_SYMBOLS - Define this in the case where you don't want to ever dllexport symbols
 CJSON_EXPORT_SYMBOLS - Define this on library build when you want to dllexport symbols (default)
@@ -101,26 +52,84 @@ then using the CJSON_API_VISIBILITY flag to "export" the same symbols the way CJ
 
 */
 
+#define CJSON_CDECL __cdecl
+#define CJSON_STDCALL __stdcall
+
 /* export symbols by default, this is necessary for copy pasting the C and header file */
 #if !defined(CJSON_HIDE_SYMBOLS) && !defined(CJSON_IMPORT_SYMBOLS) && !defined(CJSON_EXPORT_SYMBOLS)
 #define CJSON_EXPORT_SYMBOLS
 #endif
 
 #if defined(CJSON_HIDE_SYMBOLS)
-#define CJSON_PUBLIC(type) type __stdcall
+#define CJSON_PUBLIC(type)   type CJSON_STDCALL
 #elif defined(CJSON_EXPORT_SYMBOLS)
-#define CJSON_PUBLIC(type) __declspec(dllexport) type __stdcall
+#define CJSON_PUBLIC(type)   __declspec(dllexport) type CJSON_STDCALL
 #elif defined(CJSON_IMPORT_SYMBOLS)
-#define CJSON_PUBLIC(type) __declspec(dllimport) type __stdcall
+#define CJSON_PUBLIC(type)   __declspec(dllimport) type CJSON_STDCALL
 #endif
-#else /* !WIN32 */
-#if (defined(__GNUC__) || defined(__SUNPRO_CC) || defined(__SUNPRO_C)) &&                          \
-	defined(CJSON_API_VISIBILITY)
-#define CJSON_PUBLIC(type) __attribute__((visibility("default"))) type
+#else /* !__WINDOWS__ */
+#define CJSON_CDECL
+#define CJSON_STDCALL
+
+#if (defined(__GNUC__) || defined(__SUNPRO_CC) || defined (__SUNPRO_C)) && defined(CJSON_API_VISIBILITY)
+#define CJSON_PUBLIC(type)   __attribute__((visibility("default"))) type
 #else
 #define CJSON_PUBLIC(type) type
 #endif
 #endif
+
+/* project version */
+#define CJSON_VERSION_MAJOR 1
+#define CJSON_VERSION_MINOR 7
+#define CJSON_VERSION_PATCH 12
+
+#include <stddef.h>
+
+/* cJSON Types: */
+#define cJSON_Invalid (0)
+#define cJSON_False  (1 << 0)
+#define cJSON_True   (1 << 1)
+#define cJSON_NULL   (1 << 2)
+#define cJSON_Number (1 << 3)
+#define cJSON_String (1 << 4)
+#define cJSON_Array  (1 << 5)
+#define cJSON_Object (1 << 6)
+#define cJSON_Raw    (1 << 7) /* raw json */
+
+#define cJSON_IsReference 256
+#define cJSON_StringIsConst 512
+
+/* The cJSON structure: */
+typedef struct cJSON
+{
+    /* next/prev allow you to walk array/object chains. Alternatively, use GetArraySize/GetArrayItem/GetObjectItem */
+    struct cJSON *next;
+    struct cJSON *prev;
+    /* An array or object item will have a child pointer pointing to a chain of the items in the array/object. */
+    struct cJSON *child;
+
+    /* The type of the item, as above. */
+    int type;
+
+    /* The item's string, if type==cJSON_String  and type == cJSON_Raw */
+    char *valuestring;
+    /* writing to valueint is DEPRECATED, use cJSON_SetNumberValue instead */
+    int valueint;
+    /* The item's number, if type==cJSON_Number */
+    double valuedouble;
+
+    /* The item's name string, if this item is the child of, or is in the list of subitems of an object. */
+    char *string;
+} cJSON;
+
+typedef struct cJSON_Hooks
+{
+      /* malloc/free are CDECL on Windows regardless of the default calling convention of the compiler, so ensure the hooks allow passing those functions directly. */
+      void *(CJSON_CDECL *malloc_fn)(size_t sz);
+      void (CJSON_CDECL *free_fn)(void *ptr);
+} cJSON_Hooks;
+
+typedef int cJSON_bool;
 
 /* Limits how deeply nested arrays/objects can be before cJSON rejects to parse them.
  * This is to prevent stack overflows. */
@@ -128,15 +137,24 @@ then using the CJSON_API_VISIBILITY flag to "export" the same symbols the way CJ
 #define CJSON_NESTING_LIMIT 1000
 #endif
 
+/* Precision of double variables comparison */
+#ifndef CJSON_DOUBLE_PRECISION
+#define CJSON_DOUBLE_PRECISION .0000000000000001
+#endif
+
 /* returns the version of cJSON as a string */
-CJSON_PUBLIC(const char *) cJSON_Version(void);
+CJSON_PUBLIC(const char*) cJSON_Version(void);
 
 /* Supply malloc, realloc and free functions to cJSON */
-CJSON_PUBLIC(void) cJSON_InitHooks(cJSON_Hooks *hooks);
+CJSON_PUBLIC(void) cJSON_InitHooks(cJSON_Hooks* hooks);
 
 /* Memory Management: the caller is always responsible to free the results from all variants of cJSON_Parse (with cJSON_Delete) and cJSON_Print (with stdlib free, cJSON_Hooks.free_fn, or cJSON_free as appropriate). The exception is cJSON_PrintPreallocated, where the caller has full responsibility of the buffer. */
 /* Supply a block of JSON, and this returns a cJSON object you can interrogate. */
 CJSON_PUBLIC(cJSON *) cJSON_Parse(const char *value);
+/* ParseWithOpts allows you to require (and check) that the JSON is null terminated, and to retrieve the pointer to the final byte parsed. */
+/* If you supply a ptr in return_parse_end and parsing fails, then return_parse_end will contain a pointer to the error so will match cJSON_GetErrorPtr(). */
+CJSON_PUBLIC(cJSON *) cJSON_ParseWithOpts(const char *value, const char **return_parse_end, cJSON_bool require_null_terminated);
+
 /* Render a cJSON entity to text for transfer/storage. */
 CJSON_PUBLIC(char *) cJSON_Print(const cJSON *item);
 /* Render a cJSON entity to text for transfer/storage without any formatting. */
@@ -145,34 +163,35 @@ CJSON_PUBLIC(char *) cJSON_PrintUnformatted(const cJSON *item);
 CJSON_PUBLIC(char *) cJSON_PrintBuffered(const cJSON *item, int prebuffer, cJSON_bool fmt);
 /* Render a cJSON entity to text using a buffer already allocated in memory with given length. Returns 1 on success and 0 on failure. */
 /* NOTE: cJSON is not always 100% accurate in estimating how much memory it will use, so to be safe allocate 5 bytes more than you actually need */
-CJSON_PUBLIC(cJSON_bool)
-cJSON_PrintPreallocated(cJSON *item, char *buffer, const int length, const cJSON_bool format);
+CJSON_PUBLIC(cJSON_bool) cJSON_PrintPreallocated(cJSON *item, char *buffer, const int length, const cJSON_bool format);
 /* Delete a cJSON entity and all subentities. */
-CJSON_PUBLIC(void) cJSON_Delete(cJSON *c);
+CJSON_PUBLIC(void) cJSON_Delete(cJSON *item);
 
 /* Returns the number of items in an array (or object). */
 CJSON_PUBLIC(int) cJSON_GetArraySize(const cJSON *array);
-/* Retrieve item number "item" from array "array". Returns NULL if unsuccessful. */
+/* Retrieve item number "index" from array "array". Returns NULL if unsuccessful. */
 CJSON_PUBLIC(cJSON *) cJSON_GetArrayItem(const cJSON *array, int index);
 /* Get item "string" from object. Case insensitive. */
-CJSON_PUBLIC(cJSON *) cJSON_GetObjectItem(const cJSON *const object, const char *const string);
-CJSON_PUBLIC(cJSON *)
-cJSON_GetObjectItemCaseSensitive(const cJSON *const object, const char *const string);
+CJSON_PUBLIC(cJSON *) cJSON_GetObjectItem(const cJSON * const object, const char * const string);
+CJSON_PUBLIC(cJSON *) cJSON_GetObjectItemCaseSensitive(const cJSON * const object, const char * const string);
 CJSON_PUBLIC(cJSON_bool) cJSON_HasObjectItem(const cJSON *object, const char *string);
 /* For analysing failed parses. This returns a pointer to the parse error. You'll probably need to look a few chars back to make sense of it. Defined when cJSON_Parse() returns 0. 0 when cJSON_Parse() succeeds. */
 CJSON_PUBLIC(const char *) cJSON_GetErrorPtr(void);
 
+/* Check if the item is a string and return its valuestring */
+CJSON_PUBLIC(char *) cJSON_GetStringValue(const cJSON * const item);
+
 /* These functions check the type of an item */
-CJSON_PUBLIC(cJSON_bool) cJSON_IsInvalid(const cJSON *const item);
-CJSON_PUBLIC(cJSON_bool) cJSON_IsFalse(const cJSON *const item);
-CJSON_PUBLIC(cJSON_bool) cJSON_IsTrue(const cJSON *const item);
-CJSON_PUBLIC(cJSON_bool) cJSON_IsBool(const cJSON *const item);
-CJSON_PUBLIC(cJSON_bool) cJSON_IsNull(const cJSON *const item);
-CJSON_PUBLIC(cJSON_bool) cJSON_IsNumber(const cJSON *const item);
-CJSON_PUBLIC(cJSON_bool) cJSON_IsString(const cJSON *const item);
-CJSON_PUBLIC(cJSON_bool) cJSON_IsArray(const cJSON *const item);
-CJSON_PUBLIC(cJSON_bool) cJSON_IsObject(const cJSON *const item);
-CJSON_PUBLIC(cJSON_bool) cJSON_IsRaw(const cJSON *const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsInvalid(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsFalse(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsTrue(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsBool(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsNull(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsNumber(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsString(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsArray(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsObject(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsRaw(const cJSON * const item);
 
 /* These calls create a cJSON item of the appropriate type. */
 CJSON_PUBLIC(cJSON *) cJSON_CreateNull(void);
@@ -186,11 +205,20 @@ CJSON_PUBLIC(cJSON *) cJSON_CreateRaw(const char *raw);
 CJSON_PUBLIC(cJSON *) cJSON_CreateArray(void);
 CJSON_PUBLIC(cJSON *) cJSON_CreateObject(void);
 
-/* These utilities create an Array of count items. */
+/* Create a string where valuestring references a string so
+ * it will not be freed by cJSON_Delete */
+CJSON_PUBLIC(cJSON *) cJSON_CreateStringReference(const char *string);
+/* Create an object/array that only references it's elements so
+ * they will not be freed by cJSON_Delete */
+CJSON_PUBLIC(cJSON *) cJSON_CreateObjectReference(const cJSON *child);
+CJSON_PUBLIC(cJSON *) cJSON_CreateArrayReference(const cJSON *child);
+
+/* These utilities create an Array of count items.
+ * The parameter count cannot be greater than the number of elements in the number array, otherwise array access will be out of bounds.*/
 CJSON_PUBLIC(cJSON *) cJSON_CreateIntArray(const int *numbers, int count);
 CJSON_PUBLIC(cJSON *) cJSON_CreateFloatArray(const float *numbers, int count);
 CJSON_PUBLIC(cJSON *) cJSON_CreateDoubleArray(const double *numbers, int count);
-CJSON_PUBLIC(cJSON *) cJSON_CreateStringArray(const char **strings, int count);
+CJSON_PUBLIC(cJSON *) cJSON_CreateStringArray(const char *const *strings, int count);
 
 /* Append item to the specified array/object. */
 CJSON_PUBLIC(void) cJSON_AddItemToArray(cJSON *array, cJSON *item);
@@ -203,8 +231,8 @@ CJSON_PUBLIC(void) cJSON_AddItemToObjectCS(cJSON *object, const char *string, cJ
 CJSON_PUBLIC(void) cJSON_AddItemReferenceToArray(cJSON *array, cJSON *item);
 CJSON_PUBLIC(void) cJSON_AddItemReferenceToObject(cJSON *object, const char *string, cJSON *item);
 
-/* Remove/Detatch items from Arrays/Objects. */
-CJSON_PUBLIC(cJSON *) cJSON_DetachItemViaPointer(cJSON *parent, cJSON *const item);
+/* Remove/Detach items from Arrays/Objects. */
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemViaPointer(cJSON *parent, cJSON * const item);
 CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromArray(cJSON *array, int which);
 CJSON_PUBLIC(void) cJSON_DeleteItemFromArray(cJSON *array, int which);
 CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromObject(cJSON *object, const char *string);
@@ -213,60 +241,46 @@ CJSON_PUBLIC(void) cJSON_DeleteItemFromObject(cJSON *object, const char *string)
 CJSON_PUBLIC(void) cJSON_DeleteItemFromObjectCaseSensitive(cJSON *object, const char *string);
 
 /* Update array items. */
-CJSON_PUBLIC(void)
-cJSON_InsertItemInArray(cJSON *array, int which,
-			cJSON *newitem); /* Shifts pre-existing items to the right. */
-CJSON_PUBLIC(cJSON_bool)
-cJSON_ReplaceItemViaPointer(cJSON *const parent, cJSON *const item, cJSON *replacement);
+CJSON_PUBLIC(void) cJSON_InsertItemInArray(cJSON *array, int which, cJSON *newitem); /* Shifts pre-existing items to the right. */
+CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemViaPointer(cJSON * const parent, cJSON * const item, cJSON * replacement);
 CJSON_PUBLIC(void) cJSON_ReplaceItemInArray(cJSON *array, int which, cJSON *newitem);
-CJSON_PUBLIC(void) cJSON_ReplaceItemInObject(cJSON *object, const char *string, cJSON *newitem);
-CJSON_PUBLIC(void)
-cJSON_ReplaceItemInObjectCaseSensitive(cJSON *object, const char *string, cJSON *newitem);
+CJSON_PUBLIC(void) cJSON_ReplaceItemInObject(cJSON *object,const char *string,cJSON *newitem);
+CJSON_PUBLIC(void) cJSON_ReplaceItemInObjectCaseSensitive(cJSON *object,const char *string,cJSON *newitem);
 
 /* Duplicate a cJSON item */
 CJSON_PUBLIC(cJSON *) cJSON_Duplicate(const cJSON *item, cJSON_bool recurse);
 /* Duplicate will create a new, identical cJSON item to the one you pass, in new memory that will
-need to be released. With recurse!=0, it will duplicate any children connected to the item.
-The item->next and ->prev pointers are always zero on return from Duplicate. */
+ * need to be released. With recurse!=0, it will duplicate any children connected to the item.
+ * The item->next and ->prev pointers are always zero on return from Duplicate. */
 /* Recursively compare two cJSON items for equality. If either a or b is NULL or invalid, they will be considered unequal.
  * case_sensitive determines if object keys are treated case sensitive (1) or case insensitive (0) */
-CJSON_PUBLIC(cJSON_bool)
-cJSON_Compare(const cJSON *const a, const cJSON *const b, const cJSON_bool case_sensitive);
+CJSON_PUBLIC(cJSON_bool) cJSON_Compare(const cJSON * const a, const cJSON * const b, const cJSON_bool case_sensitive);
 
-/* ParseWithOpts allows you to require (and check) that the JSON is null terminated, and to retrieve the pointer to the final byte parsed. */
-/* If you supply a ptr in return_parse_end and parsing fails, then return_parse_end will contain a pointer to the error. If not, then cJSON_GetErrorPtr() does the job. */
-CJSON_PUBLIC(cJSON *)
-cJSON_ParseWithOpts(const char *value, const char **return_parse_end,
-		    cJSON_bool require_null_terminated);
-
+/* Minify a strings, remove blank characters(such as ' ', '\t', '\r', '\n') from strings.
+ * The input pointer json cannot point to a read-only address area, such as a string constant, 
+ * but should point to a readable and writable adress area. */
 CJSON_PUBLIC(void) cJSON_Minify(char *json);
 
-/* Macros for creating things quickly. */
-#define cJSON_AddNullToObject(object, name) cJSON_AddItemToObject(object, name, cJSON_CreateNull())
-#define cJSON_AddTrueToObject(object, name) cJSON_AddItemToObject(object, name, cJSON_CreateTrue())
-#define cJSON_AddFalseToObject(object, name)                                                       \
-	cJSON_AddItemToObject(object, name, cJSON_CreateFalse())
-#define cJSON_AddBoolToObject(object, name, b)                                                     \
-	cJSON_AddItemToObject(object, name, cJSON_CreateBool(b))
-#define cJSON_AddNumberToObject(object, name, n)                                                   \
-	cJSON_AddItemToObject(object, name, cJSON_CreateNumber(n))
-#define cJSON_AddStringToObject(object, name, s)                                                   \
-	cJSON_AddItemToObject(object, name, cJSON_CreateString(s))
-#define cJSON_AddRawToObject(object, name, s)                                                      \
-	cJSON_AddItemToObject(object, name, cJSON_CreateRaw(s))
+/* Helper functions for creating and adding items to an object at the same time.
+ * They return the added item or NULL on failure. */
+CJSON_PUBLIC(cJSON*) cJSON_AddNullToObject(cJSON * const object, const char * const name);
+CJSON_PUBLIC(cJSON*) cJSON_AddTrueToObject(cJSON * const object, const char * const name);
+CJSON_PUBLIC(cJSON*) cJSON_AddFalseToObject(cJSON * const object, const char * const name);
+CJSON_PUBLIC(cJSON*) cJSON_AddBoolToObject(cJSON * const object, const char * const name, const cJSON_bool boolean);
+CJSON_PUBLIC(cJSON*) cJSON_AddNumberToObject(cJSON * const object, const char * const name, const double number);
+CJSON_PUBLIC(cJSON*) cJSON_AddStringToObject(cJSON * const object, const char * const name, const char * const string);
+CJSON_PUBLIC(cJSON*) cJSON_AddRawToObject(cJSON * const object, const char * const name, const char * const raw);
+CJSON_PUBLIC(cJSON*) cJSON_AddObjectToObject(cJSON * const object, const char * const name);
+CJSON_PUBLIC(cJSON*) cJSON_AddArrayToObject(cJSON * const object, const char * const name);
 
 /* When assigning an integer value, it needs to be propagated to valuedouble too. */
-#define cJSON_SetIntValue(object, number)                                                          \
-	((object) ? (object)->valueint = (object)->valuedouble = (number) : (number))
+#define cJSON_SetIntValue(object, number) ((object) ? (object)->valueint = (object)->valuedouble = (number) : (number))
 /* helper for the cJSON_SetNumberValue macro */
 CJSON_PUBLIC(double) cJSON_SetNumberHelper(cJSON *object, double number);
-#define cJSON_SetNumberValue(object, number)                                                       \
-	((object != NULL) ? cJSON_SetNumberHelper(object, (double)number) : (number))
+#define cJSON_SetNumberValue(object, number) ((object != NULL) ? cJSON_SetNumberHelper(object, (double)number) : (number))
 
 /* Macro for iterating over an array or object */
-#define cJSON_ArrayForEach(element, array)                                                         \
-	for (element = (array != NULL) ? (array)->child : NULL; element != NULL;                   \
-	     element = element->next)
+#define cJSON_ArrayForEach(element, array) for(element = (array != NULL) ? (array)->child : NULL; element != NULL; element = element->next)
 
 /* malloc/free objects using the malloc/free functions that have been set with cJSON_InitHooks */
 CJSON_PUBLIC(void *) cJSON_malloc(size_t size);

--- a/converter/docker.c
+++ b/converter/docker.c
@@ -384,7 +384,7 @@ docker_generate_basic_auth(const char *user, const char *password, const char *t
 	char *url = mem_printf("https://%s", host_url);
 
 	const char *const argv[] = { CURL_PATH, "-fsSL", "-H", auth, url, NULL };
-	ret = proc_fork_and_execvp(CURL_PATH, argv);
+	ret = proc_fork_and_execvp(argv);
 	if (ret == 0) {
 		INFO("Auth OK. Storing access token!");
 		file_printf(token_file, "{ \"token\": \"%s\" }", out);
@@ -407,7 +407,7 @@ docker_get_curl_token_new(char *image_name, char *token_file)
 
 	if (!file_exists(token_file)) {
 		const char *const argv[] = { CURL_PATH, "-fsSL", url, "-o", token_file, NULL };
-		proc_fork_and_execvp(CURL_PATH, argv);
+		proc_fork_and_execvp(argv);
 	}
 
 	cJSON *jroot = NULL;
@@ -446,10 +446,10 @@ docker_download_manifest_list(const char *curl_token, const char *out_file, cons
 	const char *const argv_bearer[] = { CURL_PATH,  "-fsSL", "-H", auth_bearer, "-H",
 					    acceptlist, url,     "-o", out_file,    NULL };
 
-	int ret = proc_fork_and_execvp(CURL_PATH, argv_bearer);
+	int ret = proc_fork_and_execvp(argv_bearer);
 	if (ret != 0) {
 		INFO("Bearer auth failed (curl returned %d), trying Basic auth", ret);
-		ret = proc_fork_and_execvp(CURL_PATH, argv_basic);
+		ret = proc_fork_and_execvp(argv_basic);
 	}
 
 	mem_free(url);
@@ -478,10 +478,10 @@ docker_download_manifest(const char *curl_token, const char *out_file, const cha
 					    "-H",      acceptv2, "-H",     acceptv1,
 					    url,       "-o",     out_file, NULL };
 
-	int ret = proc_fork_and_execvp(CURL_PATH, argv_bearer);
+	int ret = proc_fork_and_execvp(argv_bearer);
 	if (ret != 0) {
 		INFO("Bearer auth failed (curl returned %d), trying Basic auth", ret);
-		ret = proc_fork_and_execvp(CURL_PATH, argv_basic);
+		ret = proc_fork_and_execvp(argv_basic);
 	}
 
 	mem_free(url);
@@ -521,9 +521,9 @@ download_docker_remote_file(const char *curl_token, const docker_remote_file_t *
 	const char *const argv_basic[] = { CURL_PATH, "-fSL", "--progress", "-H", auth_basic,
 					   url,       "-o",   out_file,     NULL };
 
-	ret = proc_fork_and_execvp(CURL_PATH, argv_bearer);
+	ret = proc_fork_and_execvp(argv_bearer);
 	if (ret != 0)
-		ret = proc_fork_and_execvp(CURL_PATH, argv_basic);
+		ret = proc_fork_and_execvp(argv_basic);
 
 	mem_free(url);
 	mem_free(auth_basic);

--- a/converter/util.c
+++ b/converter/util.c
@@ -81,7 +81,7 @@ int
 util_tar_extract(const char *tar_filename, const char *out_dir)
 {
 	const char *const argv[] = { TAR_PATH, "-xvf", tar_filename, "-C", out_dir, NULL };
-	return proc_fork_and_execvp(argv[0], argv);
+	return proc_fork_and_execvp(argv);
 }
 
 static char *
@@ -150,7 +150,7 @@ util_squash_image(const char *dir, const char *image_file)
 {
 	const char *const argv[] = { MKSQUASHFS_PATH, dir,  image_file,       "-noappend", "-comp",
 				     MKSQUASHFS_COMP, "-b", MKSQUASHFS_BSIZE, NULL };
-	return proc_fork_and_execvp(MKSQUASHFS_PATH, argv);
+	return proc_fork_and_execvp(argv);
 }
 
 int
@@ -158,12 +158,12 @@ util_sign_guestos(const char *sig_file, const char *cfg_file, const char *key_fi
 {
 	const char *const argv[] = { OPENSSLBIN_PATH, "dgst",   "-sha512", "-sign", key_file,
 				     "-out",	  sig_file, cfg_file,  NULL };
-	return proc_fork_and_execvp(argv[0], argv);
+	return proc_fork_and_execvp(argv);
 }
 
 int
 util_gen_pki(void)
 {
 	const char *const argv[] = { "bash", PKIGENSCRIPT_PATH, PKIGENCONF_PATH, NULL };
-	return proc_fork_and_execvp(argv[0], argv);
+	return proc_fork_and_execvp(argv);
 }

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -26,7 +26,7 @@ CC ?= gcc
 LOCAL_CFLAGS := -std=gnu99 -Icommon -I.. -I../include -I../tpm2d -pedantic -O2
 LOCAL_CFLAGS += -Wall -Wextra -Wcast-align -Wformat -Wformat-security -Werror -fstack-protector-all -fstack-clash-protection -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -fpic -pie
 LOCAL_CFLAGS += -DDEBUG_BUILD
-LDLIBS := -lc -lprotobuf-c -lprotobuf-c-text -lselinux -Lcommon -lcommon -lutil
+LDLIBS := -lc -lprotobuf-c -lprotobuf-c-text -lselinux -Lcommon -lcommon -lutil -lctccid -lcardservice
 
 TRUSTME_HARDWARE := x86
 

--- a/daemon/c_cap.c
+++ b/daemon/c_cap.c
@@ -23,6 +23,11 @@
 
 #include "c_cap.h"
 
+#ifdef LOGF_MIN_PRIO
+#undef LOGF_MIN_PRIO
+#endif
+#define LOGF_MIN_PRIO LOGF_MIN_PRIO_WARN
+
 #include "common/macro.h"
 
 #include <sys/capability.h>

--- a/daemon/c_cgroups.c
+++ b/daemon/c_cgroups.c
@@ -30,6 +30,12 @@
 #include "hardware.h"
 #include "uevent.h"
 
+
+#ifdef LOGF_MIN_PRIO
+#undef LOGF_MIN_PRIO
+#endif
+#define LOGF_LOG_MIN_PRIO LOGF_PRIO_WARN
+
 #include "common/mem.h"
 #include "common/macro.h"
 #include "common/file.h"

--- a/daemon/c_service.c
+++ b/daemon/c_service.c
@@ -30,6 +30,11 @@
 
 #include "container.h"
 
+#ifdef LOGF_MIN_PRIO
+#undef LOGF_MIN_PRIO
+#endif
+#define LOGF_LOG_MIN_PRIO LOGF_PRIO_WARN
+
 #include "common/event.h"
 #include "common/fd.h"
 #include "common/macro.h"

--- a/daemon/c_user.c
+++ b/daemon/c_user.c
@@ -23,6 +23,11 @@
 
 #include "c_user.h"
 
+#ifdef LOGF_MIN_PRIO
+#undef LOGF_MIN_PRIO
+#endif
+#define LOGF_LOG_MIN_PRIO LOGF_PRIO_WARN
+
 #define _GNU_SOURCE
 #include <fcntl.h>
 #include <grp.h>

--- a/daemon/c_vol.c
+++ b/daemon/c_vol.c
@@ -29,6 +29,11 @@
 #define _GNU_SOURCE
 #endif
 
+#ifdef LOGF_MIN_PRIO
+#undef LOGF_MIN_PRIO
+#endif
+#define LOGF_LOG_MIN_PRIO LOGF_PRIO_WARN
+
 #include "c_vol.h"
 
 #include "common/macro.h"

--- a/daemon/container.c
+++ b/daemon/container.c
@@ -2578,3 +2578,10 @@ container_get_uid(const container_t *container)
 	ASSERT(container);
 	return c_user_get_uid(container->user);
 }
+
+container_token_type_t
+container_get_token_type(const container_t *container)
+{
+	ASSERT(container);
+	return container_config_get_token_type(container->config);
+}

--- a/daemon/container.c
+++ b/daemon/container.c
@@ -26,7 +26,11 @@
 
 #include "container.h"
 
-#define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE
+#ifdef LOGF_MIN_PRIO
+#undef LOGF_MIN_PRIO
+#endif
+
+#define LOGF_LOG_MIN_PRIO LOGF_PRIO_WARN
 #include "common/macro.h"
 #include "common/mem.h"
 #include "common/uuid.h"

--- a/daemon/container.c
+++ b/daemon/container.c
@@ -558,7 +558,7 @@ container_uuid_is_c0id(const uuid_t *uuid)
 }
 
 /**
- * Creates a new container container object. There are three different cases
+ * Creates a new container object. There are three different cases
  * depending on the combination of the given parameters:
  *
  * uuid && !config: In this case, a container with the given UUID must be already
@@ -2583,5 +2583,10 @@ container_token_type_t
 container_get_token_type(const container_t *container)
 {
 	ASSERT(container);
-	return container_config_get_token_type(container->config);
+
+	container_token_type_t ret;
+	container_config_t *conf = container_config_new(container->config_filename, NULL, 0);
+	ret =  container_config_get_token_type(conf);
+	container_config_free(conf);
+	return ret;
 }

--- a/daemon/container.h
+++ b/daemon/container.h
@@ -792,4 +792,10 @@ container_get_rootdir(const container_t *container);
 bool
 container_uuid_is_c0id(const uuid_t *uuid);
 
+/**
+ * Returns the type of the token that is used with the container
+ */
+container_token_type_t
+container_get_token_type(const container_t *container);
+
 #endif /* CONTAINER_H */

--- a/daemon/container.h
+++ b/daemon/container.h
@@ -70,6 +70,15 @@ typedef enum {
 } container_type_t;
 
 /**
+ * TODO
+ */
+typedef enum {
+	CONTAINER_TOKEN_TYPE_NONE = 1,
+	CONTAINER_TOKEN_TYPE_DEVICE,
+	CONTAINER_TOKEN_TYPE_USB,
+} container_token_type_t;
+
+/**
  * Structure to define the configuration for a virtual network
  * interface in a container. It defines the name and if cmld
  * should configure it in its c_net submodule.

--- a/daemon/container.proto
+++ b/daemon/container.proto
@@ -1,6 +1,6 @@
 /*
  * This file is part of trust|me
- * Copyright(c) 2013 - 2017 Fraunhofer AISEC
+ * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -39,10 +39,16 @@ message ContainerVnetConfig {
 	// TODO Define configuration, for now just use hardcoded default config in c_net
 }
 
+enum ContainerUsbType {
+	GENERIC = 1;
+	TOKEN = 2;
+}
+
 message ContainerUsbConfig {
 	required string id = 1;
 	required string serial = 2;
 	required bool assign = 3 [default = false];
+	required ContainerUsbType = 4 [default = GENERIC];
 }
 
 /**
@@ -51,6 +57,12 @@ message ContainerUsbConfig {
 enum ContainerType {
 	CONTAINER = 1;
 	KVM = 2	;
+}
+
+enum ContainerTokenType {
+	NONE = 1;
+	DEVICE = 2;
+	USB = 3;
 }
 
 message ContainerConfig {
@@ -97,13 +109,15 @@ message ContainerConfig {
 	// list of virtual network interface configuration
 	repeated ContainerVnetConfig vnet_configs = 27;
 
-	// list of virtual network interface configuration
+	// list of usb interface configuration
 	repeated ContainerUsbConfig usb_configs = 28;
 
 	// number of pipes from c0 to this container
 	// control erweitern: get container pipe fd
 	// use bindmount mechanism from c_vol
 	repeated string fifos = 29;
+
+	required ContainerTokenType token_type = 30 [ default = DEVICE ];
 }
 
 /**

--- a/daemon/container.proto
+++ b/daemon/container.proto
@@ -48,7 +48,7 @@ message ContainerUsbConfig {
 	required string id = 1;
 	required string serial = 2;
 	required bool assign = 3 [default = false];
-	required ContainerUsbType = 4 [default = GENERIC];
+	required ContainerUsbType type = 4 [default = GENERIC];
 }
 
 /**

--- a/daemon/container_config.c
+++ b/daemon/container_config.c
@@ -73,6 +73,37 @@ container_config_proto_to_type(ContainerType type)
 	}
 }
 
+/**
+ * The usual identity map between two corresponding C and protobuf enums.
+ */
+container_token_type_t
+container_config_proto_to_token_type(ContainerTokenType type)
+{
+	switch (type) {
+	case CONTAINER_TOKEN_TYPE__NONE:
+		return CONTAINER_TOKEN_TYPE_NONE;
+	case CONTAINER_TOKEN_TYPE__DEVICE:
+		return CONTAINER_TOKEN_TYPE_DEVCIE;
+	case CONTAINER_TOKEN_TYPE__USB:
+		return CONTAINER_TOKEN_TYPE_USB;
+	default:
+		FATAL("Unhandled value for ContainerTokenType: %d", type);
+	}
+}
+
+static uevent_usbdev_type_t
+container_config_proto_to_usb_type(ContainerUsbType type)
+{
+	switch (type) {
+	case CONTAINER_USB_TYPE__GENERIC:
+		return UEVENT_USBDEV_TYPE_GENERIC;
+	case CONTAINER_USB_TYPE__TOKEN:
+		return UEVENT_USBDEV_TYPE_TOKEN;
+	default:
+		FATAL("Unhandled value for ContainerTokenType: %d", type);
+	}
+}
+
 /******************************************************************************/
 
 #if 0
@@ -560,7 +591,8 @@ container_config_get_usbdev_list_new(const container_config_t *config)
 		uint16_t vendor, product;
 		sscanf(config->cfg->usb_configs[i]->id, "%hx:%hx", &vendor, &product);
 		uevent_usbdev_t *usbdev =
-			uevent_usbdev_new(vendor, product, config->cfg->usb_configs[i]->serial,
+			uevent_usbdev_new(container_config_proto_to_usb_type(config->cfg->type),
+					  vendor, product, config->cfg->usb_configs[i]->serial,
 					  config->cfg->usb_configs[i]->assign);
 		usbdev_list = list_append(usbdev_list, usbdev);
 	}
@@ -596,4 +628,12 @@ container_config_get_fifos(const container_config_t *config)
 	ASSERT(config);
 	ASSERT(config->cfg);
 	return config->cfg->fifos;
+}
+
+container_token_type_t
+container_config_get_token_type(const container_config_t *config)
+{
+	ASSERT(config);
+	ASSERT(config->cfg);
+	return config->cfg->token_type;
 }

--- a/daemon/container_config.c
+++ b/daemon/container_config.c
@@ -83,7 +83,7 @@ container_config_proto_to_token_type(ContainerTokenType type)
 	case CONTAINER_TOKEN_TYPE__NONE:
 		return CONTAINER_TOKEN_TYPE_NONE;
 	case CONTAINER_TOKEN_TYPE__DEVICE:
-		return CONTAINER_TOKEN_TYPE_DEVCIE;
+		return CONTAINER_TOKEN_TYPE_DEVICE;
 	case CONTAINER_TOKEN_TYPE__USB:
 		return CONTAINER_TOKEN_TYPE_USB;
 	default:

--- a/daemon/container_config.h
+++ b/daemon/container_config.h
@@ -259,4 +259,10 @@ container_config_get_fifos_len(const container_config_t *config);
 char **
 container_config_get_fifos(const container_config_t *config);
 
+/**
+ * Returns the type of the token which is used for encryption
+ */
+container_token_type_t
+container_config_get_token_type(const container_config_t *config);
+
 #endif /* C_CONFIG_H */

--- a/daemon/scd.proto
+++ b/daemon/scd.proto
@@ -34,6 +34,15 @@ enum HashAlgo {
 	SHA512 = 3;
 }
 
+/**
+ * Supported token types.
+ */
+enum TokenType {
+	NONE = 1;
+	DEVICE = 2;
+	USB = 3;
+}
+
 
 message DaemonToToken {
 	enum Code {
@@ -58,8 +67,16 @@ message DaemonToToken {
 
 	required Code code = 1;
 
-	optional string token_pin = 2;		// for unlocking and changeing of the token
-	optional string token_newpin = 3;	// for changeing pin of the token
+	optional string token_pin = 2;		// for unlocking and changing of the token
+	optional string token_newpin = 3;	// for changing pin of the token
+
+	// for identifying the type of the token 
+	optional TokenType token_type = 4 [default = DEVICE];
+
+	optional string container_uuid = 5;	// can be used as input for key wrapping
+	
+	/* TODO: must be implemented! */
+	optional bytes pairing_secret = 6; // to bind the token to the device
 
 	optional bytes unwrapped_key = 10;	// for wrapping a key
 	optional bytes wrapped_key = 11;	// for (un)wrapping a key

--- a/daemon/smartcard.c
+++ b/daemon/smartcard.c
@@ -32,6 +32,7 @@
 #include "hardware.h"
 #include "control.h"
 
+#define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE
 #include "common/macro.h"
 #include "common/event.h"
 #include "common/logf.h"
@@ -45,14 +46,23 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <sc-hsm-cardservice.h>
+#include <ctapi.h>
 
 // clang-format off
 #define SCD_CONTROL_SOCKET SOCK_PATH(scd-control)
 // clang-format on
 
-// TODO: centrally define key length in container or other module?
-#define TOKEN_KEY_LEN 64
+#define TOKEN_KEY_LEN 64 // ambigious name?
 #define TOKEN_MAX_WRAPPED_KEY_LEN 4096
+
+/**
+ * This is currently the Byte representation of the string "ABCD" (without trailing
+ * NULL Byte) to keep compatibility with the sc-hsm key-gen example.
+ * 
+ * TODO: should be bound securely to platform; e.g. using TPM
+ */
+const unsigned char PAIRING_SECRET[] = {0x41,0x42,0x43,0x44};
 
 struct smartcard {
 	int sock;
@@ -75,6 +85,20 @@ bytes_to_string_new(unsigned char *data, size_t len)
 	return str;
 }
 
+static TokenType
+smartcard_tokentype_to_proto(smartcard_tokentype_t tokentype) {
+	switch (tokentype) {
+		case NONE:
+			return TOKEN_TYPE__NONE;
+		case DEVICE:
+			return TOKEN_TYPE__DEVICE;
+		case USB:
+			return TOKEN_TYPE__USB;
+		default:
+			FATAL("Invalid smartcard_tokentype_t value : %d", tokentype);
+	}
+}
+
 static void
 smartcard_start_container_internal(smartcard_startdata_t *startdata, unsigned char *key, int keylen)
 {
@@ -82,7 +106,7 @@ smartcard_start_container_internal(smartcard_startdata_t *startdata, unsigned ch
 	// backward compatibility: convert binary key to ascii (to have it converted back later)
 	char *ascii_key = bytes_to_string_new(key, keylen);
 	//DEBUG("SCD: Container key (len=%d): %s", keylen, ascii_key);
-	DEBUG("SCD: %s: Starting...", container_get_name(startdata->container));
+	DEBUG("SCD:Container  %s: Starting...", container_get_name(startdata->container));
 	if (-1 == cmld_container_start(startdata->container, ascii_key))
 		control_send_message(CONTROL_RESPONSE_CONTAINER_START_EINTERNAL, resp_fd);
 	else
@@ -97,6 +121,8 @@ smartcard_cb_start_container(int fd, unsigned events, event_io_t *io, void *data
 	int resp_fd = control_get_client_sock(startdata->control);
 	bool done = false;
 
+	TRACE("smartcard_cb_start_container");
+
 	if (events & EVENT_IO_EXCEPT) {
 		ERROR("Container start failed");
 
@@ -104,12 +130,12 @@ smartcard_cb_start_container(int fd, unsigned events, event_io_t *io, void *data
 		mem_free(io);
 		mem_free(startdata);
 		return;
-	} else	if (events & EVENT_IO_READ) {
+	} else if (events & EVENT_IO_READ) {
 		// use protobuf for communication with scd
 		TokenToDaemon *msg =
 			(TokenToDaemon *)protobuf_recv_message(fd, &token_to_daemon__descriptor);
 
-		if (! msg) {
+		if (!msg) {
 			ERROR("Failed to receive message althoug EVENT_IO_READ was set. Aborting container start.");
 
 			event_remove_io(io);
@@ -160,8 +186,28 @@ smartcard_cb_start_container(int fd, unsigned events, event_io_t *io, void *data
 				out.has_wrapped_key = true;
 				out.wrapped_key.len = keylen;
 				out.wrapped_key.data = key;
+				out.container_uuid = mem_strdup(uuid_string(container_get_uuid(
+								startdata->container)));
+
+				out.has_token_type = true;
+				switch (container_get_token_type(startdata->container)) {
+					case CONTAINER_TOKEN_TYPE_DEVICE: {
+					DEBUG("Using token type DEVICE");
+					out.token_type = smartcard_tokentype_to_proto(DEVICE);
+				} break;
+				case CONTAINER_TOKEN_TYPE_USB: {
+					DEBUG("Using token type USB");
+					out.token_type = smartcard_tokentype_to_proto(USB);
+				} break;
+				default: {}
+					ERROR("Token type not supported!");
+					return;
+				}
+
 				protobuf_send_message(startdata->smartcard->sock,
 						      (ProtobufCMessage *)&out);
+
+				mem_free(out.container_uuid);
 			} else {
 				DEBUG("No previous key found for container %s. Generating new key.",
 				      container_get_name(startdata->container));
@@ -187,8 +233,28 @@ smartcard_cb_start_container(int fd, unsigned events, event_io_t *io, void *data
 				out.has_unwrapped_key = true;
 				out.unwrapped_key.len = keylen;
 				out.unwrapped_key.data = key;
+				out.container_uuid = mem_strdup(uuid_string(container_get_uuid(
+								startdata->container)));
+
+				out.has_token_type = true;
+				switch (container_get_token_type(startdata->container)) {
+					case CONTAINER_TOKEN_TYPE_DEVICE: {
+					DEBUG("Using token type DEVICE");
+					out.token_type = smartcard_tokentype_to_proto(DEVICE);
+				} break;
+				case CONTAINER_TOKEN_TYPE_USB: {
+					DEBUG("Using token type USB");
+					out.token_type = smartcard_tokentype_to_proto(USB);
+				} break;
+				default: {}
+					ERROR("Token type not supported!");
+					return;
+				}
+
 				protobuf_send_message(startdata->smartcard->sock,
 						      (ProtobufCMessage *)&out);
+
+				mem_free(out.container_uuid);
 			}
 			mem_free(keyfile);
 		} break;
@@ -196,10 +262,26 @@ smartcard_cb_start_container(int fd, unsigned events, event_io_t *io, void *data
 			// lock token via scd
 			DaemonToToken out = DAEMON_TO_TOKEN__INIT;
 			out.code = DAEMON_TO_TOKEN__CODE__LOCK;
+			out.has_token_type = true;
+			switch (container_get_token_type(startdata->container)) {
+					case CONTAINER_TOKEN_TYPE_DEVICE: {
+					DEBUG("Using token type DEVICE");
+					out.token_type = smartcard_tokentype_to_proto(DEVICE);
+				} break;
+				case CONTAINER_TOKEN_TYPE_USB: {
+					DEBUG("Using token type USB");
+					out.token_type = smartcard_tokentype_to_proto(USB);
+				} break;
+				default: {}
+					ERROR("Token type not supported!");
+					return;
+			}
 			protobuf_send_message(startdata->smartcard->sock, (ProtobufCMessage *)&out);
 			// start container
 			if (!msg->has_unwrapped_key) {
 				WARN("Expected derived key, but none was returned!");
+				/* TODO: should this be communicated to the controller? */
+				/* control seems to wait indefinitely if not */
 				break;
 			}
 			smartcard_start_container_internal(startdata, msg->unwrapped_key.data,
@@ -209,6 +291,20 @@ smartcard_cb_start_container(int fd, unsigned events, event_io_t *io, void *data
 			// lock token via scd
 			DaemonToToken out = DAEMON_TO_TOKEN__INIT;
 			out.code = DAEMON_TO_TOKEN__CODE__LOCK;
+			out.has_token_type = true;
+			switch (container_get_token_type(startdata->container)) {
+					case CONTAINER_TOKEN_TYPE_DEVICE: {
+					DEBUG("Using token type DEVICE");
+					out.token_type = smartcard_tokentype_to_proto(DEVICE);
+				} break;
+				case CONTAINER_TOKEN_TYPE_USB: {
+					DEBUG("Using token type USB");
+					out.token_type = smartcard_tokentype_to_proto(USB);
+				} break;
+				default: {}
+					ERROR("Token type not supported!");
+					return;
+			}
 			protobuf_send_message(startdata->smartcard->sock, (ProtobufCMessage *)&out);
 			// save wrapped key
 			if (!msg->has_wrapped_key) {
@@ -256,44 +352,58 @@ smartcard_container_start_handler(smartcard_t *smartcard, control_t *control,
 	startdata->container = container;
 	startdata->control = control;
 
+	int pw_size = strlen(passwd);
+	DEBUG("SCD: Passwd form UI: %s, size: %d", passwd, pw_size);
+	// register callback handler
+
+	// TODO register timer if socket does not respond
+	event_io_t *event = event_io_new(smartcard->sock, EVENT_IO_READ,
+					smartcard_cb_start_container, startdata);
+	event_add_io(event);
+	DEBUG("SCD: Registered start container callback for key from scd");
+
+	// unlock token
+	DaemonToToken out = DAEMON_TO_TOKEN__INIT;
+	out.code = DAEMON_TO_TOKEN__CODE__UNLOCK;
+	out.token_pin = mem_strdup(passwd);
+
+	/* TODO: properly implement pairing secret */
+	out.has_pairing_secret = true;
+	out.pairing_secret.len = sizeof(PAIRING_SECRET);
+	out.pairing_secret.data = mem_memcpy(PAIRING_SECRET, sizeof(PAIRING_SECRET));
 
 	switch (container_get_token_type(container)) {
-	case CONTAINER_TOKEN_TYPE_DEVICE: {
-		int pw_size = strlen(passwd);
-		DEBUG("SCD: Passwd form UI: %s, size: %d", passwd, pw_size);
-		// register callback handler
+		case CONTAINER_TOKEN_TYPE_DEVICE: {
+			TRACE("Using token type DEVICE");
+			out.has_token_type = true;
+			out.token_type = smartcard_tokentype_to_proto(DEVICE);
+		} break;
 
-		// TODO register timer if socket does not respond
-		event_io_t *event = event_io_new(smartcard->sock, EVENT_IO_READ,
-						 smartcard_cb_start_container, startdata);
-		event_add_io(event);
-		DEBUG("SCD: Registered start container callback for key from scd");
-		// unlock token
-		DaemonToToken out = DAEMON_TO_TOKEN__INIT;
-		out.code = DAEMON_TO_TOKEN__CODE__UNLOCK;
-		out.token_pin = mem_strdup(passwd);
-		protobuf_send_message(smartcard->sock, (ProtobufCMessage *)&out);
-		mem_free(out.token_pin);
-	} break;
-	case CONTAINER_TOKEN_TYPE_USB: {
-		int resp_fd = control_get_client_sock(startdata->control);
-		// TODO implement
-		key = usb_token_get_key(passwd);
-		if (NULL == key) {
-			ERROR("Unlocking the token failed.");
-			control_send_message(CONTROL_RESPONSE_CONTAINER_START_UNLOCK_FAILED,
-					     resp_fd);
-			mem_free(start_data);
+		case CONTAINER_TOKEN_TYPE_USB: {
+			TRACE("Using token type USB");
+			out.has_token_type = true;
+			out.token_type = smartcard_tokentype_to_proto(USB);
+		} break;
+
+		default: {
+			ERROR("Token type not supported!");
+			mem_free(startdata);
 			return -1;
 		}
-		smartcard_start_container_internal(startdata, key, keylen);
-		mem_free(startdata);
-	} break;
-	default: {
-		ERROR("Token type not supported!");
-		mem_free(startdata);
-		return -1;
 	}
+
+	DEBUG("Smartcard token type: %d", out.token_type);
+
+	if (LOGF_PRIO_TRACE >= LOGF_LOG_MIN_PRIO) {
+		char *msg_text = protobuf_c_text_to_string((ProtobufCMessage *)&out, NULL);
+		TRACE("Sending DaemonToToken message:\n%s", msg_text ? msg_text : "NULL");
+		if (msg_text)
+			free(msg_text);
+	}
+
+	protobuf_send_message(smartcard->sock, (ProtobufCMessage *)&out);
+	mem_free(out.token_pin);
+	mem_free(out.pairing_secret.data);
 
 	return 0;
 }

--- a/daemon/smartcard.c
+++ b/daemon/smartcard.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of trust|me
- * Copyright(c) 2013 - 2017 Fraunhofer AISEC
+ * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -250,28 +250,50 @@ smartcard_container_start_handler(smartcard_t *smartcard, control_t *control,
 	ASSERT(smartcard);
 	ASSERT(control);
 	ASSERT(container);
-	ASSERT(passwd);
 
-	int pw_size = strlen(passwd);
-	DEBUG("SCD: Passwd form UI: %s, size: %d", passwd, pw_size);
-
-	// register callback handler
 	smartcard_startdata_t *startdata = mem_alloc(sizeof(smartcard_startdata_t));
 	startdata->smartcard = smartcard;
 	startdata->container = container;
 	startdata->control = control;
 
-	// TODO register timer if socket does not respond
-	event_io_t *event = event_io_new(smartcard->sock, EVENT_IO_READ,
-					 smartcard_cb_start_container, startdata);
-	event_add_io(event);
-	DEBUG("SCD: Registered start container callback for key from scd");
-	// unlock token
-	DaemonToToken out = DAEMON_TO_TOKEN__INIT;
-	out.code = DAEMON_TO_TOKEN__CODE__UNLOCK;
-	out.token_pin = mem_strdup(passwd);
-	protobuf_send_message(smartcard->sock, (ProtobufCMessage *)&out);
-	mem_free(out.token_pin);
+
+	switch (container_get_token_type(container)) {
+	case CONTAINER_TOKEN_TYPE_DEVICE: {
+		int pw_size = strlen(passwd);
+		DEBUG("SCD: Passwd form UI: %s, size: %d", passwd, pw_size);
+		// register callback handler
+
+		// TODO register timer if socket does not respond
+		event_io_t *event = event_io_new(smartcard->sock, EVENT_IO_READ,
+						 smartcard_cb_start_container, startdata);
+		event_add_io(event);
+		DEBUG("SCD: Registered start container callback for key from scd");
+		// unlock token
+		DaemonToToken out = DAEMON_TO_TOKEN__INIT;
+		out.code = DAEMON_TO_TOKEN__CODE__UNLOCK;
+		out.token_pin = mem_strdup(passwd);
+		protobuf_send_message(smartcard->sock, (ProtobufCMessage *)&out);
+		mem_free(out.token_pin);
+	} break;
+	case CONTAINER_TOKEN_TYPE_USB: {
+		int resp_fd = control_get_client_sock(startdata->control);
+		// TODO implement
+		key = usb_token_get_key(passwd);
+		if (NULL == key) {
+			ERROR("Unlocking the token failed.");
+			control_send_message(CONTROL_RESPONSE_CONTAINER_START_UNLOCK_FAILED,
+					     resp_fd);
+			mem_free(start_data);
+			return -1;
+		}
+		smartcard_start_container_internal(startdata, key, keylen);
+		mem_free(startdata);
+	} break;
+	default: {
+		ERROR("Token type not supported!");
+		mem_free(startdata);
+		return -1;
+	}
 
 	return 0;
 }

--- a/daemon/smartcard.h
+++ b/daemon/smartcard.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of trust|me
- * Copyright(c) 2013 - 2017 Fraunhofer AISEC
+ * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -34,6 +34,12 @@ typedef struct smartcard smartcard_t;
  */
 smartcard_t *
 smartcard_new(const char *path);
+
+/**
+ * Choice of supported token types.
+ * Must be kept in sync with scd.proto
+ */
+typedef enum smartcard_tokentype { NONE, DEVICE, USB } smartcard_tokentype_t;
 
 int
 smartcard_container_start_handler(smartcard_t *smartcard, control_t *control,

--- a/daemon/uevent.c
+++ b/daemon/uevent.c
@@ -67,12 +67,14 @@ struct uevent_usbdev {
 	int major;
 	int minor;
 	bool assign;
+	uevent_usbdev_type_t type;	
 };
 
 uevent_usbdev_t *
-uevent_usbdev_new(uint16_t id_vendor, uint16_t id_product, char *i_serial, bool assign)
+uevent_usbdev_new(uevent_usbdev_type_t type, uint16_t id_vendor, uint16_t id_product, char *i_serial, bool assign)
 {
 	uevent_usbdev_t *usbdev = mem_new0(uevent_usbdev_t, 1);
+	usbdev->type = type;
 	usbdev->id_vendor = id_vendor;
 	usbdev->id_product = id_product;
 	usbdev->i_serial = mem_strdup(i_serial);

--- a/daemon/uevent.h
+++ b/daemon/uevent.h
@@ -37,6 +37,13 @@
 
 #define UEVENT_BUF_LEN 64 * 1024
 
+
+
+typedef enum uevent_usbdev_type {
+	UEVENT_USBDEV_TYPE_GENERIC = 1,
+	UEVENT_USBDEV_TYPE_TOKEN
+} uevent_usbdev_type_t;
+
 /**
  * Structure to define the mapping of event to usb device
 
@@ -48,7 +55,7 @@
 typedef struct uevent_usbdev uevent_usbdev_t;
 
 uevent_usbdev_t *
-uevent_usbdev_new(uint16_t id_vendor, uint16_t id_product, char *i_serial, bool assign);
+uevent_usbdev_new(uevent_usbdev_type_t type, uint16_t id_vendor, uint16_t id_product, char *i_serial, bool assign);
 
 uint16_t
 uevent_usbdev_get_id_vendor(uevent_usbdev_t *usbdev);

--- a/scd/Makefile
+++ b/scd/Makefile
@@ -42,6 +42,7 @@ SRC_FILES := \
 	scd.pb-c.c \
 	control.c \
 	softtoken.c \
+	usbtoken.c \
 	scd.c \
 	ssl_util.c
 
@@ -60,7 +61,7 @@ libcommon:
 	$(MAKE) -C common libcommon
 
 scd: libcommon ${SRC_FILES}
-	${CC} ${LOCAL_CFLAGS} ${SRC_FILES} -lc -lprotobuf-c -lprotobuf-c-text -lssl -lcrypto -Lcommon -lcommon -o scd
+	${CC} ${LOCAL_CFLAGS} ${SRC_FILES} -lc -lprotobuf-c -lprotobuf-c-text -lssl -lcrypto -Lcommon -lcommon -lctccid -lcardservice -o scd
 
 
 .PHONY: clean

--- a/scd/control.c
+++ b/scd/control.c
@@ -28,10 +28,12 @@
 #include "scd.pb-c.h"
 #endif
 
+#include "usbtoken.h"
 #include "softtoken.h"
 #include "ssl_util.h"
 #include "scd.h"
 
+#define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE
 #include "common/macro.h"
 #include "common/mem.h"
 #include "common/sock.h"
@@ -166,6 +168,8 @@ do_signature:
 static void
 scd_control_handle_message(const DaemonToToken *msg, int fd)
 {
+	TRACE("SCD: Handle messsage");
+
 	if (NULL == msg) {
 		WARN("msg=NULL, returning");
 		return;
@@ -180,22 +184,26 @@ scd_control_handle_message(const DaemonToToken *msg, int fd)
 
 	switch (msg->code) {
 	case DAEMON_TO_TOKEN__CODE__UNLOCK: {
+		TRACE("SCD: Handle messsage UNLOCK");
 		TokenToDaemon out = TOKEN_TO_DAEMON__INIT;
 		out.code = TOKEN_TO_DAEMON__CODE__UNLOCK_FAILED;
 
-		softtoken_t *token = scd_get_token();
+		scd_token_t *token = scd_get_token(msg);
+
 		if (!token) {
 			ERROR("No token loaded, unlock failed");
 		} else if (!msg->token_pin) {
 			ERROR("Token passphrase not specified");
-		} else if (softtoken_is_locked_till_reboot(token)) {
+		} else if (token->is_locked_till_reboot(token)) {
 			out.code = TOKEN_TO_DAEMON__CODE__LOCKED_TILL_REBOOT;
 		} else {
-			int ret = softtoken_unlock(token, msg->token_pin);
+			int ret = token->unlock(token, msg->token_pin,
+									msg->pairing_secret.data,
+									msg->pairing_secret.len);
 			if (ret == 0)
 				out.code = TOKEN_TO_DAEMON__CODE__UNLOCK_SUCCESSFUL;
 			else if (ret == -2) {
-				if (softtoken_is_locked_till_reboot(token))
+				if (token->is_locked_till_reboot(token))
 					out.code = TOKEN_TO_DAEMON__CODE__LOCKED_TILL_REBOOT;
 				else
 					out.code = TOKEN_TO_DAEMON__CODE__PASSWD_WRONG;
@@ -206,32 +214,36 @@ scd_control_handle_message(const DaemonToToken *msg, int fd)
 		protobuf_send_message(fd, (ProtobufCMessage *)&out);
 	} break;
 	case DAEMON_TO_TOKEN__CODE__LOCK: {
+		TRACE("SCD: Handle messsage LOCK");
 		TokenToDaemon out = TOKEN_TO_DAEMON__INIT;
 		out.code = TOKEN_TO_DAEMON__CODE__LOCK_FAILED;
 
-		softtoken_t *token = scd_get_token();
+		scd_token_t *token = scd_get_token(msg);
 		if (!token) {
 			ERROR("No token loaded, lock failed");
-		} else if (softtoken_lock(token) == 0) {
+		} else if (token->lock(token) == 0) {
 			out.code = TOKEN_TO_DAEMON__CODE__LOCK_SUCCESSFUL;
 		}
 
 		protobuf_send_message(fd, (ProtobufCMessage *)&out);
 	} break;
 	case DAEMON_TO_TOKEN__CODE__WRAP_KEY: {
+		TRACE("SCD: Handle messsage WRAP_KEY");
 		int wrapped_key_len;
 		unsigned char *wrapped_key;
 		TokenToDaemon out = TOKEN_TO_DAEMON__INIT;
 		out.code = TOKEN_TO_DAEMON__CODE__WRAPPED_KEY;
 
-		softtoken_t *token = scd_get_token();
+		scd_token_t *token = scd_get_token(msg);
 		if (!token) {
 			ERROR("No token loaded, wrap failed");
-		} else if (softtoken_is_locked(token)) {
+		} else if (token->is_locked(token)) {
 			ERROR("Token is locked. Unlock first.");
 		} else if (!msg->has_unwrapped_key) {
 			ERROR("Unwrapped key not specified.");
-		} else if (softtoken_wrap_key(token, msg->unwrapped_key.data,
+		} else if (token->wrap_key(token,
+						  msg->container_uuid,
+						  msg->unwrapped_key.data,
 					      msg->unwrapped_key.len, &wrapped_key,
 					      &wrapped_key_len) == 0) {
 			out.has_wrapped_key = true;
@@ -246,20 +258,22 @@ scd_control_handle_message(const DaemonToToken *msg, int fd)
 			mem_free(wrapped_key);
 	} break;
 	case DAEMON_TO_TOKEN__CODE__UNWRAP_KEY: {
+		TRACE("SCD: Handle messsage UNWRAP_KEY");
 		int unwrapped_key_len;
 		unsigned char *unwrapped_key;
 		TokenToDaemon out = TOKEN_TO_DAEMON__INIT;
 		out.code = TOKEN_TO_DAEMON__CODE__UNWRAPPED_KEY;
 
-		softtoken_t *token = scd_get_token();
+		scd_token_t *token = scd_get_token(msg);
 		if (!token) {
 			ERROR("No token loaded, unwrap failed");
-		} else if (softtoken_is_locked(token)) {
+		} else if (token->is_locked(token)) {
 			ERROR("Token is locked. Unlock first.");
 		} else if (!msg->has_wrapped_key) {
 			ERROR("Wrapped key not specified.");
-		} else if (softtoken_unwrap_key(token, msg->wrapped_key.data, msg->wrapped_key.len,
-						&unwrapped_key, &unwrapped_key_len) == 0) {
+		} else if (token->unwrap_key(token, msg->container_uuid,
+					msg->wrapped_key.data, msg->wrapped_key.len,
+					&unwrapped_key, &unwrapped_key_len) == 0) {
 			out.has_unwrapped_key = true;
 			out.unwrapped_key.len = unwrapped_key_len;
 			out.unwrapped_key.data = unwrapped_key;
@@ -272,18 +286,19 @@ scd_control_handle_message(const DaemonToToken *msg, int fd)
 			mem_free(unwrapped_key);
 	} break;
 	case DAEMON_TO_TOKEN__CODE__CHANGE_PIN: {
+		TRACE("SCD: Handle messsage CHANGE_PIN");
 		TokenToDaemon out = TOKEN_TO_DAEMON__INIT;
 		out.code = TOKEN_TO_DAEMON__CODE__CHANGE_PIN_FAILED;
 
-		softtoken_t *token = scd_get_token();
+		scd_token_t *token = scd_get_token(msg);
 		if (!token) {
 			ERROR("No token loaded, change pass failed");
 		} else if (!msg->token_pin) {
 			ERROR("Token passphrase not specified");
-		} else if (softtoken_is_locked_till_reboot(token)) {
+		} else if (token->is_locked_till_reboot(token)) {
 			out.code = TOKEN_TO_DAEMON__CODE__LOCKED_TILL_REBOOT;
 		} else {
-			int ret = softtoken_change_passphrase(token, msg->token_pin,
+			int ret = token->change_passphrase(token, msg->token_pin,
 							      msg->token_newpin);
 			if (ret == 0)
 				out.code = TOKEN_TO_DAEMON__CODE__CHANGE_PIN_SUCCESSFUL;
@@ -294,6 +309,7 @@ scd_control_handle_message(const DaemonToToken *msg, int fd)
 		protobuf_send_message(fd, (ProtobufCMessage *)&out);
 	} break;
 	case DAEMON_TO_TOKEN__CODE__PULL_DEVICE_CSR: {
+		TRACE("SCD: Handle messsage PULL_DEV_CSR");
 		uint8_t *csr = NULL;
 		int csr_len = 0;
 		TokenToDaemon out = TOKEN_TO_DAEMON__INIT;
@@ -319,6 +335,7 @@ scd_control_handle_message(const DaemonToToken *msg, int fd)
 			mem_free(csr);
 	} break;
 	case DAEMON_TO_TOKEN__CODE__PUSH_DEVICE_CERT: {
+		TRACE("SCD: Handle messsage PUSH_DEV_CERT");
 		TokenToDaemon out = TOKEN_TO_DAEMON__INIT;
 		if (!scd_in_provisioning_mode()) {
 			out.code = TOKEN_TO_DAEMON__CODE__DEVICE_PROV_ERROR;
@@ -335,6 +352,7 @@ scd_control_handle_message(const DaemonToToken *msg, int fd)
 		protobuf_send_message(fd, (ProtobufCMessage *)&out);
 	} break;
 	case DAEMON_TO_TOKEN__CODE__CRYPTO_HASH_FILE: {
+		TRACE("SCD: Handle messsage CRYPTO_HASH_FILE");
 		unsigned int hash_len;
 		char *hash_algo;
 		unsigned char *hash = NULL;
@@ -359,6 +377,7 @@ scd_control_handle_message(const DaemonToToken *msg, int fd)
 			mem_free(hash);
 	} break;
 	case DAEMON_TO_TOKEN__CODE__CRYPTO_VERIFY_FILE: {
+		TRACE("SCD: Handle messsage CRYPTO_VERIFY_FILE");
 		TokenToDaemon out = TOKEN_TO_DAEMON__INIT;
 		out.code = scd_control_handle_verify(msg);
 		protobuf_send_message(fd, (ProtobufCMessage *)&out);

--- a/scd/ssl_util.c
+++ b/scd/ssl_util.c
@@ -57,6 +57,8 @@
 /* Cipher for device CSR private key encryption */
 #define CIPHER_PW_CSR SN_aes_256_cbc
 #define CIPHER_KEY_WRAP SN_aes_256_cbc
+/* Cipher for key wrapping with symmetric key */
+#define CIPHER_KEY_WRAP_SKEY SN_id_aes256_wrap
 /* RSA key size when keypair is created */
 #define RSA_KEY_SIZE_MKKEYP 4096
 
@@ -663,6 +665,142 @@ ssl_unwrap_key(EVP_PKEY *pkey, const unsigned char *wrapped_key, size_t wrapped_
 cleanup:
 	EVP_CIPHER_CTX_free(ctx);
 	return res;
+}
+
+int
+ssl_wrap_key_sym(const unsigned char *kek, const unsigned char *plain_key, size_t plain_key_len,
+	     unsigned char **wrapped_key, int *wrapped_key_len)
+{
+	ASSERT(kek);
+	ASSERT(plain_key);
+	ASSERT(wrapped_key);
+	ASSERT(wrapped_key_len);
+
+	int res = -1;
+	int tmplen = 0;
+	int outlen = 0;
+	const EVP_CIPHER *type;
+
+	if (!(type = EVP_get_cipherbyname(CIPHER_KEY_WRAP_SKEY))) {
+		ERROR("Error setting up cipher for key wrap");
+		return res;
+	}
+
+	EVP_CIPHER_CTX *ctx;
+	if ((ctx = EVP_CIPHER_CTX_new()) == NULL) {
+		ERROR("Allocating EVP cipher failed!");
+		return res;
+	}
+
+	/* see https://mta.openssl.org/pipermail/openssl-users/2018-May/007998.html */
+	EVP_CIPHER_CTX_set_flags(ctx, EVP_CIPHER_CTX_FLAG_WRAP_ALLOW);
+
+	/* TODO: set proper iv */
+	DEBUG("IV length used: %d", EVP_CIPHER_iv_length(type));
+
+	/**
+	 * static default IV as defined in RFC 3394 
+	 * TODO: investigate whether a random IV which is passed along with the
+	 * 			wrapped key is possible and desirable
+	 */
+	unsigned char iv[] = {0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6};
+
+	/* TODO: investigate whether more space may be required */ 
+	unsigned char *out = mem_alloc(plain_key_len + EVP_CIPHER_block_size(type));
+
+   if(1 != EVP_EncryptInit_ex(ctx, type, NULL, kek, iv)) {
+        ERROR("EVP_EncryptInit_ex failed");
+		goto cleanup;
+	}
+
+   if(1 != EVP_EncryptUpdate(ctx, out, &tmplen, plain_key, plain_key_len)) {
+        ERROR("EVP_EncryptUpdate failed");
+		goto cleanup;
+	}
+	outlen = tmplen;
+
+   if(1 != EVP_EncryptFinal_ex(ctx, out + tmplen, &tmplen)) {
+		ERROR("EVP_EncryptFinal_ex failed");
+		goto cleanup;
+	}
+    outlen += tmplen;
+
+	*wrapped_key_len = outlen;
+	*wrapped_key = out;
+
+	res = 0;
+
+cleanup:
+    EVP_CIPHER_CTX_free(ctx);
+	return res;
+}
+
+
+int
+ssl_unwrap_key_sym(const unsigned char *kek, const unsigned char *wrapped_key, size_t wrapped_key_len,
+	       unsigned char **plain_key, int *plain_key_len)
+{
+	ASSERT(kek);
+	ASSERT(plain_key);
+	ASSERT(wrapped_key);
+	ASSERT(wrapped_key_len);
+
+	int res = -1;
+	int tmplen = 0;
+	int outlen = 0;
+	const EVP_CIPHER *type;
+
+	if (!(type = EVP_get_cipherbyname(CIPHER_KEY_WRAP_SKEY))) {
+		ERROR("Error setting up cipher for key wrap");
+		return res;
+	}
+
+	EVP_CIPHER_CTX *ctx;
+	if ((ctx = EVP_CIPHER_CTX_new()) == NULL) {
+		ERROR("Allocating EVP cipher failed!");
+		return res;
+	}
+
+	/* see https://mta.openssl.org/pipermail/openssl-users/2018-May/007998.html */
+	EVP_CIPHER_CTX_set_flags(ctx, EVP_CIPHER_CTX_FLAG_WRAP_ALLOW);
+
+	/**
+	 * static default IV as defined in RFC 3394 
+	 * TODO: investigate whether a random IV which is passed along with the
+	 * 			wrapped key is desirable and possible
+	 */
+	unsigned char iv[] = {0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6};
+
+	/* TODO: investigate whether more space may be required */ 
+	unsigned char *out = mem_alloc(wrapped_key_len + EVP_CIPHER_block_size(type));
+
+   if(1 != EVP_DecryptInit_ex(ctx, type, NULL, kek, iv)) {
+        ERROR("EVP_DecryptInit_ex failed");
+		goto cleanup;
+	}
+
+   if(1 != EVP_DecryptUpdate(ctx, out, &tmplen, wrapped_key, wrapped_key_len)) {
+        ERROR("EVP_DecryptUpdate failed");
+		goto cleanup;
+	}
+	outlen = tmplen;
+
+   if(1 != EVP_DecryptFinal_ex(ctx, out + tmplen, &tmplen)) {
+		ERROR("EVP_DecryptFinal_ex failed");
+		goto cleanup;
+	}
+    outlen += tmplen;
+
+	*plain_key_len = outlen;
+	*plain_key = out;
+
+	res = 0;
+
+
+cleanup:
+    EVP_CIPHER_CTX_free(ctx);
+	return res;
+
 }
 
 int

--- a/scd/ssl_util.h
+++ b/scd/ssl_util.h
@@ -67,6 +67,26 @@ int
 ssl_unwrap_key(EVP_PKEY *pkey, const unsigned char *wrapped_key, size_t wrapped_key_len,
 	       unsigned char **plain_key, int *plain_key_len);
 
+
+/**
+ * This function wraps a (symmetric) key plain_key of length plain_key_len into a wrapped key wrapped_key
+ * of length wrapped_key_len using a symmetric key wr_key.
+ * @return returns 0 on succes, -1 in case of a failure. */
+int
+ssl_wrap_key_sym(const unsigned char *kek, const unsigned char *plain_key, size_t plain_key_len,
+	     unsigned char **wrapped_key, int *wrapped_key_len);
+
+
+/**
+ * This function unwraps a (symmetric) key wrapped_key of length wrapped_key_len into an unwrapped key
+ * plain_key of length plain_key_len using the symmetric wrapping key wr_key.
+ * @return returns 0 on succes, -1 in case of a failure. */
+int
+ssl_unwrap_key_sym(const unsigned char *kek, const unsigned char *wrapped_key, size_t wrapped_key_len,
+	       unsigned char **plain_key, int *plain_key_len);
+
+
+
 /**
  * this function verifies a certificate located in test_cert_file using
  * the root certificate in root_cert_file.

--- a/scd/token.c
+++ b/scd/token.c
@@ -1,0 +1,225 @@
+/*
+ * This file is part of trust|me
+ * Copyright(c) 2013 - 2017 Fraunhofer AISEC
+ * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 (GPL 2), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * The full GNU General Public License is included in this distribution in
+ * the file called "COPYING".
+ *
+ * Contact Information:
+ * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ */
+
+#if 0
+#include "token.h"
+#include "softtoken.h"
+#include "usbtoken.h"
+
+#include "common/macro.h"
+#include "common/mem.h"
+
+
+
+
+
+/*****************************************************************************/
+/******************* internal Helper functions *******************************/
+/*****************************************************************************/
+
+/**
+ * TODO: investigate whether error handling and/or input sanitazion is needed
+ */
+
+int
+int_lock_st(scd_token_t *token) {
+    return softtoken_lock(token->int_token.softtoken);
+}
+
+int
+int_unlock_st(scd_token_t *token, char *passwd) {
+    return softtoken_unlock(token->int_token.softtoken, passwd);
+}
+
+bool
+int_is_locked_st(scd_token_t *token) {
+    return softtoken_is_locked(token->int_token.softtoken);
+}
+
+bool
+int_is_locked_till_reboot_st(scd_token_t *token) {
+    return softtoken_is_locked_till_reboot(token->int_token.softtoken);
+}
+
+int
+int_wrap_st(scd_token_t *token, unsigned char *label, size_t label_len,
+			unsigned char *plain_key, size_t plain_key_len,
+			unsigned char **wrapped_key, int *wrapped_key_len)
+{   
+    ASSERT(label);
+    ASSERT(label_len);
+
+    return softtoken_wrap_key(token->int_token.softtoken, plain_key, plain_key_len,
+                              wrapped_key, wrapped_key_len);
+}
+
+int
+int_unwrap_st(scd_token_t *token, unsigned char *label, size_t label_len,
+                unsigned char *wrapped_key, size_t wrapped_key_len,
+		        unsigned char **plain_key, int *plain_key_len)
+{  
+    ASSERT(label);
+    ASSERT(label_len);
+    
+    return softtoken_unwrap_key(token->int_token.softtoken, wrapped_key,
+                                wrapped_key_len, plain_key, plain_key_len);
+}
+
+/*  -----------------------------------------------------------------------  */
+int
+int_lock_usb(scd_token_t *token) {
+    return usbtoken_lock(token->int_token.usbtoken);
+}
+
+int
+int_unlock_usb(scd_token_t *token, char *passwd) {
+    DEBUG("1");
+    return usbtoken_unlock(token->int_token.usbtoken, passwd);
+}
+
+bool
+int_is_locked_usb(scd_token_t *token) {
+    return usbtoken_is_locked(token->int_token.usbtoken);
+}
+
+bool
+int_is_locked_till_reboot_usb(scd_token_t *token) {
+    return usbtoken_is_locked_till_reboot(token->int_token.usbtoken);
+}
+
+int
+int_wrap_usb(scd_token_t *token, unsigned char *label, size_t label_len,
+			unsigned char *plain_key, size_t plain_key_len,
+			unsigned char **wrapped_key, int *wrapped_key_len)
+{   
+    return usbtoken_wrap_key(token->int_token.usbtoken, label, label_len,
+                            plain_key, plain_key_len,
+                            wrapped_key, wrapped_key_len);
+}
+
+int
+int_unwrap_usb(scd_token_t *token, unsigned char *label, size_t label_len,
+                unsigned char *wrapped_key, size_t wrapped_key_len,
+		        unsigned char **plain_key, int *plain_key_len)
+{   
+    return usbtoken_unwrap_key(token->int_token.usbtoken, label, label_len,
+                                wrapped_key, wrapped_key_len,
+                                plain_key, plain_key_len);
+}
+
+
+scd_tokentype_t
+scd_token_get_type(scd_token_t *token) {
+    return token->type;
+}
+
+/**
+ * creates a new generic token
+ * calls the respective create function for the selected type of token and
+ * sets the function pointer appropriately
+ */
+
+scd_token_t *
+scd_token_create(scd_tokentype_t type, const char *softtoken_dir) {
+
+    // ASSERT(filename); // TODO: only needed if softtoken
+
+    scd_token_t *new_token;
+    int rc;
+
+
+    new_token = mem_new0(scd_token_t, 1);
+    if (!new_token) {
+        ERROR("Could not allocate new scd_token_t");
+        return NULL;
+    }
+
+    switch (type) {
+        case (NONE): {
+            WARN("Create scd_token with internal type 'NONE' selected");
+            new_token->type       = NONE;
+            break;
+        }
+        case (DEVICE): {
+            DEBUG("Create scd_token with internal type 'DEVICE'");
+            new_token->int_token.softtoken = softtoken_new_from_p12(filename);
+            if (!new_token->int_token.softtoken) {
+                ERROR("Creation of softtoken failed");
+                mem_free(new_token);
+                return NULL;
+            }
+            new_token->type       = DEVICE;
+            new_token->lock       = int_lock_st;
+            new_token->unlock     = int_unlock_st;
+            new_token->is_locked  = int_is_locked_st;
+            new_token->is_locked_till_reboot = int_is_locked_till_reboot_st;
+            new_token->wrap_key   = int_wrap_st;
+            new_token->unwrap_key  = int_unwrap_st;
+            break;
+        }
+        case (USB): {
+            DEBUG("Create scd_token with internal type 'USB'");
+            new_token->int_token.usbtoken = usbtoken_init();
+            ASSERT(new_token->int_token.usbtoken);
+            if (NULL == new_token->int_token.usbtoken) {
+                ERROR("Creation of usbtoken failed");
+                mem_free(new_token);
+                return NULL;
+            }
+            new_token->type       = USB;
+            new_token->lock       = int_lock_usb;
+            new_token->unlock     = int_unlock_usb;
+            new_token->is_locked  = int_is_locked_usb;
+            new_token->is_locked_till_reboot = int_is_locked_till_reboot_usb;
+            new_token->wrap_key   = int_wrap_usb;
+            new_token->unwrap_key  = int_unwrap_usb;
+            break;
+        }
+        default: {
+            ERROR("Unrecognized token type");
+            mem_free(new_token);
+            return NULL;
+        }
+    }
+    return new_token;
+}
+
+void scd_token_free(scd_token_t *token) {
+
+    /* TODO */
+    switch (token->type) {
+        case (NONE): break;
+        case (DEVICE):
+            softtoken_free(token->int_token.softtoken);
+            break;
+        case (USB):
+            usbtoken_free(token->int_token.usbtoken);
+            break;
+        default:
+            ERROR("Failed to determine token type. Cannot clean up");
+            return;
+    }
+    mem_free(token);
+}
+
+#endif

--- a/scd/token.h
+++ b/scd/token.h
@@ -1,0 +1,72 @@
+#if 0
+
+#ifndef TOKEN_H
+#define TOKEN_H
+
+#include <stdbool.h>
+
+#include "softtoken.h"
+#include "usbtoken.h"
+
+/**
+ *  Generic token type
+ */
+typedef struct scd_token scd_token_t;
+
+/**
+ * Choice of supported token types.
+ * Must be kept in sync with scd.proto
+ */
+typedef enum scd_tokentype { NONE, DEVICE, USB } scd_tokentype_t;
+
+
+typedef union{
+    softtoken_t *softtoken;
+    usbtoken_t *usbtoken;
+} int_token_t;
+
+/**
+ * TODO: create a unifying structure for scd_token
+ */
+struct scd_token {
+    
+    int_token_t int_token;
+    scd_tokentype_t type;
+
+//    int (*init) (scd_token_t *token);
+
+    int (*lock) (scd_token_t *token);
+    int (*unlock) (scd_token_t *token, char *passwd);
+
+    bool (*is_locked) (scd_token_t *token);
+    bool (*is_locked_till_reboot) (scd_token_t *token);
+
+    int (*wrap_key) (scd_token_t *token, unsigned char *label, size_t label_len,
+				  unsigned char *plain_key, size_t plain_key_len,
+				  unsigned char **wrapped_key, int *wrapped_key_len);
+
+    int (*unwrap_key) (scd_token_t *token, unsigned char *label, size_t label_len,
+                       unsigned char *wrapped_key, size_t wrapped_key_len,
+		               unsigned char **plain_key, int *plain_key_len);
+
+//    void (*free) (scd_token_t *token);
+};
+
+/** 
+ * Initializes a generic token
+ * TODO: needs all the inputs to create any of the supported types
+ */
+scd_token_t *
+scd_token_create(scd_tokentype_t type, const char *softtoken_dir);
+
+scd_tokentype_t
+scd_token_get_type(scd_token_t *token);
+
+/**
+ * frees a token structure
+ */
+void
+scd_token_free(scd_token_t *token);
+
+#endif
+#endif

--- a/scd/usbtoken.c
+++ b/scd/usbtoken.c
@@ -1,0 +1,494 @@
+/*
+ * This file is part of trust|me
+ * Copyright(c) 2013 - 2020 Fraunhofer AISEC
+ * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 (GPL 2), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * The full GNU General Public License is included in this distribution in
+ * the file called "COPYING".
+ *
+ * Contact Information:
+ * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ */
+
+#include "usbtoken.h"
+#include "ssl_util.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE
+#include "common/macro.h"
+
+#include "common/mem.h"
+#include "common/file.h"
+
+#include <ctapi.h>
+
+#include "sc-hsm-cardservice.h"
+
+#define TOKEN_MAX_AUTH_CODE_LEN 16
+#define TOKEN_KEY_LEN 32 /* must be coordonated with ssl_util.c */
+
+/* TODO: investigate enforcement done by hardware token */
+#define USBTOKEN_MAX_WRONG_UNLOCK_ATTEMPTS 3 
+
+
+static unsigned char requesticc[] = {0x20,0x12,0x00,0x01,0x00};
+
+struct usbtoken {
+	/* Identify the usb device to be used */
+	// int major;
+	// int minor;
+	// char *serial;
+
+	int ctn;				// card terminal number
+
+	bool locked;			// whether the token is locked or not
+	unsigned wrong_unlock_attempts; // wrong consecutive password attempts
+};
+
+/*
+ * Dump the memory pointed to by <mem>
+ * TODO: remove
+ */
+static void dump(unsigned char *mem, int len)
+{
+	while(len--) {
+		printf("%02x", *mem);
+		mem++;
+	}
+
+	printf("\n");
+}
+
+/*
+ * Request card
+ *
+ */
+static int requestICC(int ctn)
+{
+	unsigned char Brsp[260];
+	unsigned short lr;
+	unsigned char dad, sad;
+	int rc;
+
+	TRACE("USBTOKEN: requestICC");
+
+	dad = 1;   /* Reader */
+	sad = 2;   /* Host */
+	lr = sizeof(Brsp);
+
+	rc = CT_data((unsigned short)ctn, &dad, &sad, sizeof(requesticc),
+                    (unsigned char *) &requesticc, &lr, Brsp);
+	if (rc != OK) {
+		ERROR("CT_data failedwith code: %d", rc);
+		return rc;
+	}				
+
+	DEBUG("USBTOKEN: ATR: ");
+	dump(Brsp, lr);
+
+	if((Brsp[0] == 0x64) || (Brsp[0] == 0x62)) {
+		ERROR("No card present or card reset error");
+		return -1;
+	}
+
+	return 0;
+}
+
+/**
+ * Produce a key value by derivation from the master key
+ *
+ * @param ctn the card terminal number
+ * @param label he derivation parameter (aka label), must NOT be NULL
+ * @return < 0 for error or 0
+ * 
+ * TODO: make params const where possible
+ */
+static int produceKey(int ctn, unsigned char *label, size_t label_len,
+                        unsigned char *key, size_t key_len)
+{
+	int rc;
+
+	TRACE("USBTOKEN: produceKey");
+
+	unsigned char def_label[] = "disk1";
+
+	if ((NULL == label) || (0 == label_len)) {
+		WARN("USBTOKEN: no 'label' provided for key derivation; using default label");
+		rc = deriveKey(ctn, 1, def_label, sizeof(def_label), key, key_len);
+	} else {
+		rc = deriveKey(ctn, 1, label, label_len, key, key_len);
+	}
+
+	if (rc < 0) {
+		ERROR("USBTOKEN: deriveKey failed");
+		return rc;
+	}
+
+    DEBUG("Usbtoken generated key:");
+	dump(key, key_len); /* TODO: remove */
+
+	return 0;
+}
+
+/**
+ * Report the status of the PIN
+ *
+ * @param sw the SW1/SW2 status word returned by the VERIFY or CHANGE REFERENCE DATA command
+ */
+static void reportPinStatus(int sw) {
+	switch(sw) {
+	case 0x6700:
+		DEBUG("USBTOKEN: Wrong PIN length. Pairing secret missing ?");
+		break;
+	case 0x6983:
+		DEBUG("USBTOKEN: PIN blocked");
+		break;
+	case 0x6984:
+		DEBUG("USBTOKEN: PIN in transport state");
+		break;
+	default:
+		if ((sw & 0x63C0) == 0x63C0) {
+			int rc = sw & 0xF;
+
+			if (rc > 1) {
+				ERROR("USBTOKEN: PIN wrong, %d tries remaining", rc);
+			} else {
+				ERROR("USBTOKEN: PIN wrong, one try remaining");
+			}
+		}
+	}
+}
+
+/**
+ * Perform user authentication, potentially including the pairing secret
+ *
+ * @param ctn the card terminal number
+ * @return < 0 for error or 0
+ * 
+ * TODO: reports false length of PIN as dedicated error. Is that really desirable?
+ */
+static int authenticateUser(int ctn, char *pin, size_t pin_len,
+                            unsigned char *pairing_secret, size_t pairing_sec_len)
+{
+	int rc, ofs;
+	unsigned char code[TOKEN_MAX_AUTH_CODE_LEN]; /* TODO: is this length limited by the token? */
+
+	TRACE("USBTOKEN: authenticateUser");
+
+	if ((pin == NULL) || (pin_len == 0)) {
+		ERROR("No PIN provided");
+		return -1;
+	}
+	
+    if ((pin_len +  pairing_sec_len) > sizeof(code) ) {
+        ERROR("PIN and pairing secret combined must not exceed %d",
+				TOKEN_MAX_AUTH_CODE_LEN);
+        return -1;
+    }
+
+    ofs = 0;
+
+	TRACE("USBTOKEN: pairing_sec_len: %d", (int) pairing_sec_len);
+	TRACE("USBTOKEN: pin_len: %d", (int) pin_len);
+	
+    if (pairing_secret != NULL) {
+		memcpy(code, pairing_secret, pairing_sec_len);
+		ofs = pairing_sec_len;
+	}
+
+	memcpy(code + ofs, (unsigned char *)pin, strlen(pin));
+	ofs += pin_len;
+
+	TRACE("USBTOKEN: Total authentication code len: %d", ofs);
+
+	rc = verifyPIN(ctn, code, ofs);
+
+	memset(code, 0, sizeof(code));
+
+	if (rc != 0x9000) {
+		reportPinStatus(rc);
+		return -1;
+	}
+
+	return 0;
+}
+
+/** 
+ * Initializes a usb token
+ * TODO: select and init only desired usb token
+ */
+usbtoken_t *
+usbtoken_init(void) {
+	unsigned short lr;
+	int rc;
+	unsigned char readers[4096],*po; /* TODO */
+	usbtoken_t *token = NULL;
+
+	TRACE("USBTOKEN: usbtoken_init");
+
+	token = mem_new0(usbtoken_t, 1);
+	ASSERT(token);
+
+	token->locked = true;
+
+	lr = sizeof(readers);
+	CT_list(readers, &lr, 0);
+
+	if (lr <= 0) {
+		ERROR("No token found.");
+		return NULL;
+	}
+
+	po = readers;
+	unsigned short port = *po << 8 | *(po + 1);
+	po += 2;
+
+	DEBUG("USBTOKEN: using token %04x : %s\n", port, po);
+
+	token->ctn = 0;
+
+	rc = CT_init(token->ctn, port);
+	requestICC(token->ctn);
+
+	rc = queryPIN(token->ctn);
+
+	if (rc != 0x9000) {
+		selectHSM(token->ctn);
+		rc = queryPIN(token->ctn);
+	}
+
+	TRACE("Usbtoken initialized");
+	return token;
+}
+
+/** scd interface to usbtoken **/
+
+int
+usbtoken_change_passphrase(usbtoken_t *token, const char *oldpass, const char *newpass)
+{
+	ASSERT(token);
+
+	TRACE("USBTOKEN: usbtoken_change_passphrase");
+
+	/* TODO */
+	ASSERT(oldpass);
+	ASSERT(newpass);
+
+//	return ssl_newpass_pkcs12_token(token->token_file, oldpass, newpass);
+	ERROR("Usbtoken PIN changing not implemented yet");
+	return -1;
+}
+
+/**
+ * Free secrets.
+ */
+static void
+usbtoken_free_secrets(usbtoken_t *token)
+{
+	ASSERT(token);
+
+	TRACE("USBTOKEN: usbtoken_free_secrets");
+	
+ 	/* TODO: are there any secrets to be freed? */
+}
+
+void
+usbtoken_free(usbtoken_t *token)
+{
+	ASSERT(token);
+
+	TRACE("USBTOKEN: usbtoken_free");
+
+	usbtoken_free_secrets(token);
+
+	mem_free(token);
+}
+
+
+/**
+ * Wraps the plain key.
+ */
+int
+usbtoken_wrap_key(usbtoken_t *token, unsigned char *label, size_t label_len,
+				  unsigned char *plain_key, size_t plain_key_len,
+				  unsigned char **wrapped_key, int *wrapped_key_len)
+{
+	ASSERT(token);
+
+	ASSERT(plain_key);
+	ASSERT(wrapped_key);
+	ASSERT(wrapped_key_len);
+	ASSERT(plain_key_len);
+
+	int rc;
+	unsigned char key[TOKEN_KEY_LEN];
+
+	TRACE("USBTOKEN: usbtoken_wrap_key");
+
+	// TODO allow wrapping (encryption with public key) even with locked token?
+	if (usbtoken_is_locked(token)) {
+		WARN("Trying to wrap key with locked token.");
+		return -1;
+	}
+
+	produceKey(token->ctn, label, label_len, key, sizeof(key));
+
+	const unsigned char *kek = key;
+	rc = ssl_wrap_key_sym(kek, plain_key, plain_key_len, wrapped_key, wrapped_key_len);
+
+	if (0 != rc) {
+		ERROR("ssl_wrap_key_sym failed");
+		return -1;
+	}
+
+	TRACE("USBTOKEN: key wrap successful");
+	return rc;
+}
+
+int
+usbtoken_unwrap_key(usbtoken_t *token, unsigned char *label, size_t label_len,
+					unsigned char *wrapped_key, size_t wrapped_key_len,
+		    		unsigned char **plain_key, int *plain_key_len)
+{
+	ASSERT(token);
+	ASSERT(wrapped_key);
+	ASSERT(plain_key);
+	ASSERT(plain_key_len);
+
+	ASSERT(wrapped_key_len);
+
+	TRACE("USBTOKEN: usbtoken_unwrap_key");
+
+	int rc;
+	unsigned char key[TOKEN_KEY_LEN];
+
+	if (usbtoken_is_locked(token)) {
+		WARN("Trying to unwrap key with locked token.");
+		return -1;
+	}
+	
+	produceKey(token->ctn, label, label_len, key, sizeof(key));
+
+	const unsigned char *kek = key;
+	TRACE("Call ssl_unwrap_unkey_sym");
+	rc = ssl_unwrap_key_sym(kek, wrapped_key, wrapped_key_len, plain_key, plain_key_len);
+
+	if (0 != rc) {
+		ERROR("ssl_unwrap_key_sym failed");
+		return -1;
+	}
+	
+	TRACE("USBTOKEN: key unwrap successful");
+	return rc;	
+}
+
+bool
+usbtoken_is_locked_till_reboot(usbtoken_t *token)
+{
+	ASSERT(token);
+	
+	TRACE("USBTOKEN: usbtoken_is_locked_till_reboot");
+
+	return token->wrong_unlock_attempts >= USBTOKEN_MAX_WRONG_UNLOCK_ATTEMPTS;
+}
+
+bool
+usbtoken_is_locked(usbtoken_t *token)
+{
+	ASSERT(token);
+	
+	TRACE("USBTOKEN: usbtoken_is_locked");
+	
+	return token->locked;
+}
+
+int
+usbtoken_available(void)
+{
+	/* TODO */
+
+	TRACE("USBTOKEN: usbtoken_is_available");
+
+	return 0;
+}
+
+int
+usbtoken_unlock(usbtoken_t *token, char *passwd, 
+				unsigned char *pairing_secret, size_t pairing_sec_len)
+{
+	ASSERT(token);
+	ASSERT(passwd);
+
+	TRACE("USBTOKEN: usbtoken_unlock");
+
+	if (!usbtoken_is_locked(token)) {
+		WARN("Token is alread unlocked, returning");
+		return 0;
+	}
+
+	if (usbtoken_is_locked_till_reboot(token)) {
+		WARN("Token is locked till reboot, returning");
+		return -1;
+	}
+
+	if (0 != usbtoken_available()) {
+		ERROR("Usb token not available!");
+		return -1;
+	}
+
+	int res = authenticateUser(token->ctn, passwd, strlen(passwd), 
+								pairing_secret, pairing_sec_len);
+	if (res == -1) {// wrong password
+		token->wrong_unlock_attempts++;
+		ERROR("Usbtoken unlock failed (wrong PW)");
+	} else if (res == 0) {
+		token->locked = false;
+		token->wrong_unlock_attempts = 0;
+		DEBUG("Usbtoken unlock successful");
+	} else {
+		ERROR("Usbtoken unlock failed");
+	}
+	// TODO what to do with wrong_unlock_attempts if unlock failed for some other reason?
+
+	if (res != 0)
+		usbtoken_free_secrets(token); // just to be sure
+
+	return res;
+}
+
+/**
+ * locks the usb token
+ * TODO: this should actually lock the HW token nad not just set a flag
+ */
+int
+usbtoken_lock(usbtoken_t *token)
+{
+	ASSERT(token);
+
+	TRACE("USBTOKEN: usbtoken_lock");
+
+	if (usbtoken_is_locked(token)) {
+		DEBUG("USBTOKEN: Token is already locked, returning.");
+		return 0;
+	}
+
+	/* TODO: actually lock hardware token */
+
+	// usbtoken_free_secrets(token);
+	token->locked = true;
+	return 0;
+}

--- a/scd/usbtoken.h
+++ b/scd/usbtoken.h
@@ -1,0 +1,98 @@
+/*
+ * This file is part of trust|me
+ * Copyright(c) 2013 - 2020 Fraunhofer AISEC
+ * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 (GPL 2), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * The full GNU General Public License is included in this distribution in
+ * the file called "COPYING".
+ *
+ * Contact Information:
+ * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ */
+
+#ifndef USBTOKEN_H
+#define USBTOKEN_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+typedef struct usbtoken usbtoken_t;
+
+/** 
+ * Initializes a usb token
+ * TODO: select and init only desired usb token
+ */
+usbtoken_t *
+usbtoken_init(void);
+
+/**
+ * unlocks a usbtoken with a password.
+ * stores the token private key in the structure
+ */
+int
+usbtoken_unlock(usbtoken_t *token, char *passwd, 
+				unsigned char *pairing_secret, size_t pairing_sec_len);
+/**
+ * locks a usbtoken by freeing the private key
+ * reference in the usbtoken
+ */
+int
+usbtoken_lock(usbtoken_t *token);
+
+/**
+ * checks whether the usbtoken is locked or not
+ */
+bool
+usbtoken_is_locked(usbtoken_t *token);
+
+/**
+ * checks whether the usbtoken is locked or not till next reboot
+ */
+bool
+usbtoken_is_locked_till_reboot(usbtoken_t *token);
+
+/**
+ * frees a usbtoken structure
+ */
+void
+usbtoken_free(usbtoken_t *token);
+
+/**
+ * wraps a symmetric container key plain_key of length plain_key_len with a
+ * symmetric key provided by the token into a wrapped key wrapped_key of
+ * length wrapped_key_len
+ */
+int
+usbtoken_wrap_key(usbtoken_t *token, unsigned char *label, size_t label_len,
+				  unsigned char *plain_key, size_t plain_key_len,
+				  unsigned char **wrapped_key, int *wrapped_key_len);
+
+/**
+ * unwraps a symmetric container key wrapped_key of length wrapped_key_len with a
+ * symmetric key provided key into the plain key plain_key of length plain_key_len
+ */
+int
+usbtoken_unwrap_key(usbtoken_t *token, unsigned char *label, size_t label_len,
+					unsigned char *wrapped_key, size_t wrapped_key_len,
+		    		unsigned char **plain_key, int *plain_key_len);
+
+/**
+ * Changes the pasphrase/pin of the underlying low level structure
+ * of the softtoken token.
+ */
+int
+usbtoken_change_passphrase(usbtoken_t *token, const char *oldpass, const char *newpass);
+
+
+#endif


### PR DESCRIPTION
This is work in progress. DO NOT MERGE!

This PR aims to enable the usage of hardware token to wrap the FDE keys for container data encryption.
It relies on the availability of a ctccid and a cardservice library. Both of which can be build from source from [1]. To facilitate the testing, a fork of meta-trustx layer can be checked out to your local workspace from [2] which already includes the necessary changes.

If trustm3 is built with the adapted meta-trustx layer the cml layer includes the "key-generator" example as described in [3].

To test the key wrapping using the usbtoken the following procedure can be applied:
1. Ensure the token is initialized with pin "trustme" and pairing secrets "ABCD". This can be done e.g. with the key-generator from the cml shell invoking 
a) "key-generator --init --transportpin 123456"
b) "key-generator --transportpin 123456 --pin trustme --pairingsecret ABCD"
The pin can also be set arbitrarily but must then match the provided pin when starting the container.
2. create an arbitrary container whose config contains the line "token_type: USB"
3. start the container

TODOs:
- The pairing secret is hard coded
    - [ ] Enable a per-token pairing secret
    - [ ] The pairing secret should be stored securely in a platform bound manner, e.g. in a TPM
- Only a single instance of each type of supported token (soft- / usbtoken) is supported
    - [ ] develop a concept for token management
- The container config does not, as of yet, reference with which of the potentially available tokens its key should be (un-)wrapped with
   - [ ] implement a way to reference a token (possibly in the container config)
 
[1] https://github.com/CardContact/sc-hsm-embedded
[2] [ceppleaisec/meta-trustx](/ceppleaisec/meta-trustx/tree/integrate_sc_hsm)
[3] https://github.com/CardContact/sc-hsm-embedded/tree/master/src/examples/key-generator