### PR TITLE
Sanity checks added, fixed typos and small bugs

### DIFF
--- a/common/ns.h
+++ b/common/ns.h
@@ -50,7 +50,7 @@ namespace_setuid0();
  * @returns 0 if the forked child exited cleanly, -1 otherwise.
  */
 int
-namespace_exec(pid_t ns_pid, const int namespaces, bool become_root, int (*func)(void **),
+namespace_exec(pid_t ns_pid, const int namespaces, bool become_root, int (*func)(const void **),
 	       const void **data);
 
 #endif //NS_H

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -1445,6 +1445,8 @@ cmld_guestos_delete(const char *guestos_name)
 bool
 cmld_netif_phys_remove_by_name(const char *if_name)
 {
+	IF_NULL_RETVAL(if_name, false);
+
 	list_t *found = NULL;
 	for (list_t *l = cmld_netif_phys_list; l; l = l->next) {
 		char *cmld_if_name = l->data;
@@ -1465,6 +1467,7 @@ cmld_netif_phys_remove_by_name(const char *if_name)
 void
 cmld_netif_phys_add_by_name(const char *if_name)
 {
+	IF_NULL_RETURN(if_name);
 	DEBUG("Adding network interface %s to cmld", if_name);
 
 	for (list_t *l = cmld_netif_phys_list; l; l = l->next) {

--- a/daemon/container.c
+++ b/daemon/container.c
@@ -2276,6 +2276,7 @@ int
 container_add_net_iface(container_t *container, const char *iface, bool persistent)
 {
 	ASSERT(container);
+	IF_FALSE_RETVAL(iface, -1);
 
 	int res = 0;
 	pid_t pid = container_get_pid(container);
@@ -2400,10 +2401,12 @@ int
 container_update_config(container_t *container, uint8_t *buf, size_t buf_len)
 {
 	ASSERT(container);
-	int ret;
+	int ret = -1;
 	container_config_t *conf = container_config_new(container->config_filename, buf, buf_len);
-	ret = container_config_write(conf);
-	container_config_free(conf);
+	if (conf) {
+		ret = container_config_write(conf);
+		container_config_free(conf);
+	}
 	return ret;
 }
 

--- a/daemon/container.c
+++ b/daemon/container.c
@@ -2276,7 +2276,7 @@ int
 container_add_net_iface(container_t *container, const char *iface, bool persistent)
 {
 	ASSERT(container);
-	IF_FALSE_RETVAL(iface, -1);
+	IF_NULL_RETVAL(iface, -1);
 
 	int res = 0;
 	pid_t pid = container_get_pid(container);

--- a/daemon/container_config.c
+++ b/daemon/container_config.c
@@ -642,5 +642,5 @@ container_config_get_token_type(const container_config_t *config)
 {
 	ASSERT(config);
 	ASSERT(config->cfg);
-	return config->cfg->token_type;
+	return container_config_proto_to_token_type(config->cfg->token_type);
 }

--- a/daemon/control.c
+++ b/daemon/control.c
@@ -193,7 +193,7 @@ control_send_log_file(int fd, char *log_file_name, bool read_low_level, bool sen
 		mem_free(message.msg);
 	}
 	if (send_last_line_info) {
-		message.msg = "Last line of log";
+		message.msg = mem_printf("Last line of log");
 		out.log_message = &message;
 		if (protobuf_send_message(fd, (ProtobufCMessage *)&out) < 0) {
 			ERROR("Could not sent last line info for %s", log_file_name);
@@ -611,7 +611,7 @@ control_handle_message_unpriv(const ControllerToDaemon *msg, int fd)
 	} break;
 	default:
 		WARN("Unsupported ControllerToDaemon command: %d received", msg->command);
-		if (control_send_message(CONTROL_RESPONSE_CMD_UNSUPPORTED, fd))
+		if (control_send_message(CONTROL_RESPONSE_CMD_UNSUPPORTED, fd) < 0)
 			WARN("Could not send response to fd=%d", fd);
 	}
 }
@@ -910,7 +910,7 @@ control_handle_message(control_t *control, const ControllerToDaemon *msg, int fd
 		out.n_container_configs = 0;
 		out.n_container_uuids = 0;
 
-		if (!msg->has_container_config_file) {
+		if (!msg->has_container_config_file || msg->container_config_file.data == NULL) {
 			WARN("CREATE_CONTAINER without config file does not work, doing nothing...");
 			if (protobuf_send_message(fd, (ProtobufCMessage *)&out) < 0)
 				WARN("Could not send empty Response to CREATE");
@@ -1094,6 +1094,11 @@ control_handle_message(control_t *control, const ControllerToDaemon *msg, int fd
 
 	case CONTROLLER_TO_DAEMON__COMMAND__CONTAINER_ASSIGNIFACE: {
 		IF_NULL_RETURN(container);
+		if (!msg->assign_iface_params || !msg->assign_iface_params->has_persistent ||
+		    !msg->assign_iface_params->iface_name) {
+			ERROR("Missing net iface information");
+			break;
+		}
 		char *net_iface = msg->assign_iface_params->iface_name;
 		bool persistent = msg->assign_iface_params->persistent;
 		container_add_net_iface(container, net_iface, persistent);
@@ -1101,6 +1106,11 @@ control_handle_message(control_t *control, const ControllerToDaemon *msg, int fd
 
 	case CONTROLLER_TO_DAEMON__COMMAND__CONTAINER_UNASSIGNIFACE: {
 		IF_NULL_RETURN(container);
+		if (!msg->assign_iface_params || !msg->assign_iface_params->has_persistent ||
+		    !msg->assign_iface_params->iface_name) {
+			ERROR("Missing net iface information");
+			break;
+		}
 		char *net_iface = msg->assign_iface_params->iface_name;
 		bool persistent = msg->assign_iface_params->persistent;
 		container_remove_net_iface(container, net_iface, persistent);
@@ -1152,7 +1162,10 @@ control_handle_message(control_t *control, const ControllerToDaemon *msg, int fd
 	case CONTROLLER_TO_DAEMON__COMMAND__CONTAINER_EXEC_CMD: {
 		IF_NULL_RETURN(container);
 		TRACE("Got exec command: %s, attach PTY: %d", msg->exec_command, msg->exec_pty);
-
+		if (!msg->exec_command || !msg->has_exec_pty) {
+			ERROR("Missing command or exec_pty info");
+			break;
+		}
 		if ((!container) || container_run(container, msg->exec_pty, msg->exec_command,
 						  msg->n_exec_args, msg->exec_args) < 0) {
 			ERROR("Failed to exec");
@@ -1181,18 +1194,18 @@ control_handle_message(control_t *control, const ControllerToDaemon *msg, int fd
 		IF_NULL_RETURN(container);
 		TRACE("Got input for exec'ed process. Sending message on fd");
 
-		if (container != NULL) {
-			int ret = container_write_exec_input(container, msg->exec_input);
-			if (ret < 0) {
-				ERROR_ERRNO("Failed to write input to exec'ed process");
-			}
-		} else {
-			ERROR("No container UUID given");
+		int ret = container_write_exec_input(container, msg->exec_input);
+		if (ret < 0) {
+			ERROR_ERRNO("Failed to write input to exec'ed process");
 		}
-		break;
-	}
+	} break;
 
 	case CONTROLLER_TO_DAEMON__COMMAND__CONTAINER_CHANGE_TOKEN_PIN: {
+		IF_NULL_RETURN(container);
+		if (msg->device_pin == NULL || msg->device_newpin == NULL) {
+			ERROR("Current PIN or new PIN not specified");
+			break;
+		}
 		res = cmld_container_change_pin(control, container, msg->device_pin,
 						msg->device_newpin);
 	} break;

--- a/daemon/control.c
+++ b/daemon/control.c
@@ -198,6 +198,7 @@ control_send_log_file(int fd, char *log_file_name, bool read_low_level, bool sen
 		if (protobuf_send_message(fd, (ProtobufCMessage *)&out) < 0) {
 			ERROR("Could not sent last line info for %s", log_file_name);
 		}
+		mem_free(message.msg);
 	}
 	if (out.device_uuid != NULL) {
 		mem_free(out.device_uuid);

--- a/daemon/smartcard.c
+++ b/daemon/smartcard.c
@@ -698,6 +698,8 @@ smartcard_change_pin(smartcard_t *smartcard, control_t *control, const char *pas
 {
 	ASSERT(smartcard);
 	ASSERT(control);
+	ASSERT(passwd);
+	ASSERT(newpasswd);
 
 	int ret = -1;
 	int pw_size = strlen(passwd);

--- a/tpm2d/tpm2d.c
+++ b/tpm2d/tpm2d.c
@@ -341,8 +341,8 @@ main(UNUSED int argc, char **argv)
 		FATAL("Could not init tpm2d_control socket");
 	}
 	tpm2d_rcontrol_attest = tpm2d_rcontrol_new("0.0.0.0", TPM2D_RCONTROL_PORT);
-	if (!tpm2d_control_cmld) {
-		FATAL("Could not init tpm2d_control socket");
+	if (!tpm2d_rcontrol_attest) {
+		FATAL("Could not init tpm2d_rcontrol socket");
 	}
 
 	INFO("created control socket.");


### PR DESCRIPTION
In common/ns.h: adapted namespace_exec(...) arguments to match ns.c definition.
In daemon/control.c: added nullptr checks, fixed typos / bugs.
In daemon/container_config.c: added missing cast.
In tpm2d/tpm2d.c: fixed typo / bug.
In daemon/smartcard.c: added nullptr checks.
In daemon/cmld.c: added nullptr checks.
In daemon/container.c: added nullptr checks.

Notes:
- In daemon/control.c:`control_handle_message(...)`: 
   - (Future) Potentially reconsider the extent of error messages for each command, e.g. when looking at case CONTROLLER_TO_DAEMON__COMMAND__CONTAINER_EXEC_INPUT, where the error message noted a missing container (this error was never triggered though) vs all other container commands which simply return. 
   - Case CONTROLLER_TO_DAEMON__COMMAND__CONTAINER_EXEC_INPUT: Is a check for msg->exec_input required?
   - Case CONTROLLER_TO_DAEMON__COMMAND__CONTAINER_EXEC_CMD: exec_pty check performed anyway in case it is not defined despite default value set to false
- In common/ns.h: I matched `namespace_exec(...)` declaration in header and definition in common/ns.c, given that data argument is constant I assumed the argument in the function pointer is constant as is defined in the source file.