### PR TITLE
Rename network interfaces on cmld startup

### DIFF
--- a/common/network.h
+++ b/common/network.h
@@ -178,4 +178,14 @@ network_nl80211_move_ns(const char *if_name, const pid_t pid);
 int
 network_rtnet_move_ns(const char *ifi_name, const pid_t pid);
 
+/**
+ * This function renames a network interface from old_ifi_name to new_ifi_name
+ * with a netlink message using the netlink socket.
+ * @param old_ifi_name The old interface name.
+ * @param new_ifi_name The new interface name.
+ * @return 0 on success, -1 on error
+ */
+int
+network_rename_ifi(const char *old_ifi_name, const char *new_ifi_name);
+
 #endif /* NETWORK_H */

--- a/daemon/c_net.c
+++ b/daemon/c_net.c
@@ -279,73 +279,6 @@ c_net_is_veth_used(const char *if_name)
 }
 
 /**
- * This function renames a (container namespace) veth name from old_ifi_name to new_ifi_name
- * with a netlink message using the netlink socket.
- */
-static int
-c_net_rename_ifi(const char *old_ifi_name, const char *new_ifi_name)
-{
-	ASSERT(old_ifi_name && new_ifi_name);
-
-	nl_sock_t *nl_sock = NULL;
-	unsigned int ifi_index_old;
-	nl_msg_t *req = NULL;
-
-	/* Get the interface index of the interface name */
-	if (!(ifi_index_old = if_nametoindex(old_ifi_name))) {
-		ERROR("veth interface name could not be resolved");
-		return -1;
-	}
-
-	/* Open netlink socket */
-	if (!(nl_sock = nl_sock_routing_new())) {
-		ERROR("failed to allocate netlink socket");
-		return -1;
-	}
-
-	/* Create netlink message */
-	if (!(req = nl_msg_new())) {
-		ERROR("failed to allocate netlink message");
-		nl_sock_free(nl_sock);
-		return -1;
-	}
-
-	struct ifinfomsg link_req = { .ifi_family = AF_INET, .ifi_index = ifi_index_old };
-
-	/* Fill netlink message header */
-	if (nl_msg_set_type(req, RTM_NEWLINK))
-		goto msg_err;
-
-	/* Set appropriate flags for request, creating new object,
-	 *  exclusive access and acknowledgment response */
-	if (nl_msg_set_flags(req, NLM_F_REQUEST | NLM_F_ACK))
-		goto msg_err;
-
-	/* Fill link request header of request message */
-	if (nl_msg_set_link_req(req, &link_req))
-		goto msg_err;
-
-	/* Set the PID in the netlink header */
-	if (nl_msg_add_string(req, IFLA_IFNAME, new_ifi_name))
-		goto msg_err;
-
-	/* Send request message and wait for the response message */
-	if (nl_msg_send_kernel_verify(nl_sock, req))
-		goto msg_err;
-
-	nl_msg_free(req);
-	nl_sock_free(nl_sock);
-
-	return 0;
-
-msg_err:
-	ERROR("failed to create/send netlink message");
-	nl_msg_free(req);
-	nl_sock_free(nl_sock);
-	return -1;
-}
-
-/**
  * This function moves the network interface to the corresponding namespace,
  * specified by the pid (from root namespace to container namespace).
  */
@@ -929,7 +862,7 @@ c_net_start_post_clone_interface(pid_t pid, c_net_interface_t *ni)
 
 	if (ni->cont_offset == 0 && hardware_get_radio_ifname()) {
 		/* Rename the rootns first veth to the RADIO_IFACE_NAME name */
-		if (c_net_rename_ifi(ni->veth_cmld_name, hardware_get_radio_ifname()))
+		if (network_rename_ifi(ni->veth_cmld_name, hardware_get_radio_ifname()))
 			return -1;
 
 		mem_free(ni->veth_cmld_name);
@@ -1130,7 +1063,7 @@ c_net_start_child_interface(c_net_interface_t *ni)
 	DEBUG("rename ifi from %s to %s", ni->veth_cont_name, ni->nw_name);
 
 	/* Rename container veth to the given if name */
-	if (c_net_rename_ifi(ni->veth_cont_name, ni->nw_name))
+	if (network_rename_ifi(ni->veth_cont_name, ni->nw_name))
 		return -1;
 
 	/* Skip IPv4 setup if interface has no config */

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -24,6 +24,8 @@
 // uncomment to prevent reboot
 #define TRUSTME_DEBUG
 
+#define _GNU_SOURCE
+
 #include "cmld.h"
 
 #include "common/macro.h"
@@ -49,6 +51,7 @@
 #include "ksm.h"
 #include "uevent.h"
 
+#include <stdio.h>
 #include <dirent.h>
 #include <errno.h>
 #include <sys/stat.h>
@@ -947,6 +950,44 @@ cmld_start_a0(container_t *new_a0)
 	return 0;
 }
 
