### PR TITLE
Assign netif by mac and fixed netdev assignment (mainly in uevent)

### DIFF
--- a/common/network.c
+++ b/common/network.c
@@ -652,3 +652,76 @@ msg_err:
 	nl_sock_free(nl_sock);
 	return -1;
 }
+
+int
+network_str_to_mac_addr(const char *mac_str, uint8_t mac[6])
+{
+	int ret =
+		sscanf(mac_str,
+		       "%02" SCNx8 ":%02" SCNx8 ":%02" SCNx8 ":%02" SCNx8 ":%02" SCNx8 ":%02" SCNx8,
+		       &mac[0], &mac[1], &mac[2], &mac[3], &mac[4], &mac[5]);
+
+	IF_TRUE_RETVAL((ret == EOF || ret < 6), -1);
+
+	return 0;
+}
+
+char *
+network_mac_addr_to_str_new(uint8_t mac[6])
+{
+	return mem_printf("%02" SCNx8 ":%02" SCNx8 ":%02" SCNx8 ":%02" SCNx8 ":%02" SCNx8
+			  ":%02" SCNx8,
+			  mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+}
+
+int
+network_get_mac_by_ifname(const char *ifname, uint8_t mac[6])
+{
+	IF_NULL_RETVAL(ifname, -1);
+	IF_NULL_RETVAL(mac, -1);
+
+	char *dev_addr_path = mem_printf("/sys/class/net/%s/address", ifname);
+	char *mac_str = file_read_new(dev_addr_path, 128);
+	mem_free(dev_addr_path);
+
+	IF_NULL_RETVAL(mac_str, -1);
+
+	memset(mac, 0, 6);
+	int ret = network_str_to_mac_addr(mac_str, mac);
+
+	mem_free(mac_str);
+	return ret;
+}
+
+char *
+network_get_ifname_by_addr_new(uint8_t mac[6])
+{
+	IF_NULL_RETVAL(mac, NULL);
+
+	struct if_nameindex *if_ni, *i;
+	if_ni = if_nameindex();
+
+	IF_NULL_RETVAL(if_ni, NULL);
+
+	uint8_t mac_i[6];
+
+	for (i = if_ni; i->if_index != 0 || i->if_name != NULL; i++) {
+		char *dev_addr_path = mem_printf("/sys/class/net/%s/address", i->if_name);
+		char *mac_str = file_read_new(dev_addr_path, 128);
+		mem_free(dev_addr_path);
+		if (mac_str == NULL)
+			continue;
+
+		memset(mac_i, 0, 6);
+
+		if ((0 == network_str_to_mac_addr(mac_str, mac_i)) &&
+		    (0 == memcmp(mac, mac_i, 6))) {
+			mem_free(mac_str);
+			return mem_strdup(i->if_name);
+		}
+
+		mem_free(mac_str);
+	}
+
+	return NULL;
+}

--- a/common/network.h
+++ b/common/network.h
@@ -188,4 +188,40 @@ network_rtnet_move_ns(const char *ifi_name, const pid_t pid);
 int
 network_rename_ifi(const char *old_ifi_name, const char *new_ifi_name);
 
+/**
+ * Convert a String representing a mac address ,e.g., "00:11:22:33:44:55"
+ * to the corresponding byte array.
+ * @param mac_str String representing the mac
+ * @param mac buffer for the resulting byte array
+ * @return 0 on success, -1 on error
+ */
+int
+network_str_to_mac_addr(const char *mac_str, uint8_t mac[6]);
+
+/**
+ * Constructs a String representation for a mac address.
+ * @param mac array to be converted
+ * @return The string representing the mac, NULL on error
+ */
+char *
+network_mac_addr_to_str_new(uint8_t mac[6]);
+
+/**
+ * Walk through sysfs to find the if name, e.g., shown by ip addr, to the corresponding
+ * hardware (mac) address.
+ * @param mac array containing the mac address
+ * @return The name of the interface
+ */
+char *
+network_get_ifname_by_addr_new(uint8_t mac[6]);
+
+/**
+ * Get mac address for network interface given by name.
+ * @param ifname network interface name
+ * @param mac buffer for the resulting byte array
+ * @return 0 on success, -1 on error
+ */
+int
+network_get_mac_by_ifname(const char *ifname, uint8_t mac[6]);
+
 #endif /* NETWORK_H */

--- a/common/proc.h
+++ b/common/proc.h
@@ -69,4 +69,12 @@ proc_fork_and_execvp(const char *const *argv);
 int
 proc_cap_last_cap(void);
 
+/**
+ * Returns the btime field from /proc/stat in buffer boottime_sec
+ * @param boottime_sec pointer to buffer for result
+ * @return 0 on success, -1 on error
+ */
+int
+proc_stat_btime(unsigned long long *boottime_sec);
+
 #endif /* PROC_H */

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -101,6 +101,7 @@ SRC_FILES := main.c \
 	c_run.c \
 	c_fifo.c \
 	c_time.c \
+	time.c \
 	hw_$(TRUSTME_HARDWARE).c \
 	input.c
 

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -52,6 +52,7 @@
 #include "tss.h"
 #include "ksm.h"
 #include "uevent.h"
+#include "time.h"
 
 #include <stdio.h>
 #include <dirent.h>
@@ -798,6 +799,7 @@ cmld_container_start(container_t *container)
 			     container_get_description(container));
 			return -1;
 		}
