### PR TITLE
Handle token attachment and detachment + related fixes

### DIFF
--- a/common/str.c
+++ b/common/str.c
@@ -264,12 +264,11 @@ str_free(str_t *str, bool free_buf)
 }
 
 str_t *
-str_hexdump_new(unsigned char *mem, int len)
+str_hexdump_new(unsigned char *mem, size_t len)
 {
 	str_t *ret = str_new_len(len * 2 + 1);
 
 	while (len--) {
-		ASSERT(len >= 0);
 		str_append_printf(ret, "%02x ", *mem);
 		mem++;
 	}

--- a/common/str.h
+++ b/common/str.h
@@ -205,7 +205,7 @@ str_length(str_t *str);
  * @return The resulting hex dump
  */
 str_t *
-str_hexdump_new(unsigned char *mem, int len);
+str_hexdump_new(unsigned char *mem, size_t len);
 
 /**
  * Frees the allocated string memory.

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -519,6 +519,9 @@ cmld_container_boot_complete_cb(container_t *container, container_callback_t *cb
 			uevent_udev_trigger_coldboot();
 		container_unregister_observer(container, cb);
 
+		DEBUG("Freeing key of container %s", container_get_name(container));
+		container_free_key(container);
+
 		/* Make KSM aggressive to immmediately share as many pages as
 		 * possible */
 		ksm_set_aggressive_for(CMLD_KSM_AGGRESSIVE_TIME_AFTER_CONTAINER_BOOT);

--- a/daemon/cmld.h
+++ b/daemon/cmld.h
@@ -147,6 +147,9 @@ cmld_wipe_device();
 container_t *
 cmld_container_get_by_uuid(uuid_t *uuid);
 
+container_t *
+cmld_container_get_by_token_serial(const char *serial);
+
 int
 cmld_containers_stop(void (*on_all_stopped)(void));
 
@@ -288,5 +291,19 @@ cmld_rename_ifi_new(const char *oldname);
  */
 bool
 cmld_is_shiftfs_supported(void);
+
+/**
+ * Handles attachment of a container token.
+ * @return 0 if the given USB serial belongs to a container token and the attachment procedure could be performed properly, -1 otherwise
+*/
+int
+cmld_token_attach(const char *serial, char *devpath);
+
+/**
+ * Handles detachment of a container token.
+ * @return 0 if the given USB serial belongs to a container token and the detachment procedure could be performed properly, -1 otherwise
+*/
+int
+cmld_token_detach(char *usb_serial_short);
 
 #endif /* CMLD_H */

--- a/daemon/container.c
+++ b/daemon/container.c
@@ -634,6 +634,8 @@ container_free(container_t *container)
 {
 	ASSERT(container);
 
+	container_free_key(container);
+
 	uuid_free(container->uuid);
 	mem_free(container->name);
 
@@ -707,6 +709,8 @@ container_free(container_t *container)
 	if (container->token.serial)
 		mem_free(container->token.serial);
 
+	if (container->token.devpath)
+		mem_free(container->token.devpath);
 	mem_free(container);
 }
 
@@ -2465,7 +2469,32 @@ char *
 container_get_usbtoken_serial(const container_t *container)
 {
 	ASSERT(container);
+	IF_FALSE_RETVAL_ERROR(CONTAINER_TOKEN_TYPE_USB == container->token.type, NULL);
+
 	return container->token.serial;
+}
+
+char *
+container_get_usbtoken_devpath(const container_t *container)
+{
+	ASSERT(container);
+	IF_FALSE_RETVAL_ERROR(CONTAINER_TOKEN_TYPE_USB == container->token.type, NULL);
+
+	return container->token.devpath;
+}
+
+void
+container_set_usbtoken_devpath(container_t *container, char *devpath)
+{
+	ASSERT(container);
+	IF_FALSE_RETURN(CONTAINER_TOKEN_TYPE_USB == container->token.type);
+
+	if (container->token.devpath)
+		mem_free(container->token.devpath);
+
+	DEBUG("Setting token devpath for container %s to %s", container->name, devpath);
+
+	container->token.devpath = devpath;
 }
 
 void

--- a/daemon/container.c
+++ b/daemon/container.c
@@ -215,6 +215,19 @@ container_get_next_adb_port(void)
 #endif
 }
 
