### PR TITLE
README.md: Added DCO documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+
+# Container Management Layer
+
+This repository contains the daemons and tools of the trust|me Container Management Layer (CML).
+The project documentation can by found on [trustm3.github.io](https://trustm3.github.io).
+
+## Contributing
+
+This project is part of trust|me which enforces the [Developer Certificate of Origin](https://developercertificate.org/) (DCO) on Pull Requests. It requires all commit messages to contain the Signed-off-by line with an email address that matches the commit author and the name on your GitHub account.
+
+The Developer Certificate of Origin (DCO) is a lightweight way for contributors to certify that they wrote or otherwise have the right to submit the code they are contributing to the project. Here is the full text of the DCO, reformatted for readability:
+
+By making a contribution to this project, I certify that:
+
+1. The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or
+
+2. The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or
+
+3. The contribution was provided directly to me by some other person who certified (1.), (2.) or (3.) and I have not modified it.
+
+4. I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
+
+Contributors sign-off that they adhere to these requirements by adding a Signed-off-by line to commit messages.
+
+```
+Signed-off-by: NAME <EMAIL>
+```
+
+Use `git commit -s` to append this automatically to your commit message.
+


### PR DESCRIPTION
Added README.md which states the requirement for the DCO on
commits inside a pull request.

Signed-off-by: Michael Weiß <michael.weiss@aisec.fraunhofer.de>