### PR TITLE
Bind token comm socket to corresponding container

### DIFF
--- a/daemon/c_vol.h
+++ b/daemon/c_vol.h
@@ -56,8 +56,10 @@ c_vol_is_encrypted(c_vol_t *vol);
 /* Start hooks */
 int
 c_vol_start_pre_clone(c_vol_t *vol);
+
 int
 c_vol_start_child(c_vol_t *vol);
+
 int
 c_vol_start_pre_exec(c_vol_t *vol);
 

--- a/daemon/smartcard.h
+++ b/daemon/smartcard.h
@@ -30,6 +30,11 @@
 
 typedef struct smartcard smartcard_t;
 
+//has to be kept in sync with token.h
+// clang-format off
+#define SCD_TOKENCONTROL_SOCKET SOCK_PATH(tokencontrol)
+// clang-format on
+
 /**
  * @param path The directory where smartcard-related data is stored.
  */

--- a/scd/token.c
+++ b/scd/token.c
@@ -121,8 +121,10 @@ err:
 
 out:
 	out.return_code = TOKEN_TO_CONTAINER__CODE__OK;
+	out.has_response = true;
 	out.response.len = len;
 	out.response.data = brsp;
+
 	if ((protobuf_send_message(fd, (ProtobufCMessage *)&out)) < 0) {
 		ERROR("Could not send protobuf response on socket %d", fd);
 	}

--- a/scd/token.h
+++ b/scd/token.h
@@ -34,6 +34,7 @@
 
 #define STOKEN_DEFAULT_PASS "trustme"
 
+//has to be kept in sync with smartcard.h
 // clang-format off
 #define SCD_TOKENCONTROL_SOCKET SOCK_PATH(tokencontrol)
 // clang-format on


### PR DESCRIPTION
This PR bind mounts the token communication sockets created by the scd to the corresponding container.
To achieve this, the mount propagation type of the container's /dev tmpfs is changed to MS_SHARED to propagate the socket mount events to the container's mount namespace.     