+		time_register_clock_check();
 	} else {
 		DEBUG("Container %s has been already started",
 		      container_get_description(container));
@@ -1220,6 +1222,10 @@ cmld_init(const char *path)
 		FATAL("Could not init power module");
 	INFO("power initialized.");
 #endif
+	if (time_init() < 0)
+		FATAL("Could not init time module");
+	INFO("time initialized.");
+
 	if (uevent_init() < 0)
 		FATAL("Could not init uevent module");
 	INFO("uevent initialized.");

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -1517,7 +1517,7 @@ cmld_netif_phys_remove_by_name(const char *if_name)
 	}
 	if (found) {
 		INFO("Removing '%s' from global available physical netifs", if_name);
-		cmld_netif_phys_list = list_remove(cmld_netif_phys_list, found);
+		cmld_netif_phys_list = list_unlink(cmld_netif_phys_list, found);
 		return true;
 	}
 	return false;

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -1477,7 +1477,7 @@ void
 cmld_netif_phys_add_by_name(const char *if_name)
 {
 	IF_NULL_RETURN(if_name);
-	DEBUG("Adding network interface %s to cmld", if_name);
+	INFO("Adding '%s' to global available physical netifs", if_name);
 
 	for (list_t *l = cmld_netif_phys_list; l; l = l->next) {
 		char *cmld_if_name = l->data;
@@ -1485,6 +1485,7 @@ cmld_netif_phys_add_by_name(const char *if_name)
 			return;
 		}
 	}
+	cmld_netif_phys_list = list_append(cmld_netif_phys_list, mem_strdup(if_name));
 }
 
 #define PROC_FSES "/proc/filesystems"

--- a/daemon/cmld.h
+++ b/daemon/cmld.h
@@ -283,9 +283,6 @@ cmld_netif_phys_remove_by_name(const char *if_name);
 void
 cmld_netif_phys_add_by_name(const char *if_name);
 
-char *
-cmld_rename_ifi_new(const char *oldname);
-
 /**
  * Checks if kernel supports shiftfs
  */

--- a/daemon/container.c
+++ b/daemon/container.c
@@ -333,12 +333,10 @@ container_new_internal(const uuid_t *uuid, const char *name, container_type_t ty
 	}
 
 	// network interfaces from container config
-	//TODO if_name == NULL => segfault
 	for (list_t *elem = net_ifaces; elem != NULL; elem = elem->next) {
-		char *if_name = elem->data;
-		DEBUG("List element in net_ifaces: %s", if_name);
-		if (cmld_netif_phys_remove_by_name(if_name))
-			nw_mv_name_list = list_append(nw_mv_name_list, mem_strdup(if_name));
+		char *if_name_macstr = elem->data;
+		nw_mv_name_list = list_append(nw_mv_name_list, mem_strdup(if_name_macstr));
+		DEBUG("List element in net_ifaces: %s", if_name_macstr);
 	}
 
 	container->net = c_net_new(container, ns_net, vnet_cfg_list, nw_mv_name_list, adb_port);

