### PR TITLE
Fixes for the APDU-Relay

### DIFF
--- a/common/str.c
+++ b/common/str.c
@@ -262,3 +262,17 @@ str_free(str_t *str, bool free_buf)
 
 	return buf;
 }
+
+str_t *
+str_hexdump_new(unsigned char *mem, int len)
+{
+	str_t *ret = str_new_len(len * 2 + 1);
+
+	while (len--) {
+		ASSERT(len >= 0);
+		str_append_printf(ret, "%02x ", *mem);
+		mem++;
+	}
+
+	return ret;
+}

--- a/common/str.h
+++ b/common/str.h
@@ -197,6 +197,16 @@ str_buffer(str_t *str);
 size_t
 str_length(str_t *str);
 
+/*
+ * Dumps the memory pointed to by <mem> as hex string
+ *
+ * @param mem The memory to be dumped
+ * @param len The length of the memory area to be dumped
+ * @return The resulting hex dump
+ */
+str_t *
+str_hexdump_new(unsigned char *mem, int len);
+
 /**
  * Frees the allocated string memory.
  *
@@ -206,5 +216,4 @@ str_length(str_t *str);
  */
 char *
 str_free(str_t *str, bool free_buf);
-
 #endif /* STR_H */

--- a/daemon/c_vol.c
+++ b/daemon/c_vol.c
@@ -1172,10 +1172,10 @@ c_vol_bind_token(c_vol_t *vol)
 	int ret = -1;
 	uid_t uid = container_get_uid(vol->container);
 
-	char *src_path = mem_printf("%s/%s", SCD_TOKENCONTROL_SOCKET,
+	char *src_path = mem_printf("%s/%s.sock", SCD_TOKENCONTROL_SOCKET,
 				    uuid_string(container_get_uuid(vol->container)));
 	char *dest_dir = mem_printf("%s/dev/tokens", vol->root);
-	char *dest_path = mem_printf("%s/token", dest_dir);
+	char *dest_path = mem_printf("%s/token.sock", dest_dir);
 
 	DEBUG("Binding token socket to %s", dest_path);
 

--- a/scd/scd.c
+++ b/scd/scd.c
@@ -318,6 +318,11 @@ main(int argc, char **argv)
 	event_signal_t *sig_term = event_signal_new(SIGTERM, &scd_sigterm_cb, NULL);
 	event_add_signal(sig_term);
 
+#if defined ENABLESCHSM && defined DEBUG_BUILD
+	DEBUG("Creating libctccid log directory at /var/tmp/sc-hsm-embedded");
+	dir_mkdir_p("/var/tmp/sc-hsm-embedded", 0755);
+#endif
+
 	provisioning_mode();
 
 	INFO("Starting scd ...");


### PR DESCRIPTION
Fixes for issues to the APDU relay:
- Add .sock extention to relay sockets
- Keep relay connection open
- Log hexdumps of APDU communication 