### PR TITLE
New time submodule for cml

### DIFF
--- a/common/proc.h
+++ b/common/proc.h
@@ -69,4 +69,12 @@ proc_fork_and_execvp(const char *const *argv);
 int
 proc_cap_last_cap(void);
 
+/**
+ * Returns the btime field from /proc/stat in buffer boottime_sec
+ * @param boottime_sec pointer to buffer for result
+ * @return 0 on success, -1 on error
+ */
+int
+proc_stat_btime(unsigned long long *boottime_sec);
+
 #endif /* PROC_H */

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -101,6 +101,7 @@ SRC_FILES := main.c \
 	c_run.c \
 	c_fifo.c \
 	c_time.c \
+	time.c \
 	hw_$(TRUSTME_HARDWARE).c
 
 protobuf: container.proto control.proto guestos.proto common/logf.proto device.proto scd.proto c_service.proto

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -52,6 +52,7 @@
 #include "tss.h"
 #include "ksm.h"
 #include "uevent.h"
+#include "time.h"
 
 #include <stdio.h>
 #include <dirent.h>
@@ -798,6 +799,7 @@ cmld_container_start(container_t *container)
 			     container_get_description(container));
 			return -1;
 		}
+		time_register_clock_check();
 	} else {
 		DEBUG("Container %s has been already started",
 		      container_get_description(container));
@@ -1220,6 +1222,10 @@ cmld_init(const char *path)
 		FATAL("Could not init power module");
 	INFO("power initialized.");
 #endif
+	if (time_init() < 0)
+		FATAL("Could not init time module");
+	INFO("time initialized.");
+
 	if (uevent_init() < 0)
 		FATAL("Could not init uevent module");
 	INFO("uevent initialized.");

--- a/daemon/time.c
+++ b/daemon/time.c
@@ -1,0 +1,195 @@
+/*
+ * This file is part of trust|me
+ * Copyright(c) 2013 - 2020 Fraunhofer AISEC
+ * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 (GPL 2), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * The full GNU General Public License is included in this distribution in
+ * the file called "COPYING".
+ *
+ * Contact Information:
+ * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ */
+
+#include "time.h"
+
+#include "common/macro.h"
+#include "common/mem.h"
+#include "common/event.h"
+#include "common/proc.h"
+#include "common/sock.h"
+#include "common/fd.h"
+
+#include <errno.h>
+#include <time.h>
+#include <math.h>
+#include <stdio.h>
+#include <arpa/inet.h>
+#include <sys/types.h>
+#include <stdbool.h>
+
+#define NTP_SERVICE_PORT "123"
+#define NTP_TIMESTAMP_DELTA 2208988800ull
+
+#define TIME_MINUTES(m) (m * 60)
+#define TIME_HOURES(h) (h * 60 * 60)
+
+#define TIME_SYSTEM_OFF_ALLOW (TIME_HOURES(1))
+
+#define NTP_LI_VERSION_MODE(li, version, mode) ((li << 6) | (version << 3) | mode)
+
+typedef struct {
+	uint8_t li_version_mode;
+	uint8_t stratum;
+	uint8_t poll_interval;
+	uint8_t precision;
+	uint32_t root_delay;
+	uint32_t root_dispersion;
+	uint32_t ref_clock_id;
+	uint32_t ref_timestamp_sec;
+	uint32_t ref_timestamp_frac;
+	uint32_t orig_timestamp_sec;
+	uint32_t orig_timestamp_frac;
+	uint32_t rx_timestamp_sec;
+	uint32_t rx_timestamp_frac;
+	uint32_t tx_timestamp_sec; // for coarse server time we only use this
+	uint32_t tx_timestamp_frac;
+} ntp_v3_t;
+
+static time_t btime_cml;
+static char *time_ntp_server = "de.pool.ntp.org";
+event_timer_t *time_clock_check_timer = NULL;
+static bool time_out_of_sync = false;
+
+static time_t
+time_get_ntp_coarse(char *server)
+{
+	/*
+	 * since we cannot trust our local time we just take
+	 * the servers transmit timestamp into account and ignore
+	 * local timestamps for roundtrip elimination
+	 */
+	ntp_v3_t *ntp = mem_new0(ntp_v3_t, 1);
+
+	// li = 0 , version = 3 , mode = 3
+	ntp->li_version_mode = NTP_LI_VERSION_MODE(0, 3, 3);
+
+	int sock = sock_inet_create_and_connect(SOCK_DGRAM, server, NTP_SERVICE_PORT);
+	IF_TRUE_GOTO(sock < 0, err);
+	IF_TRUE_GOTO(write(sock, (char *)ntp, sizeof(ntp_v3_t)) < 0, err);
+	IF_TRUE_GOTO(read(sock, (char *)ntp, sizeof(ntp_v3_t)) < 0, err);
+
+	ntp->tx_timestamp_sec = ntohl(ntp->tx_timestamp_sec);
+	ntp->tx_timestamp_frac = ntohl(ntp->tx_timestamp_frac);
+
+	time_t ret = (time_t)(ntp->tx_timestamp_sec - NTP_TIMESTAMP_DELTA);
+
+	INFO("Got current time from server %s", ctime(&ret));
+	mem_free(ntp);
+	return ret;
+err:
+	ERROR("Communication Error with NTP Server '%s'!", server);
+	mem_free(ntp);
+	return (time_t)-1;
+}
+
+static bool
+time_system_clock_has_changed(void)
+{
+	unsigned long long btime;
+
+	if (proc_stat_btime(&btime) < 0) {
+		ERROR_ERRNO("Unable to read btime from proc)");
+		return true;
+	}
+	if (fabs(difftime(btime, btime_cml)) < TIME_MINUTES(1)) {
+		INFO("System clock still in trusted range.");
+		return false;
+	}
+	return true;
+}
+
+static void
+time_check_and_reset_clock_cb(event_timer_t *timer, UNUSED void *data)
+{
+	ASSERT(timer == time_clock_check_timer);
+
+	if (!time_system_clock_has_changed()) {
+		INFO("System clock not changed.");
+		return;
+	}
+
+	time_t ntp_now = time_get_ntp_coarse(time_ntp_server);
+	IF_TRUE_RETURN(ntp_now == (time_t)-1);
+
+	time_t system_now = time(NULL);
+	IF_TRUE_RETURN(system_now == (time_t)-1);
+
+	if (fabs(difftime(ntp_now, system_now)) > TIME_SYSTEM_OFF_ALLOW) {
+		INFO("System clock out of trusted range. updating internal btime according to NTP");
+		btime_cml = ntp_now - btime_cml;
+		event_remove_timer(timer);
+		event_timer_free(timer);
+		time_clock_check_timer = NULL;
+		time_out_of_sync = true;
+	} else {
+		INFO("System clock still in trusted range.");
+	}
+}
+
+int
+time_init(void)
+{
+	unsigned long long btime;
+	if (proc_stat_btime(&btime) < 0) {
+		ERROR_ERRNO("Unable to read btime from proc)");
+		return -1;
+	}
+	btime_cml = btime;
+	return 0;
+}
+
+time_t
+time_cml(time_t *tloc)
+{
+	time_t ret;
+	struct timespec ts;
+
+	if (clock_gettime(CLOCK_BOOTTIME, &ts) == -1) {
+		ERROR_ERRNO("Unable to read CLOCK_BOOTTIME");
+		return (time_t)-1;
+	}
+
+	ret = ts.tv_sec + btime_cml;
+	if (tloc)
+		*tloc = ret;
+
+	return ret;
+}
+
+void
+time_register_clock_check(void)
+{
+	// time already out of sync and coarse ntp timestamp in use
+	IF_TRUE_RETURN(time_out_of_sync);
+
+	if (time_clock_check_timer == NULL) {
+		time_clock_check_timer =
+			event_timer_new(TIME_MINUTES(11) * 1000, EVENT_TIMER_REPEAT_FOREVER,
+					time_check_and_reset_clock_cb, NULL);
+		event_add_timer(time_clock_check_timer);
+	}
+
+	// run time_check_and_reset_clock_cb at once
+	time_check_and_reset_clock_cb(time_clock_check_timer, NULL);
+}

--- a/daemon/time.h
+++ b/daemon/time.h
@@ -1,0 +1,54 @@
+/*
+ * This file is part of trust|me
+ * Copyright(c) 2013 - 2020 Fraunhofer AISEC
+ * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 (GPL 2), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * The full GNU General Public License is included in this distribution in
+ * the file called "COPYING".
+ *
+ * Contact Information:
+ * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ */
+
+#include <time.h>
+
+/**
+ * Initialize time subsystem. This function takes a snapshot
+ * of btime stamp according to the realtime and boottime clocks.
+ *
+ * @return  0 on success, -1 on error
+ */
+int
+time_init(void);
+
+/*
+ * Simulate "time_t time(time_t *tloc)" with CLOCK_BOOTTIME and fixed CML
+ * btime stamp during cmld start with time_init() before any container was running.
+ *
+ * @return  the value of time in seconds since the Epoch, ((time_t) -1) on error
+ */
+time_t
+time_cml(time_t *tloc);
+
+/*
+ * Register the clock check timer. Execute this function after a container start.
+ * Since container's (at least privileged containers) may set the system clock
+ * through the service interface, e.g., by running an ntp server with
+ * CAP_SYS_TIME inside the container. We have to register the clock watcher
+ * which prvides coarse time stamp through time_cml above.
+ * The timer deregisters it self if clock out of sync is detected and the
+ * internal cml boot time stamp is adapted to an CML internal ntp request.
+ */
+void
+time_register_clock_check(void);


### PR DESCRIPTION
Since we allow to run processes with CAP_SYS_TIME inside of
containers, we may not trust the real-time clock in CML anymore.
However, this approach is necessary to be able to run an NTP server and
client inside of a container.
However, if the container is malicious we cannot trust the real time clock
anymore. To provide a real-time clock independent time stamp, we rely on the
boot time clock which is time namespaced by the kernel. Further, if out
of sync of real-time clock and boot time based internal clock is detected,
we update the internal btime by a simple internal ntp call.

For certificate validity checks, we can now use the coarse time stamp
provided by time_cml() which is based on the above described implementation.

Further, patches can use this in combination with seccomp notify to emulate
the time() syscall, e.g., used by scd.