### PR TITLE
daemon/guestos_mgr.c: fix ca_register

### DIFF
--- a/daemon/guestos_mgr.c
+++ b/daemon/guestos_mgr.c
@@ -297,7 +297,11 @@ guestos_mgr_update_images(void)
 static char *
 write_to_tmpfile_new(unsigned char *buf, size_t buflen)
 {
-	char *file = mem_strdup("/tmp/tmpXXXXXXXX");
+	/* this fixes the problem that /tmp is unshared between cmld and scd which is why
+	 * it cannot be used to share files to be hashed (e.g. newca_certs)
+	 * FIXME: move SCD in own container and introduce shared mount
+	 */
+	char *file = mem_printf("%s/shared/tmpXXXXXXXX", DEFAULT_BASE_PATH);
 	int fd = mkstemp(file);
 	if (fd != -1) {
 		int len = fd_write(fd, (char *)buf, buflen);


### PR DESCRIPTION
New CA certs to be registered are hashed by the SCD to check whether they have already been registered. This has been done using a temporary file located under /tmp. As the cmld unshares his mount namespace an remounts /tmp this file has not been accessible to the SCD for hashing anymore.
This PR is a temporary fix that uses /data/cml/shared as fs location that is accessible to both the cmld and scd.
In the future it might be considered to move the SCd into a container and establish a more general way to share data between the cmld and a specific container.