+void
+container_free_key(container_t *container)
+{
+	ASSERT(container);
+
+	IF_NULL_RETURN(container->key);
+
+	memset(container->key, 0, strlen(container->key));
+	mem_free(container->key);
+
+	INFO("Key of container %s was freed", container->name);
+}
+
 container_t *
 container_new_internal(const uuid_t *uuid, const char *name, container_type_t type, bool ns_usr,
 		       bool ns_net, bool privileged, const guestos_t *os,
@@ -1963,8 +1976,7 @@ container_set_key(container_t *container, const char *key)
 	if (container->key && !strcmp(container->key, key))
 		return;
 
-	if (container->key)
-		mem_free(container->key);
+	container_free_key(container);
 
 	container->key = strdup(key);
 

--- a/daemon/container.h
+++ b/daemon/container.h
@@ -110,6 +110,9 @@ typedef struct container_token_config {
 	bool is_init;
 	// indicates whether the token has already been provisioned with a platform-bound authentication code
 	bool is_paired_with_device;
+	// the current DEVPATH of this token,
+	// this is needed as the remove/unbind kernel uevents do not contain the USB_SERIAL_SHORT
+	char *devpath;
 } container_token_config_t;
 
 /**
@@ -843,6 +846,18 @@ container_get_token_type(const container_t *container);
  */
 char *
 container_get_usbtoken_serial(const container_t *container);
+
+/**
+ * Returns the current devpath of the container's token or NULL if the reader is currently not attached
+ */
+char *
+container_get_usbtoken_devpath(const container_t *container);
+
+/**
+ * Sets the current devpath of the container's token
+ */
+void
+container_set_usbtoken_devpath(container_t *container, char *devpath);
 
 /**
  * Sets the uuid of the token the container is associated with.

--- a/daemon/container.h
+++ b/daemon/container.h
@@ -216,6 +216,12 @@ container_new_clone(container_t *container);
 */
 
 /**
+ * Free the container's key
+*/
+void
+container_free_key(container_t *container);
+
+/**
  * Free a container data structure. Does not remove the persistent parts of the container,
  * i.e. the configuration and the images.
  */

--- a/daemon/smartcard.c
+++ b/daemon/smartcard.c
@@ -334,6 +334,8 @@ smartcard_cb_start_container(int fd, unsigned events, event_io_t *io, void *data
 				protobuf_send_message(startdata->smartcard->sock,
 						      (ProtobufCMessage *)&out);
 
+				//delete wrapped key from RAM
+				memset(key, 0, sizeof(key));
 				mem_free(out.container_uuid);
 				mem_free(out.token_uuid);
 			} else {
@@ -356,6 +358,8 @@ smartcard_cb_start_container(int fd, unsigned events, event_io_t *io, void *data
 				// set the key
 				char *ascii_key = bytes_to_string_new(key, keylen);
 				container_set_key(startdata->container, ascii_key);
+				// delete key from RAM
+				memset(ascii_key, 0, strlen(ascii_key));
 				mem_free(ascii_key);
 				// wrap key via scd
 				DaemonToToken out = DAEMON_TO_TOKEN__INIT;
@@ -376,6 +380,8 @@ smartcard_cb_start_container(int fd, unsigned events, event_io_t *io, void *data
 				protobuf_send_message(startdata->smartcard->sock,
 						      (ProtobufCMessage *)&out);
 
+				// delete key from RAM
+				memset(key, 0, sizeof(key));
 				mem_free(out.container_uuid);
 				mem_free(out.token_uuid);
 			}
@@ -406,6 +412,9 @@ smartcard_cb_start_container(int fd, unsigned events, event_io_t *io, void *data
 			char *ascii_key = bytes_to_string_new(msg->unwrapped_key.data,
 							      msg->unwrapped_key.len);
 			container_set_key(startdata->container, ascii_key);
+			//delete key from RAM
+			memset(ascii_key, 0, strlen(ascii_key));
+			memset(msg->unwrapped_key.data, 0, msg->unwrapped_key.len);
 			mem_free(ascii_key);
 		} break;
 		case TOKEN_TO_DAEMON__CODE__WRAPPED_KEY: {
@@ -439,6 +448,8 @@ smartcard_cb_start_container(int fd, unsigned events, event_io_t *io, void *data
 				      container_get_name(startdata->container), keyfile);
 			}
 			TRACE("Stored wrapped key on disk successfully");
+			// delete wrapped key from RAM
+			memset(msg->wrapped_key.data, 0, msg->wrapped_key.len);
 			mem_free(keyfile);
 		} break;
 		default:

--- a/scd/control.c
+++ b/scd/control.c
@@ -204,7 +204,8 @@ scd_control_handle_message(const DaemonToToken *msg, int fd)
 		scd_token_t *token = scd_get_token_from_msg(msg);
 
 		if (token != NULL) {
-			WARN("Token already exists. Aborting...");
+			INFO("Token already exists.");
+			out.code = TOKEN_TO_DAEMON__CODE__TOKEN_ADD_SUCCESSFUL;
 		} else if (scd_token_new(msg) == 0) {
 			out.code = TOKEN_TO_DAEMON__CODE__TOKEN_ADD_SUCCESSFUL;
 		} else {

--- a/scd/token.c
+++ b/scd/token.c
@@ -88,7 +88,7 @@ scd_tokencontrol_handle_message(const ContainerToToken *msg, int fd, void *data)
 	IF_NULL_GOTO_ERROR(tctrl, err);
 
 	TokenToContainer out = TOKEN_TO_CONTAINER__INIT;
-	brsp = mem_alloc0(APDU_MAX_BUF_LEN);
+	brsp = mem_alloc0(MAX_APDU_BUF_LEN);
 
 	switch (msg->command) {
 	case CONTAINER_TO_TOKEN__COMMAND__GET_ATR:


### PR DESCRIPTION
Currently, the cmld and scd do not reflect token detachments and attachments during runtime in their internal data structures.
This pull request handles these events based on the kernel uevents triggered by USB device attachments / detachments.

Also, this PR deletes the container's encryption key as long as it is no longer needed by the cmld.
Thereby, it is assured that the container's sensitive data can no longer be accessed once a token was detached 