### PR TITLE
Exec process with cap_sys_time in container with enabled userns

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -62,6 +62,9 @@ OBJS_COMMON := \
 	logf.o \
 	mem.o \
 	str.o \
+	fd.o \
+	file.o \
+	dir.o \
 	ns.o \
 	nl.o
 
@@ -69,9 +72,6 @@ OBJS_COMMON_FULL := \
 	$(OBJS_COMMON) \
 	protobuf.o \
 	logf.pb-c.o \
-	file.o \
-	dir.o \
-	fd.o \
 	sock.o \
 	network.o \
 	proc.o \

--- a/common/ns.c
+++ b/common/ns.c
@@ -1,3 +1,26 @@
+/*
+ * This file is part of trust|me
+ * Copyright(c) 2013 - 2020 Fraunhofer AISEC
+ * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 (GPL 2), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * The full GNU General Public License is included in this distribution in
+ * the file called "COPYING".
+ *
+ * Contact Information:
+ * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ */
+
 #define _GNU_SOURCE
 #include <sched.h>
 #include <unistd.h>

--- a/common/ns.h
+++ b/common/ns.h
@@ -54,14 +54,16 @@ namespace_exec(pid_t ns_pid, const int namespaces, bool become_root, int (*func)
 	       const void **data);
 
 /**
- * This function joins the current process to all namespaces of process give
- * by its pid. Do not use this function in main process of cmld directly!
+ * This function joins the current process to all namespaces of a process given
+ * by its pid. The userns is joined only if switch userns is true.
+ * Do not use this function in main process of cmld directly!
  * Fork or clone a child beforehand and execute this in the child.
  *
- * @param ns_pid pid of the namespace to join
+ * @param pid pid of the namespace to join
+ * @param userns switch for joining userns
  * @returns 0 if all namespaces are changed succesfully, -1 otherwise.
  */
 int
-ns_join_all(pid_t ns_pid);
+ns_join_all(pid_t pid, bool userns);
 
 #endif //NS_H

--- a/common/ns.h
+++ b/common/ns.h
@@ -53,4 +53,15 @@ int
 namespace_exec(pid_t ns_pid, const int namespaces, bool become_root, int (*func)(const void **),
 	       const void **data);
 
+/**
+ * This function joins the current process to all namespaces of process give
+ * by its pid. Do not use this function in main process of cmld directly!
+ * Fork or clone a child beforehand and execute this in the child.
+ *
+ * @param ns_pid pid of the namespace to join
+ * @returns 0 if all namespaces are changed succesfully, -1 otherwise.
+ */
+int
+ns_join_all(pid_t ns_pid);
+
 #endif //NS_H

--- a/common/proc.c
+++ b/common/proc.c
@@ -249,3 +249,19 @@ proc_fork_and_execvp(const char *const *argv)
 	}
 	return -1;
 }
+
+int
+proc_cap_last_cap(void)
+{
+	int cap;
+	const char *file_cap_last_cap = "/proc/sys/kernel/cap_last_cap";
+
+	char *str_cap_last_cap = file_read_new(file_cap_last_cap, 24);
+	if (sscanf(str_cap_last_cap, "%d", &cap) <= 0) {
+		ERROR_ERRNO("Can't read cap from '%s'", file_cap_last_cap);
+		cap = -1;
+	}
+
+	mem_free(str_cap_last_cap);
+	return cap;
+}

--- a/common/proc.h
+++ b/common/proc.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of trust|me
- * Copyright(c) 2013 - 2017 Fraunhofer AISEC
+ * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -61,5 +61,12 @@ proc_find(pid_t ppid, const char *name);
 
 int
 proc_fork_and_execvp(const char *const *argv);
+
+/**
+ * Returns the last cap from the running kernel
+ * @return last cap of running kernel, -1 on error;
+ */
+int
+proc_cap_last_cap(void);
 
 #endif /* PROC_H */

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -75,9 +75,6 @@ SRC_FILES := main.c \
 	control.c \
 	container_config.c \
 	device_config.c \
