### PR TITLE
Feature: Hostedmode for cmld to allow cmld to run inside standard linux distributions

### DIFF
--- a/common/event.c
+++ b/common/event.c
@@ -334,17 +334,21 @@ event_reset()
 	TRACE("Resetting event epoll fd");
 	event_reset_fd();
 
-	TRACE("Resetting event timers");
-	list_foreach(event_timer_list, wrapped_remove_timer);
-	event_timer_list = NULL;
-
-	TRACE("Resetting event signal handler list");
-	list_foreach(event_signal_list, wrapped_remove_signal);
-	event_signal_list = NULL;
-
-	TRACE("Resetting event inotify list");
-	list_foreach(event_inotify_list, wrapped_remove_inotify);
-	event_inotify_list = NULL;
+	if (event_timer_list) {
+		TRACE("Resetting event timers");
+		list_foreach(event_timer_list, wrapped_remove_timer);
+		event_timer_list = NULL;
+	}
+	if (event_signal_list) {
+		TRACE("Resetting event signal handler list");
+		list_foreach(event_signal_list, wrapped_remove_signal);
+		event_signal_list = NULL;
+	}
+	if (event_inotify_list) {
+		TRACE("Resetting event inotify list");
+		list_foreach(event_inotify_list, wrapped_remove_inotify);
+		event_inotify_list = NULL;
+	}
 }
 
 event_io_t *

--- a/daemon/c_user.c
+++ b/daemon/c_user.c
@@ -158,7 +158,7 @@ c_user_set_next_uid_range_start(c_user_t *user)
 	} else {
 		int offset;
 		if (file_read(file_name_uid, (char *)&offset, sizeof(offset)) < 0) {
-			WARN("Failed to get restore uid for container %s",
+			WARN("Failed to restore uid for container %s",
 			     uuid_string(container_get_uuid(user->container)));
 		}
 		user->offset = c_user_set_offset(offset);

--- a/daemon/c_vol.c
+++ b/daemon/c_vol.c
@@ -1433,9 +1433,9 @@ c_vol_pivot_root(const c_vol_t *vol)
 	close(new_root);
 	return 0;
 error:
-	if (old_root > 0)
+	if (old_root >= 0)
 		close(old_root);
-	if (new_root > 0)
+	if (new_root >= 0)
 		close(new_root);
 	return -1;
 }

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -1410,3 +1410,13 @@ cmld_netif_phys_add_by_name(const char *if_name)
 		}
 	}
 }
+
+#define PROC_FSES "/proc/filesystems"
+bool
+cmld_is_shiftfs_supported(void)
+{
+	char *fses = file_read_new(PROC_FSES, 2048);
+	bool ret = strstr(fses, "shiftfs") ? true : false;
+	mem_free(fses);
+	return ret;
+}

--- a/daemon/cmld.h
+++ b/daemon/cmld.h
@@ -273,4 +273,10 @@ cmld_netif_phys_add_by_name(const char *if_name);
 char *
 cmld_rename_ifi_new(const char *oldname);
 
+/**
+ * Checks if kernel supports shiftfs
+ */
+bool
+cmld_is_shiftfs_supported(void);
+
 #endif /* CMLD_H */

--- a/daemon/cmld.h
+++ b/daemon/cmld.h
@@ -138,7 +138,7 @@ container_t *
 cmld_container_get_by_uuid(uuid_t *uuid);
 
 int
-cmld_containers_stop();
+cmld_containers_stop(void (*on_all_stopped)(void));
 
 /* state as parameter? */
 //void

--- a/daemon/cmld.h
+++ b/daemon/cmld.h
@@ -188,6 +188,12 @@ bool
 cmld_is_internet_active(void);
 
 /**
+ * Checks if cmld is running in hosted mode (e.g. on debian)
+ */
+bool
+cmld_is_hostedmode_active(void);
+
+/**
  * Get the dns server set for the host interface in device config
  */
 const char *

--- a/daemon/device.proto
+++ b/daemon/device.proto
@@ -56,4 +56,7 @@ message DeviceConfig {
 
 	// enable locally signed images
 	optional bool locally_signed_images = 13 [default = false];
+
+	// hostmode
+	required bool hostedmode = 14 [default = false];
 }

--- a/daemon/device_config.c
+++ b/daemon/device_config.c
@@ -217,3 +217,12 @@ device_config_get_locally_signed_images(const device_config_t *config)
 
 	return config->cfg->locally_signed_images;
 }
+
+bool
+device_config_get_hostedmode(const device_config_t *config)
+{
+	ASSERT(config);
+	ASSERT(config->cfg);
+
+	return config->cfg->hostedmode;
+}

--- a/daemon/device_config.h
+++ b/daemon/device_config.h
@@ -100,4 +100,7 @@ device_config_get_host_if(const device_config_t *config);
 
 bool
 device_config_get_locally_signed_images(const device_config_t *config);
+
+bool
+device_config_get_hostedmode(const device_config_t *config);
 #endif /* DEVICE_H */

--- a/daemon/mount.h
+++ b/daemon/mount.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of trust|me
- * Copyright(c) 2013 - 2017 Fraunhofer AISEC
+ * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * This program is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
This patch-set allows to run cmld in a standard distribution such as debian for development purpose.
The standard distribution runs in the CML. Neither a c0os nor a c0 container is necessary
to run user containers. The network/routing part which is usually done by c0/in c0's network
namespace is kept in CML.

Further since standard distributions do not support shiftfs, a preliminary support for kernel's
without shiftfs is provided by this patch set.