--- a/daemon/container.c
+++ b/daemon/container.c
@@ -2293,13 +2293,15 @@ container_add_net_iface(container_t *container, const char *iface, bool persiste
 	bool a0_is_up = (state_a0 == CONTAINER_STATE_RUNNING ||
 			 state_a0 == CONTAINER_STATE_BOOTING || state_a0 == CONTAINER_STATE_SETUP);
 
+	IF_FALSE_RETVAL(cmld_netif_phys_remove_by_name(iface), -1);
+
 	if (cmld_containers_get_a0() == container) {
 		if (a0_is_up)
 			res = c_net_move_ifi(iface, pid);
+		// re-add iface to list of available network interfaces
+		cmld_netif_phys_add_by_name(iface);
 		return res;
 	}
-
-	IF_FALSE_RETVAL(cmld_netif_phys_remove_by_name(iface), -1);
 
 	pid_t pid_a0 = container_get_pid(cmld_containers_get_a0());
 

--- a/daemon/container_config.c
+++ b/daemon/container_config.c
@@ -40,6 +40,7 @@
 #include "guestos.h"
 #include "guestos_mgr.h"
 #include "hardware.h"
+#include "network.h"
 #include "uevent.h"
 
 struct container_config {
@@ -548,17 +549,13 @@ container_config_get_vnet_cfg_list_new(const container_config_t *config)
 			if (file_read("/dev/urandom", (char *)mac, 6) < 0) {
 				WARN_ERRNO("Failed to read from /dev/urandom");
 			}
-			config->cfg->vnet_configs[i]->if_mac =
-				mem_printf("%02" PRIx8 ":%02" PRIx8 ":%02" PRIx8 ":%02" PRIx8
-					   ":%02" PRIx8 ":%02" PRIx8,
-					   mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+			config->cfg->vnet_configs[i]->if_mac = network_mac_addr_to_str_new(mac);
 		} else {
 			INFO("Using mac %s for if %s", config->cfg->vnet_configs[i]->if_mac,
 			     config->cfg->vnet_configs[i]->if_name);
-			sscanf(config->cfg->vnet_configs[i]->if_mac,
-			       "%02" SCNx8 ":%02" SCNx8 ":%02" SCNx8 ":%02" SCNx8 ":%02" SCNx8
-			       ":%02" SCNx8,
-			       &mac[0], &mac[1], &mac[2], &mac[3], &mac[4], &mac[5]);
+			if (network_str_to_mac_addr(config->cfg->vnet_configs[i]->if_mac, mac) ==
+			    -1)
+				WARN_ERRNO("Failed to parse mac from config!");
 		}
 		// sanitize mac veth otherwise kernel may reject the mac
 		mac[0] &= 0xfe; /* clear multicast bit */

--- a/daemon/time.c
+++ b/daemon/time.c
@@ -1,0 +1,195 @@
+/*
+ * This file is part of trust|me
+ * Copyright(c) 2013 - 2020 Fraunhofer AISEC
+ * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 (GPL 2), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * The full GNU General Public License is included in this distribution in
+ * the file called "COPYING".
+ *
+ * Contact Information:
+ * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ */
+
+#include "time.h"
+
+#include "common/macro.h"
+#include "common/mem.h"
+#include "common/event.h"
+#include "common/proc.h"
+#include "common/sock.h"
+#include "common/fd.h"
+
+#include <errno.h>
+#include <time.h>
+#include <math.h>
+#include <stdio.h>
+#include <arpa/inet.h>
+#include <sys/types.h>
+#include <stdbool.h>
+
+#define NTP_SERVICE_PORT "123"
+#define NTP_TIMESTAMP_DELTA 2208988800ull
+
+#define TIME_MINUTES(m) (m * 60)
+#define TIME_HOURS(h) (h * 60 * 60)
+
+#define TIME_SYSTEM_OFF_ALLOW (TIME_HOURS(1))
+
+#define NTP_LI_VERSION_MODE(li, version, mode) ((li << 6) | (version << 3) | mode)
+
+typedef struct {
+	uint8_t li_version_mode;
+	uint8_t stratum;
+	uint8_t poll_interval;
+	uint8_t precision;
+	uint32_t root_delay;
+	uint32_t root_dispersion;
+	uint32_t ref_clock_id;
+	uint32_t ref_timestamp_sec;
+	uint32_t ref_timestamp_frac;
+	uint32_t orig_timestamp_sec;
+	uint32_t orig_timestamp_frac;
+	uint32_t rx_timestamp_sec;
+	uint32_t rx_timestamp_frac;
+	uint32_t tx_timestamp_sec; // for coarse server time we only use this
+	uint32_t tx_timestamp_frac;
+} ntp_v3_t;
+
+static time_t btime_cml;
+static char *time_ntp_server = "de.pool.ntp.org";
+event_timer_t *time_clock_check_timer = NULL;
+static bool time_out_of_sync = false;
+
+static time_t
+time_get_ntp_coarse(char *server)
+{
+	/*
+	 * since we cannot trust our local time we just take
+	 * the servers transmit timestamp into account and ignore
+	 * local timestamps for roundtrip elimination
+	 */
+	ntp_v3_t *ntp = mem_new0(ntp_v3_t, 1);
+
+	// li = 0 , version = 3 , mode = 3
+	ntp->li_version_mode = NTP_LI_VERSION_MODE(0, 3, 3);
+
+	int sock = sock_inet_create_and_connect(SOCK_DGRAM, server, NTP_SERVICE_PORT);
+	IF_TRUE_GOTO(sock < 0, err);
+	IF_TRUE_GOTO(write(sock, (char *)ntp, sizeof(ntp_v3_t)) < 0, err);
+	IF_TRUE_GOTO(read(sock, (char *)ntp, sizeof(ntp_v3_t)) < 0, err);
+
+	ntp->tx_timestamp_sec = ntohl(ntp->tx_timestamp_sec);
+	ntp->tx_timestamp_frac = ntohl(ntp->tx_timestamp_frac);
+
+	time_t ret = (time_t)(ntp->tx_timestamp_sec - NTP_TIMESTAMP_DELTA);
+
+	INFO("Got current time from server %s", ctime(&ret));
+	mem_free(ntp);
+	return ret;
+err:
+	ERROR("Communication Error with NTP Server '%s'!", server);
+	mem_free(ntp);
+	return (time_t)-1;
+}
+
+static bool
+time_system_clock_has_changed(void)
+{
+	unsigned long long btime;
+
+	if (proc_stat_btime(&btime) < 0) {
+		ERROR_ERRNO("Unable to read btime from proc)");
+		return true;
+	}
+	if (fabs(difftime(btime, btime_cml)) < TIME_MINUTES(1)) {
+		INFO("System clock still in trusted range.");
+		return false;
+	}
+	return true;
+}
+
+static void
+time_check_and_reset_clock_cb(event_timer_t *timer, UNUSED void *data)
+{
+	ASSERT(timer == time_clock_check_timer);
+
+	if (!time_system_clock_has_changed()) {
+		INFO("System clock not changed.");
+		return;
+	}
+
+	time_t ntp_now = time_get_ntp_coarse(time_ntp_server);
+	IF_TRUE_RETURN(ntp_now == (time_t)-1);
+
+	time_t system_now = time(NULL);
+	IF_TRUE_RETURN(system_now == (time_t)-1);
+
+	if (fabs(difftime(ntp_now, system_now)) > TIME_SYSTEM_OFF_ALLOW) {
+		INFO("System clock out of trusted range. updating internal btime according to NTP");
+		btime_cml = ntp_now - btime_cml;
+		event_remove_timer(timer);
+		event_timer_free(timer);
+		time_clock_check_timer = NULL;
+		time_out_of_sync = true;
+	} else {
+		INFO("System clock still in trusted range.");
+	}
+}
+
+int
+time_init(void)
+{
+	unsigned long long btime;
+	if (proc_stat_btime(&btime) < 0) {
+		ERROR_ERRNO("Unable to read btime from proc)");
+		return -1;
+	}
+	btime_cml = btime;
+	return 0;
+}
+
+time_t
+time_cml(time_t *tloc)
+{
+	time_t ret;
+	struct timespec ts;
+
+	if (clock_gettime(CLOCK_BOOTTIME, &ts) == -1) {
+		ERROR_ERRNO("Unable to read CLOCK_BOOTTIME");
+		return (time_t)-1;
+	}
+
+	ret = ts.tv_sec + btime_cml;
+	if (tloc)
+		*tloc = ret;
+
+	return ret;
+}
+
+void
+time_register_clock_check(void)
+{
+	// time already out of sync and coarse ntp timestamp in use
+	IF_TRUE_RETURN(time_out_of_sync);
+
+	if (time_clock_check_timer == NULL) {
+		time_clock_check_timer =
+			event_timer_new(TIME_MINUTES(11) * 1000, EVENT_TIMER_REPEAT_FOREVER,
+					time_check_and_reset_clock_cb, NULL);
+		event_add_timer(time_clock_check_timer);
+	}
+
+	// run time_check_and_reset_clock_cb at once
+	time_check_and_reset_clock_cb(time_clock_check_timer, NULL);
+}

--- a/daemon/time.h
+++ b/daemon/time.h
@@ -1,0 +1,56 @@
+/*
+ * This file is part of trust|me
+ * Copyright(c) 2013 - 2020 Fraunhofer AISEC
+ * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 (GPL 2), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * The full GNU General Public License is included in this distribution in
+ * the file called "COPYING".
+ *
+ * Contact Information:
+ * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ */
+
+#include <time.h>
+
+/**
+ * Initialize time subsystem. This function takes a snapshot
+ * of btime stamp according to the realtime and boottime clocks.
+ *
+ * @return  0 on success, -1 on error
+ */
+int
+time_init(void);
+
+/*
+ * Simulate "time_t time(time_t *tloc)" with CLOCK_BOOTTIME and fixed CML
+ * btime stamp during cmld start with time_init() before any container was running.
+ *
+ * @param   tloc If tloc is non-NULL, the return value is also stored in the memory
+ *          pointed to by tloc.
+ * @return  the value of time in seconds since the Epoch, ((time_t) -1) on error
+ */
+time_t
+time_cml(time_t *tloc);
+
+/*
+ * Register the clock check timer. Execute this function after a container start.
+ * Since container's (at least privileged containers) may set the system clock
+ * through the service interface, e.g., by running an ntp server with
+ * CAP_SYS_TIME inside the container. We have to register the clock watcher
+ * which prvides coarse time stamp through time_cml above.
+ * The timer deregisters it self if clock out of sync is detected and the
+ * internal cml boot time stamp is adapted to an CML internal ntp request.
+ */
+void
+time_register_clock_check(void);

--- a/daemon/uevent.c
+++ b/daemon/uevent.c
@@ -459,6 +459,10 @@ uevent_rename_interface(const struct uevent *uevent)
 	if (!new_ifname)
 		return NULL;
 
+	// replace ifname in cmld's available netifs
+	if (cmld_netif_phys_remove_by_name(uevent->interface))
+		cmld_netif_phys_add_by_name(new_ifname);
+
 	char *new_devpath =
 		uevent_replace_devpath_new(uevent->devpath, uevent->interface, new_ifname);
 

--- a/daemon/uevent.c
+++ b/daemon/uevent.c
@@ -414,24 +414,17 @@ uevent_replace_devpath_new(const char *str, const char *oldstr, const char *news
 }
 
 char *
-uevent_rename_ifi_new(const char *oldname)
+uevent_rename_ifi_new(const char *oldname, const char *infix)
 {
 	static unsigned int cmld_wlan_idx = 0;
 	static unsigned int cmld_eth_idx = 0;
 
 	//generate interface name that is unique
 	//in the root network namespace
-	const char *infix;
 	unsigned int *ifi_idx;
 	char *newname = NULL;
 
-	if (network_interface_is_wifi(oldname)) {
-		infix = "wlan";
-		ifi_idx = &cmld_wlan_idx;
-	} else {
-		infix = "eth";
-		ifi_idx = &cmld_eth_idx;
-	}
+	ifi_idx = !strcmp(infix, "wlan") ? &cmld_wlan_idx : &cmld_eth_idx;
 
 	if (-1 == asprintf(&newname, "%s%s%d", "cml", infix, *ifi_idx)) {
 		ERROR("Failed to generate new interface name");
@@ -454,7 +447,7 @@ uevent_rename_ifi_new(const char *oldname)
 static struct uevent *
 uevent_rename_interface(const struct uevent *uevent)
 {
-	char *new_ifname = uevent_rename_ifi_new(uevent->interface);
+	char *new_ifname = uevent_rename_ifi_new(uevent->interface, uevent->devtype);
 
 	if (!new_ifname)
 		return NULL;

--- a/daemon/uevent.h
+++ b/daemon/uevent.h
@@ -99,6 +99,22 @@ int
 uevent_unregister_usbdevice(container_t *container, uevent_usbdev_t *usbdev);
 
 /**
+  * Registers a net device by its mac address for a container at the uevent subsystem
+  */
+int
+uevent_register_netdev(container_t *container, uint8_t mac[6]);
+
+/**
+ * Unregisters a net device by its mac address for a container at the uevent subsystem
+ *
+ * @param container container which assigns the interface
+ * @param mac buffer containing the mac address of the interface which should be registered
+ * @return 0 if successful. -1 indicates an error.
+ */
+int
+uevent_unregister_netdev(container_t *container, uint8_t mac[6]);
+
+/**
   * Trigger cold boot events to allow user namespaced containers to fixup
   * their device nodes by udevd in container
   */


### PR DESCRIPTION
Main feature is: **daemon/container, c_net: allow to use mac string for netif assignment**
The container config file allows to set a repeated string for network
interface names which are assigned/moved to the container net namespace.
This field now accepts a string representation of mac addresses in form
of "00:11:22:33:44:55", too. The protobuf inteface is not touched and the
descission if the string is a mac or ifname is made in c_net submodule.

However, see commit messages for details.