-	common/file.c \
-	common/dir.c \
-	common/fd.c \
 	mount.c \
 	guestos.c \
 	guestos_mgr.c \

--- a/daemon/c_cap.c
+++ b/daemon/c_cap.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of trust|me
- * Copyright(c) 2013 - 2017 Fraunhofer AISEC
+ * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -24,16 +24,21 @@
 #include "c_cap.h"
 
 #include "common/macro.h"
+#include "common/mem.h"
+#include "common/ns.h"
+#include "common/event.h"
 
 #include <sys/capability.h>
 #include <sys/prctl.h>
+#include <sys/types.h>
+#include <sys/wait.h>
 
 #define C_CAP_DROP(cap)                                                                            \
 	do {                                                                                       \
-		DEBUG("Dropping capability %s for %s", #cap,                                       \
+		DEBUG("Dropping capability %s:%d for %s", #cap, cap,                               \
 		      container_get_description(container));                                       \
 		if (prctl(PR_CAPBSET_DROP, cap, 0, 0, 0) < 0) {                                    \
-			ERROR_ERRNO("Could not drop capability %s for %s", #cap,                   \
+			ERROR_ERRNO("Could not drop capability %s:%d for %s", #cap, cap,           \
 				    container_get_description(container));                         \
 			return -1;                                                                 \
 		}                                                                                  \
@@ -75,6 +80,11 @@ c_cap_set_current_process(const container_t *container)
 	/* 34 */ C_CAP_DROP(CAP_SYSLOG);
 	///* 35 */ C_CAP_DROP(CAP_WAKE_ALARM); /* needed by alarm driver */
 
+	if (container_has_userns(container))
+		return 0;
+
+	/* 21 */ C_CAP_DROP(CAP_SYS_ADMIN);
+
 	/* Use the following for dropping caps only in unprivileged containers */
 	if (!container_is_privileged(container) &&
 	    container_get_state(container) != CONTAINER_STATE_SETUP) {
@@ -82,10 +92,131 @@ c_cap_set_current_process(const container_t *container)
 		/* 25 */ C_CAP_DROP(CAP_SYS_TIME);
 		/* 26 */ C_CAP_DROP(CAP_SYS_TTY_CONFIG);
 	}
-	if (!container_has_userns(container)) {
-		/* 21 */ C_CAP_DROP(CAP_SYS_ADMIN);
+
+	return 0;
+}
+
+static int
+c_cap_do_exec_cap_systime(const container_t *container, char *const *argv)
+{
+	int uid = container_get_uid(container);
+
+	for (int cap = 0; cap < CAP_LAST_CAP; cap++) {
+		// ntpd needs to bind a socket to
+		if (cap == CAP_SYS_TIME || cap == CAP_NET_BIND_SERVICE || cap == CAP_SETUID)
+			continue;
+		C_CAP_DROP(cap);
 	}
 
+	// keep caps during uid switch
+	if (prctl(PR_SET_KEEPCAPS, 1, 0, 0, 0) < 0) {
+		ERROR_ERRNO("Could not set KEEPCAPS");
+		exit(EXIT_FAILURE);
+	}
+	// switch to uid and gid of mapped userns root user
+	if (setgid(uid) < 0) {
+		ERROR_ERRNO("Could not set gid to '%d' in root userns", uid);
+		exit(EXIT_FAILURE);
+	}
+	if (setuid(uid) < 0) {
+		ERROR_ERRNO("Could not become user '%d' in root userns", uid);
+		exit(EXIT_FAILURE);
+	}
+
+	struct __user_cap_header_struct hdr = { 0 };
+	hdr.version = _LINUX_CAPABILITY_VERSION_3;
+	hdr.pid = 0;
+
+	struct __user_cap_data_struct data[2] = { 0 };
+	data[CAP_TO_INDEX(CAP_SYS_TIME)].effective |= CAP_TO_MASK(CAP_SYS_TIME);
+	data[CAP_TO_INDEX(CAP_SYS_TIME)].permitted |= CAP_TO_MASK(CAP_SYS_TIME);
+	data[CAP_TO_INDEX(CAP_SYS_TIME)].inheritable |= CAP_TO_MASK(CAP_SYS_TIME);
+
+	data[CAP_TO_INDEX(CAP_NET_BIND_SERVICE)].effective |= CAP_TO_MASK(CAP_NET_BIND_SERVICE);
+	data[CAP_TO_INDEX(CAP_NET_BIND_SERVICE)].permitted |= CAP_TO_MASK(CAP_NET_BIND_SERVICE);
+	data[CAP_TO_INDEX(CAP_NET_BIND_SERVICE)].inheritable |= CAP_TO_MASK(CAP_NET_BIND_SERVICE);
+
+	if (capset(&hdr, &data[0]) < 0) {
+		ERROR_ERRNO("capset failed!");
+		exit(EXIT_FAILURE);
+	}
+	if (prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE, CAP_SYS_TIME, 0, 0) < 0) {
+		ERROR_ERRNO("Could not preserve CAP_SYS_TIME");
+		exit(EXIT_FAILURE);
+	}
+	if (prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE, CAP_NET_BIND_SERVICE, 0, 0) < 0) {
+		ERROR_ERRNO("Could not preserve CAP_NET_BIND_SERVICE");
+		exit(EXIT_FAILURE);
+	}
+
+	execvp(argv[0], argv);
+	ERROR_ERRNO("exec '%s' failed!", argv[0]);
+	return -1;
+}
+
+static void
+c_cap_exec_cap_systime_sigchld_cb(UNUSED int signum, event_signal_t *sig, void *data)
+{
+	pid_t *pid = data;
+	int status = 0;
+
+	DEBUG("exec_cap_systime SIGCHLD handler called for PID %d", *pid);
+	if (waitpid(*pid, &status, WNOHANG) > 0) {
+		TRACE("Reaped exec_cap_systime process: %d", *pid);
+		event_remove_signal(sig);
+		event_signal_free(sig);
+		mem_free(pid);
+	} else {
+		TRACE("Failed to reap exec_cap_systime process");
+	}
+}
+
+int
+c_cap_exec_cap_systime(const container_t *container, char *const *argv)
+{
+	ASSERT(container);
+	IF_FALSE_RETVAL(container_is_privileged(container), -1);
+
+	int i = 1;
+	char *cmd = mem_strdup(argv[0]);
+	while (argv[i]) {
+		cmd = mem_printf("%s %s", cmd, argv[i]);
+		++i;
+	}
+	INFO("Going to exec '%s' with CAP_SYS_TIME!", cmd);
+
+	int pid = fork();
+	if (pid == 0) {
+		// join container namespace but maintain root user ns
+		if (ns_join_all(container_get_pid(container), false) < 0) {
+			ERROR("Could not join namesapces");
+			exit(EXIT_FAILURE);
+		}
+
+		// double fork for to join pidns
+		int pid_2 = fork();
+		if (pid_2 == 0) {
+			c_cap_do_exec_cap_systime(container, argv);
+			exit(EXIT_FAILURE);
+		} else if (pid < 0) {
+			ERROR("double fork faild!");
+			exit(EXIT_FAILURE);
+		} else {
+			// exit parent to handover child to init of container
+			exit(0);
+		}
+	} else if (pid < 0) {
+		ERROR_ERRNO("Failed to exec %s with CAP_SYS_TIME!", argv[0]);
+		return -1;
+	}
+
+	// sucessfully double forked child in target pidns
+	pid_t *_pid = mem_new(pid_t, 1);
+	*_pid = pid;
+	// register reaper for intermediate process
+	event_signal_t *sigchld =
+		event_signal_new(SIGCHLD, c_cap_exec_cap_systime_sigchld_cb, _pid);
+	event_add_signal(sigchld);
 	return 0;
 }
 

--- a/daemon/c_cap.c
+++ b/daemon/c_cap.c
@@ -27,6 +27,7 @@
 #include "common/mem.h"
 #include "common/ns.h"
 #include "common/event.h"
+#include "common/proc.h"
 
 #include <sys/capability.h>
 #include <sys/prctl.h>
@@ -101,7 +102,9 @@ c_cap_do_exec_cap_systime(const container_t *container, char *const *argv)
 {
 	int uid = container_get_uid(container);
 
-	for (int cap = 0; cap < CAP_LAST_CAP; cap++) {
+	int last_cap = proc_cap_last_cap() < 0 ? CAP_LAST_CAP : proc_cap_last_cap();
+	TRACE("Last CAP %d", last_cap);
+	for (int cap = 0; cap < last_cap; cap++) {
 		// ntpd needs to bind a socket to
 		if (cap == CAP_SYS_TIME || cap == CAP_NET_BIND_SERVICE || cap == CAP_SETUID)
 			continue;

--- a/daemon/c_cap.h
+++ b/daemon/c_cap.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of trust|me
- * Copyright(c) 2013 - 2017 Fraunhofer AISEC
+ * Copyright(c) 2013 - 2020 Fraunhofer AISEC
  * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -28,6 +28,9 @@
 
 int
 c_cap_set_current_process(const container_t *container);
+
+int
+c_cap_exec_cap_systime(const container_t *container, char *const *argv);
 
 int
 c_cap_start_child(const container_t *container);

--- a/daemon/c_run.c
+++ b/daemon/c_run.c
@@ -320,7 +320,7 @@ c_run_join_container(c_run_t *run)
 		ERROR("Could not join container cgroups!");
 		goto error;
 	}
-	if (ns_join_all(container_get_pid(run->container)) < 0) {
+	if (ns_join_all(container_get_pid(run->container), true) < 0) {
 		ERROR("Could not set namespaces!");
 		goto error;
 	}

--- a/daemon/c_service.proto
+++ b/daemon/c_service.proto
@@ -82,6 +82,8 @@ message ServiceToCmldMessage {
 
 		CONTAINER_CFG_NAME_REQ = 18;
 		CONTAINER_CFG_DNS_REQ = 19;
+
+		EXEC_CAP_SYSTIME_PRIV = 20;
 	}
 	required Code code = 1;
 
@@ -93,4 +95,6 @@ message ServiceToCmldMessage {
 	optional bool airplane_mode = 11;
 	optional string target_container = 13;
 	optional bool wifi_user_enabled = 14;
+	optional string captime_exec_path = 15;
+	repeated string captime_exec_param = 16;
 }

--- a/daemon/container.c
+++ b/daemon/container.c
@@ -2497,3 +2497,10 @@ container_get_token_is_linked_to_device(const container_t *container)
 	ASSERT(container);
 	return container->token.is_paired_with_device;
 }
+
+int
+container_exec_cap_systime(const container_t *container, char *const *argv)
+{
+	ASSERT(container);
+	return c_cap_exec_cap_systime(container, argv);
+}

--- a/daemon/container.h
+++ b/daemon/container.h
@@ -878,4 +878,10 @@ container_set_token_is_linked_to_device(container_t *container, const bool is_pa
 bool
 container_get_token_is_linked_to_device(const container_t *container);
 
+/**
+ * Executes a binary of a priviliegd container with cap_sys_time in root userns.
+ */
+int
+container_exec_cap_systime(const container_t *container, char *const *argv);
+
 #endif /* CONTAINER_H */

--- a/service/Makefile
+++ b/service/Makefile
@@ -62,13 +62,21 @@ SRC_FILES := \
 	common/logf.pb-c.c \
 	service.c
 
+SRC_FILES_EXEC_CAP_SYSTIME := \
+	c_service.pb-c.c \
+	container.pb-c.c \
+	control.pb-c.c \
+	guestos.pb-c.c \
+	common/logf.pb-c.c \
+	exec_cap_systime.c
+
 LD_LIB_FLAGS := \
 	-Lcommon -lcommon_full \
 	-lprotobuf-c \
 	-lprotobuf-c-text
 
 .PHONY: all
-all: service
+all: service exec_cap_systime
 
 protobuf: c_service.proto container.proto control.proto guestos.proto common/logf.proto
 	protoc-c --c_out=. c_service.proto
@@ -88,8 +96,11 @@ service: libcommon $(SRC_FILES)
 service-static: libcommon $(SRC_FILES)
 	$(CC) -static $(LOCAL_CFLAGS) $(CFLAGS) $(SRC_FILES) ${LD_LIB_FLAGS} -o cml-service-container
 
+exec_cap_systime: libcommon $(SRC_FILES_EXEC_CAP_SYSTIME)
+	$(CC) -static $(LOCAL_CFLAGS) $(CFLAGS) $(SRC_FILES_EXEC_CAP_SYSTIME) ${LD_LIB_FLAGS} -o exec_cap_systime
+
 
 .PHONY: clean
 clean:
-	rm -f cml-service-container *.o *.pb-c.*
+	rm -f cml-service-container exec_cap_systime *.o *.pb-c.*
 	$(MAKE) -C common clean

--- a/service/exec_cap_systime.c
+++ b/service/exec_cap_systime.c
@@ -1,0 +1,77 @@
+/*
+ * This file is part of trust|me
+ * Copyright(c) 2013 - 2020 Fraunhofer AISEC
+ * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 (GPL 2), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * The full GNU General Public License is included in this distribution in
+ * the file called "COPYING".
+ *
+ * Contact Information:
+ * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ */
+
+#ifdef ANDROID
+#include "device/fraunhofer/common/cml/service/c_service.pb-c.h"
+#else
+#include "c_service.pb-c.h"
+#endif
+
+#include "common/macro.h"
+#include "common/mem.h"
+#include "common/logf.h"
+#include "common/protobuf.h"
+#include "common/sock.h"
+#include "common/file.h"
+
+#include <unistd.h>
+
+// clang-format off
+#define SERVICE_SOCKET SOCK_PATH(service)
+// clang-format on
+
+int
+main(int argc, char **argv)
+{
+	logf_register(&logf_file_write, stdout);
+
+	IF_TRUE_RETVAL(argc < 2, -1);
+
+	const char *socket_file = SERVICE_SOCKET;
+	if (!file_exists(socket_file))
+		FATAL("Could not find socket file %s. Aborting.", socket_file);
+
+	int sock = sock_unix_create_and_connect(SOCK_STREAM, socket_file);
+	if (sock < 0)
+		FATAL("Could not connect to service on socket file %s. Aborting.", socket_file);
+
+	ServiceToCmldMessage msg = SERVICE_TO_CMLD_MESSAGE__INIT;
+	msg.code = SERVICE_TO_CMLD_MESSAGE__CODE__EXEC_CAP_SYSTIME_PRIV;
+	msg.captime_exec_path = argv[1];
+	msg.n_captime_exec_param = argc - 2;
+	msg.captime_exec_param = mem_new0(char *, argc - 2);
+	for (int i = 0; i < argc - 2; ++i) {
+		msg.captime_exec_param[i] = argv[i + 2];
+		TRACE("param[%d]: %s", i, msg.captime_exec_param[i]);
+	}
+
+	ssize_t msg_size = protobuf_send_message(sock, (ProtobufCMessage *)&msg);
+	if (msg_size < 0)
+		FATAL("Could not send exec request to cmld!, error: %zd\n", msg_size);
+
+	// closing socket to cmld
+	close(sock);
+
+	mem_free(msg.captime_exec_param);
+	return 0;
+}


### PR DESCRIPTION
This PR provides ability to set system time from a privileged container.
privileged means per definition in guestos, the container itself runs
in unprivileged user namespace.

Main commit is:
**daemon/c_cap: Introduce function to exec with cap_sys_time:**
To provide the ability to set system time in a privileged container
with userns enabled, we introduce the c_cap_exec_capsystime() function.
It could be used to execute a binary inside the target container
with cap_sys_time in root userns. To keep isolation impact as low as
possible, we switch to the user witch is mapped to the root user in
the userns of the container. Further, we drop all other capabilities,
except CAP_SYS_TIME.