+char *
+cmld_rename_ifi_new(const char *oldname)
+{
+	static unsigned int cmld_wlan_idx = 0;
+	static unsigned int cmld_eth_idx = 0;
+
+	//generate interface name that is unique
+	//in the root network namespace
+	const char *infix;
+	unsigned int *ifi_idx;
+	char *newname = NULL;
+
+	if (network_interface_is_wifi(oldname)) {
+		infix = "wlan";
+		ifi_idx = &cmld_wlan_idx;
+	} else {
+		infix = "eth";
+		ifi_idx = &cmld_eth_idx;
+	}
+
+	if (-1 == asprintf(&newname, "%s%s%d", "cml", infix, *ifi_idx)) {
+		ERROR("Failed to generate new interface name");
+		return NULL;
+	}
+
+	*ifi_idx += 1;
+
+	INFO("Renaming %s to %s", oldname, newname);
+
+	if (network_rename_ifi(oldname, newname)) {
+		ERROR("Failed to rename interface %s", oldname);
+		mem_free(newname);
+		return NULL;
+	}
+
+	return newname;
+}
+
 static void
 cmld_tune_network(const char *host_addr, uint32_t host_subnet, const char *host_if,
 		  const char *host_gateway, const char *host_dns)
@@ -963,7 +1004,19 @@ cmld_tune_network(const char *host_addr, uint32_t host_subnet, const char *host_
 	/* configure loopback interface of root network namespace */
 	network_setup_loopback();
 
-	cmld_netif_phys_list = network_get_physical_interfaces_new();
+	list_t *ifis = network_get_physical_interfaces_new();
+
+	for (list_t *l = ifis; l; l = l->next) {
+		char *ifi_new = cmld_rename_ifi_new(l->data);
+
+		if (ifi_new) {
+			DEBUG("Got physical network interface %s", ifi_new);
+			cmld_netif_phys_list = list_append(cmld_netif_phys_list, ifi_new);
+		} else {
+			ERROR("Failed to rename ifi, using as %s", (char *)l->data);
+			cmld_netif_phys_list = list_append(cmld_netif_phys_list, l->data);
+		}
+	}
 
 	/* configure resolver of root network namespace */
 	if (-1 == file_printf("/etc/resolv.conf", "nameserver %s", host_dns))
@@ -1328,11 +1381,12 @@ cmld_netif_phys_remove_by_name(const char *if_name)
 void
 cmld_netif_phys_add_by_name(const char *if_name)
 {
+	DEBUG("Adding network interface %s to cmld", if_name);
+
 	for (list_t *l = cmld_netif_phys_list; l; l = l->next) {
 		char *cmld_if_name = l->data;
 		if (0 == strcmp(if_name, cmld_if_name)) {
 			return;
 		}
 	}
-	cmld_netif_phys_list = list_append(cmld_netif_phys_list, mem_strdup(if_name));
 }

--- a/daemon/cmld.h
+++ b/daemon/cmld.h
@@ -264,4 +264,7 @@ cmld_netif_phys_remove_by_name(const char *if_name);
 void
 cmld_netif_phys_add_by_name(const char *if_name);
 
+char *
+cmld_rename_ifi_new(const char *oldname);
+
 #endif /* CMLD_H */

--- a/daemon/container.c
+++ b/daemon/container.c
@@ -2285,7 +2285,6 @@ container_add_net_iface(container_t *container, const char *iface, bool persiste
 			 state_a0 == CONTAINER_STATE_BOOTING || state_a0 == CONTAINER_STATE_SETUP);
 
 	if (cmld_containers_get_a0() == container) {
-		cmld_netif_phys_add_by_name(iface);
 		if (a0_is_up)
 			res = c_net_move_ifi(iface, pid);
 		return res;


### PR DESCRIPTION
Avoid name clashes with container-internal interface renaming mechanisms by prefixing the interfaces on cmld startup