### PR TITLE
Audit subsystem

### DIFF
--- a/common/logf.c
+++ b/common/logf.c
@@ -299,6 +299,9 @@ logf_file_write(logf_prio_t prio, const char *msg, void *data)
 	if (!data)
 		return;
 
+	int fd = fileno(data);
+	printf("%d", fd);
+
 	logf_file_write_timestamp(data);
 	fprintf(data, "[%u] %s %s\n", getpid(), prio_str(prio), msg);
 	fflush(data);

--- a/common/logf.h
+++ b/common/logf.h
@@ -297,4 +297,12 @@ logf_klog_new(const char *name);
 void
 logf_klog_write(logf_prio_t prio, const char *msg, void *data);
 
+/**
+ * Create timestamp
+ *
+ * @return Timestamp as ascii string.
+ */
+char *
+logf_get_timestamp_new();
+
 #endif /* LOGF_H */

--- a/common/uuid.c
+++ b/common/uuid.c
@@ -26,6 +26,8 @@
 #include <string.h>
 #include <strings.h>
 #include <stdlib.h>
+#include <limits.h>
+#include <unistd.h>
 
 #include "common/macro.h"
 #include "common/mem.h"
@@ -172,4 +174,25 @@ uuid_string(const uuid_t *uuid)
 {
 	IF_NULL_RETVAL(uuid, NULL);
 	return uuid->string;
+}
+
+uint64_t
+uuid_get_node(const uuid_t *uuid)
+{
+	ASSERT(uuid);
+
+	uint64_t node = 0;
+
+	sleep(30);
+
+	// 48-bit correspond to 12 hex characters
+	int ret = sscanf(uuid->string - (strlen(uuid->string) - 12), "%12lx", &node);
+	if (1 < ret) {
+		ERROR_ERRNO("Failed to read node ID");
+		DEBUG("Failed to return id");
+		return ULLONG_MAX;
+	}
+
+	DEBUG("Read id: %lx", node);
+	return node;
 }

--- a/common/uuid.h
+++ b/common/uuid.h
@@ -32,6 +32,7 @@
 #define UUID_H
 
 #include <stdbool.h>
+#include <stdint.h>
 
 typedef struct uuid uuid_t;
 
@@ -72,5 +73,14 @@ uuid_free(uuid_t *uuid);
  */
 const char *
 uuid_string(const uuid_t *uuid);
+
+/**
+ * Get 48 bit node ID in last Part of uuid
+ *
+ * @param uuid UUID for which the string representation is returned.
+ * @return The node ID as 64 bit unsigned integer
+ */
+uint64_t
+uuid_get_node(const uuid_t *uuid);
 
 #endif /* UUID_H */

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -29,7 +29,7 @@ SANITIZERS ?= n
 TRUSTME_HARDWARE := x86
 
 LOCAL_CFLAGS := -std=gnu99 -Icommon -I.. -I../include -I../tpm2d -pedantic -O2
-LOCAL_CFLAGS += -Wall -Wextra -Wcast-align -Wformat -Wformat-security -fstack-protector-all -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -fpic -pie
+LOCAL_CFLAGS += -Wall -Wextra -Wcast-align -Wformat -Wformat-security -fstack-protector-all -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -fpic -pie -O0
 ifeq ($(CC),gcc)
     # clang does not support stack clash protection yet
     LOCAL_CFLAGS += -fstack-clash-protection
@@ -104,7 +104,9 @@ SRC_FILES := main.c \
 	time.c \
 	hw_$(TRUSTME_HARDWARE).c \
 	lxcfs.c \
-	input.c
+	input.c \
+	audit.c \
+	c_audit.c
 
 protobuf: container.proto control.proto guestos.proto common/logf.proto device.proto scd.proto c_service.proto
 	protoc-c --c_out=. container.proto

--- a/daemon/audit.c
+++ b/daemon/audit.c
@@ -1,0 +1,697 @@
+/*
+ * This file is part of trust|me
+ * Copyright(c) 2013 - 2020 Fraunhofer AISEC
+ * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 (GPL 2), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * The full GNU General Public License is included in this distribution in
+ * the file called "COPYING".
+ *
+ * Contact Information:
+ * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include "audit.h"
+
+#include "cmld.h"
+#include "smartcard.h"
+#include "common/mem.h"
+#include "common/uuid.h"
+#include "common/str.h"
+#include "common/macro.h"
+#include "common/dir.h"
+#include "common/file.h"
+#include "common/protobuf.h"
+
+#include <string.h>
+#include <time.h>
+#include <google/protobuf-c/protobuf-c-text.h>
+
+//TODO implement ACK mechanism fpr all service messages inside c-service.c?
+#ifdef ANDROID
+#include "device/fraunhofer/common/cml/daemon/c_service.pb-c.h"
+#else
+#include "c_service.pb-c.h"
+#endif
+
+#define AUDIT_HASH_ALGO SHA512
+#define AUDIT_HASH_ALGO_LEN 64
+
+#define AUDIT_DEFAULT_CONTAINER "00000000-0000-0000-0000-000000000000"
+
+#define AUDIT_DELIMITER "-----\n"
+
+#undef LOGF_LOG_MIN_PRIO
+#define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE
+
+#define AUDIT_LOGDIR "/data/audit"
+
+uint64_t AUDIT_STORAGE = 0;
+
+const char *evcategory[] = { "SUA", "FUA", "SSA", "FSA", "RLE" };
+const char *evclass[] = { "GUESTOS_MGMT", "TOKEN_MGMT", "CONTAINER_MGMT", "CONTAINER_ISOLATION",
+			  "TPM_COMM" };
+const char *severity[] = { "INFO", "WARN", "ERROR", "FATAL" };
+const char *component[] = { "CMLD", "SCD", "TPM2D" };
+const char *result[] = { "SUCCESS", "FAIL" };
+
+static AUDIT_MODE LOGMODE = CONTAINER;
+
+typedef struct {
+	char *key;
+	char *value;
+} audit_meta_t;
+
+static container_t *
+audit_get_log_container(const uuid_t *uuid)
+{
+	container_t *c = NULL;
+
+	if (uuid && LOGMODE == CONTAINER) {
+		c = cmld_container_get_by_uuid(uuid);
+	}
+
+	if (!c) {
+		c = cmld_containers_get_a0();
+	}
+
+	return c;
+}
+
+char *
+audit_log_file_new(const char *uuid)
+{
+	if (C0 == LOGMODE)
+		return mem_printf("%s/%s.log", AUDIT_LOGDIR, AUDIT_DEFAULT_CONTAINER);
+	else
+		return mem_printf("%s/%s.log", AUDIT_LOGDIR, uuid);
+}
+
+static uint64_t
+audit_remaining_storage(const char *uuid)
+{
+	char *file = audit_log_file_new(uuid);
+	off_t size = file_size(file);
+
+	mem_free(file);
+
+	if (!file_exists(file)) {
+		return AUDIT_STORAGE;
+	}
+
+	if (0 > size) {
+		ERROR_ERRNO("Failed to retrieve size of audit log file");
+		return 0;
+	}
+
+	if ((uint64_t)size > AUDIT_STORAGE) {
+		ERROR("Detected audit log overflow");
+		return 0;
+	}
+
+	return AUDIT_STORAGE - size;
+}
+
+const char *
+audit_result_to_string(AUDIT_RESULT c)
+{
+	return result[c];
+}
+
+const char *
+audit_category_to_string(AUDIT_CATEGORY c)
+{
+	return evcategory[c];
+}
+
+const char *
+audit_evclass_to_string(AUDIT_EVENTCLASS c)
+{
+	return evclass[c];
+}
+
+const char *
+audit_severity_to_string(AUDIT_SEVERITY s)
+{
+	return severity[s];
+}
+
+const char *
+audit_component_to_string(AUDIT_COMPONENT c)
+{
+	return component[c];
+}
+
+static void
+audit_send_record_cb(const char *hash_string, const char *hash_file,
+		     UNUSED smartcard_crypto_hashalgo_t hash_algo, void *data)
+{
+	if (!hash_string) {
+		ERROR("audit_send_record_cb: hash_string was empty");
+		return;
+	}
+
+	if (!hash_file) {
+		ERROR("audit_send_record_cb: hash_file was empty");
+		return;
+	}
+
+	if (!data) {
+		ERROR("audit_send_record_cb: No container given");
+		return;
+	}
+
+	const container_t *c = (const container_t *)data;
+	ASSERT(c);
+
+	uint32_t buf_len = file_size(hash_file);
+	uint8_t *buf = mem_alloc0(buf_len);
+
+	int read = file_read(hash_file, (char *)buf, buf_len);
+
+	if (read < 0 || buf_len != (unsigned int)read) {
+		ERROR("Processing SCD response: read %u bytes, expected %u", read, buf_len);
+		goto out;
+	}
+
+	TRACE("Got hash from SCD for file %s: %s", hash_file, hash_string);
+
+	container_audit_set_processing_ack(c, false);
+
+	if (unlink(hash_file)) {
+		ERROR_ERRNO("Failed to unlink %s", hash_file);
+	}
+
+	if (0 > container_audit_record_send(c, buf, buf_len)) {
+		ERROR("Failed to send audit record to container");
+		goto out;
+	}
+
+	container_audit_set_last_ack(c, mem_strdup(hash_string));
+	TRACE("Sent audit record with ID %s to container %s", container_audit_get_last_ack(c),
+	      uuid_string(container_get_uuid(c)));
+	//sleep(30);
+
+out:
+	mem_free(buf);
+}
+
+void
+audit_record_free(AuditRecord *record)
+{
+	ASSERT(record);
+
+	if (record->type)
+		mem_free(record->type);
+
+	if (record->subject_id)
+		mem_free(record->subject_id);
+
+	if (record->meta)
+		mem_free(record->meta);
+
+	mem_free(record);
+}
+
+static AuditRecord *
+audit_record_new(AUDIT_CATEGORY category, AUDIT_COMPONENT component, AUDIT_EVENTCLASS evclass,
+		 const char *evtype, const char *subject_id, int meta_length,
+		 AuditRecord__Meta **metas)
+{
+	AuditRecord *s = mem_new0(AuditRecord, 1);
+
+	audit_record__init(s);
+
+	char *type = mem_printf("%s.%s.%s.%s", audit_category_to_string(category),
+				audit_component_to_string(component),
+				audit_evclass_to_string(evclass), evtype);
+	s->timestamp = time(NULL);
+
+	if (EFAULT == errno) {
+		ERROR_ERRNO("Failed to get current time");
+		return NULL;
+	}
+
+	s->type = type;
+
+	if (subject_id)
+		s->subject_id = mem_strdup(subject_id);
+
+	s->n_meta = meta_length;
+	s->meta = metas;
+
+	return s;
+}
+
+static AuditRecord *
+audit_record_from_textfile_new(const char *filename, const ProtobufCMessageDescriptor *descriptor,
+			       bool purge)
+{
+	ASSERT(filename);
+	ASSERT(descriptor);
+
+	FILE *file = fopen(filename, "r");
+	if (!file) {
+		WARN_ERRNO("Could not open file \"%s\" for reading.", filename);
+		return NULL;
+	}
+
+	ssize_t size = file_size(filename);
+
+	if (0 > size) {
+		ERROR("Failed to retrieve size of audit record log");
+		return NULL;
+	}
+
+	// read file up to delimiter
+	char *buf = mem_alloc0(size + 1);
+	size_t read = 0;
+	bool delim_found = false;
+
+	while (!delim_found && read < (size_t)size) {
+		ssize_t current = 0;
+		size_t n = 0;
+		char *line = NULL;
+
+		if (0 > (current = getline(&line, &n, file))) {
+			ERROR_ERRNO("Failed to read line from file");
+			fclose(file);
+			goto out;
+		}
+
+		if (read + current > (size_t)size) {
+			ERROR("File was changed while reading");
+			fclose(file);
+			goto out;
+		}
+
+		// if delimiter line was read, stop further processing
+		if (!strcmp(AUDIT_DELIMITER, line)) {
+			delim_found = true;
+			continue;
+		}
+
+		memcpy(buf + read, line, current);
+		read += current;
+	}
+	fclose(file);
+
+	// parse record from file
+	AuditRecord *record;
+	if (0 == size) {
+		INFO("Read audit record with default values");
+		record = (AuditRecord *)mem_new0(AuditRecord, 1);
+		audit_record__init(record);
+		goto out;
+	} else {
+		record = (AuditRecord *)protobuf_message_new_from_buf((uint8_t *)buf, read,
+								      descriptor);
+	}
+
+	if (!record) {
+		ERROR("Failed to parse text protobuf message (%s) from file \"%s\".",
+		      descriptor->name ? descriptor->name : "UNKNOWN", filename);
+		goto out;
+	}
+
+	if (purge) {
+		// delete record from file
+		if (read + strlen(AUDIT_DELIMITER) == (size_t)size) {
+			DEBUG("Audit log empty, removing file");
+			if (-1 == unlink(filename)) {
+				ERROR_ERRNO("Failed to remove audit log file");
+			}
+			goto out;
+		}
+
+		char *filebuf = file_read_new(filename, AUDIT_STORAGE);
+
+		if (!filebuf) {
+			ERROR("Failed to read audit log file");
+			goto out;
+		}
+
+		size_t offset = read + strlen(AUDIT_DELIMITER);
+		if (-1 == file_write(filename, filebuf + offset, strlen(filebuf + offset))) {
+			ERROR_ERRNO("Failed to remove message from file: %s", filename);
+		}
+		mem_free(filebuf);
+	}
+
+out:
+	if (buf)
+		mem_free(buf);
+
+	return (AuditRecord *)record;
+}
+
+static int
+audit_write_file(const uuid_t *uuid, const AuditRecord *msg)
+{
+	int ret = -1;
+
+	char *dir = mem_printf("%s/audit", AUDIT_LOGDIR);
+
+	if (!file_is_dir(dir) && dir_mkdir_p(dir, 0600)) {
+		ERROR("Failed to create logdir");
+		mem_free(dir);
+		return -1;
+	}
+	mem_free(dir);
+
+	char *file = audit_log_file_new(uuid_string(uuid));
+
+	char *msg_text = protobuf_c_text_to_string((ProtobufCMessage *)msg, NULL);
+
+	//TODO send error message
+	if (audit_remaining_storage(uuid_string(uuid)) <
+	    (strlen(msg_text) + strlen(AUDIT_DELIMITER))) {
+		container_t *c = cmld_container_get_by_uuid(uuid);
+
+		TRACE("Trying to notify container %s about stored audit events, remaining storage: %ld",
+		      (uuid_string(uuid)), audit_remaining_storage(uuid_string(uuid)));
+		if ((!c) || (-1 == container_audit_record_notify(
+					   c, audit_remaining_storage(uuid_string(uuid))))) {
+			ERROR("Failed to notify container about audit log overflow");
+		}
+		ERROR("Failed to store audit record: max. log size exceeded");
+		goto out;
+	}
+
+	TRACE("Logging audit record to file: %s", file);
+	if (0 > file_write_append(file, msg_text, strlen(msg_text))) {
+		ERROR("Failed to log audit message to file: %s", file);
+		goto out;
+	}
+
+	if (0 > file_write_append(file, "-----\n", strlen("-----\n"))) {
+		ERROR("Failed to log audit message to file: %s", msg_text);
+		goto out;
+	}
+
+	ret = 0;
+
+out:
+	mem_free(file);
+
+	return ret;
+}
+
+static AuditRecord *
+audit_next_record_new(const container_t *c, bool purge)
+{
+	AuditRecord *r = NULL;
+
+	char *file = audit_log_file_new(uuid_string(container_get_uuid(c)));
+
+	if (file_exists(file)) {
+		r = (AuditRecord *)audit_record_from_textfile_new(file, &audit_record__descriptor,
+								  purge);
+
+		if (!r) {
+			ERROR("Failed to read audit record");
+			goto out;
+		}
+
+		TRACE("Read audit record %s from file",
+		      protobuf_c_text_to_string((ProtobufCMessage *)r, NULL) ?
+			      protobuf_c_text_to_string((ProtobufCMessage *)r, NULL) :
+			      "<broken>");
+	}
+
+out:
+	mem_free(file);
+
+	return r;
+}
+
+static int
+audit_do_send_record(const container_t *c, AuditRecord *record)
+{
+	int ret = -1;
+
+	char tmpfile[strlen(AUDIT_LOGDIR) + 14];
+	if (0 >= sprintf(tmpfile, "%s/%s", AUDIT_LOGDIR, "audit_XXXXXX")) {
+		ERROR_ERRNO("Failed to prepare temporary filename");
+		return -1;
+	}
+
+	if (!strcmp("", mktemp(tmpfile))) {
+		ERROR_ERRNO("Failed to generate temporary filename");
+		return -1;
+	}
+
+	CmldToServiceMessage *message_proto = mem_new0(CmldToServiceMessage, 1);
+	cmld_to_service_message__init(message_proto);
+	message_proto->code = CMLD_TO_SERVICE_MESSAGE__CODE__AUDIT_RECORD;
+
+	message_proto->audit_record = record;
+
+	uint8_t *packed;
+	uint32_t packed_len = protobuf_pack_message_new((ProtobufCMessage *)message_proto, &packed);
+
+	//	audit_record_free(record);
+	//	mem_free(message_proto);
+
+	protobuf_free_message((ProtobufCMessage *)message_proto);
+
+	if (!packed) {
+		ERROR("Failed to pack protobuf message");
+		goto out;
+	}
+
+	if (-1 == file_write(tmpfile, (char *)packed, packed_len)) {
+		ERROR("Failed to write packed message to file.");
+		mem_free(packed);
+		goto out;
+	}
+	mem_free(packed);
+
+	TRACE("Requesting scd to hash serialized protobuf message at %s", tmpfile);
+
+	// this state is needed s.t. additional ACKs from container arriving while scd is hashing the file
+	// do not lead to multiple transmissions of the same record
+	container_audit_set_processing_ack(c, true);
+
+	if (smartcard_crypto_hash_file(tmpfile, AUDIT_HASH_ALGO, audit_send_record_cb, (void *)c)) {
+		container_audit_set_processing_ack(c, false);
+		str_t *dump = str_hexdump_new((unsigned char *)packed, (int)packed_len);
+		ERROR("Failed to request hashing of record to be sent with length %u: %s.",
+		      packed_len, str_buffer(dump));
+		mem_free(dump);
+	}
+
+	ret = 0;
+out:
+
+	return ret;
+}
+
+static int
+audit_send_next_stored(const container_t *c)
+{
+	if (!c)
+		return -1;
+
+	char *file = audit_log_file_new(uuid_string(container_get_uuid(c)));
+
+	if (!file_exists(file)) {
+		DEBUG("Sent all stored audit messages");
+		mem_free(file);
+
+		if (0 > container_audit_notify_complete(c)) {
+			ERROR("Failed to notify container that all records were sent");
+			return -1;
+		}
+
+		container_audit_set_last_ack(c, NULL);
+		container_audit_set_processing_ack(c, false);
+
+		return 0;
+	}
+	mem_free(file);
+
+	AuditRecord *record;
+	if (!(record = audit_next_record_new(c, false))) {
+		ERROR("Could not read next audit record");
+		return -1;
+	}
+
+	if (audit_do_send_record(c, record)) {
+		ERROR("Failed to send next stored audit record");
+		mem_free(record);
+		return -1;
+	}
+	mem_free(record);
+
+	return 0;
+}
+
+int
+audit_process_ack(const container_t *c, const char *ack)
+{
+	ASSERT(c);
+
+	if (!AUDIT_STORAGE) {
+		DEBUG("Got ACK from container but AUDIT_STORAGE is zero, ignoring...");
+		return 0;
+	}
+
+	if (C0 == LOGMODE && strcmp(AUDIT_DEFAULT_CONTAINER, uuid_string(container_get_uuid(c)))) {
+		DEBUG("Got ACK from container %s, but LOGMODE is C0, ignoring...",
+		      uuid_string(container_get_uuid(c)));
+		return -1;
+	}
+
+	if (!ack) {
+		ERROR("Got audit ACK missing hash from container %s",
+		      uuid_string(container_get_uuid(c)));
+	}
+
+	if (container_audit_get_processing_ack(c)) {
+		TRACE("Already processing ACK for container %s, ignoring additional ACK",
+		      uuid_string(container_get_uuid(c)));
+		return 0;
+	}
+
+	TRACE("Got audit record ACK from container %s: %s", uuid_string(container_get_uuid(c)),
+	      ack);
+
+	if (match_hash(AUDIT_HASH_ALGO_LEN, container_audit_get_last_ack(c), ack)) {
+		TRACE("ACK hash matched last sent record %s", container_audit_get_last_ack(c));
+
+		AuditRecord *record = audit_next_record_new(c, true);
+
+		if (!record) {
+			ERROR("Failed to delete audit record %s", ack);
+			return -1;
+		}
+
+		mem_free(record);
+		TRACE("Cleaned up ack'ed record");
+
+		container_audit_set_last_ack(c, mem_strdup(""));
+	} else {
+		WARN("ACK from container %s did not match last sent audit record, try to send last stored record again",
+		     uuid_string(container_get_uuid(c)));
+	}
+
+	return audit_send_next_stored(c);
+}
+
+int
+audit_log_event(const uuid_t *uuid, AUDIT_CATEGORY category, AUDIT_COMPONENT component,
+		AUDIT_EVENTCLASS evclass, const char *evtype, const char *subject_id,
+		int meta_count, ...)
+{
+	container_t *c = NULL;
+	AuditRecord *record = NULL;
+	AuditRecord__Meta **metas = NULL;
+	int ret = 0;
+
+	if (!AUDIT_STORAGE) {
+		TRACE("Attempt to log audit message but AUDIT_STORAGE is zero, skipping...");
+		return 0;
+	}
+
+	if (0 < meta_count) {
+		if (0 != (meta_count % 2)) {
+			ERROR("Odd number of variadic arguments, aborting...");
+			return -1;
+		}
+
+		va_list ap;
+
+		va_start(ap, meta_count);
+
+		metas = mem_alloc0((meta_count / 2) * sizeof(AuditRecord__Meta *));
+		for (int i = 0; i < meta_count / 2; i++) {
+			metas[i] = mem_alloc0(sizeof(AuditRecord__Meta));
+
+			audit_record__meta__init(metas[i]);
+
+			metas[i]->key = mem_strdup(va_arg(ap, const char *));
+			metas[i]->value = mem_strdup(va_arg(ap, const char *));
+		}
+
+		va_end(ap);
+		meta_count /= 2;
+	}
+
+	record = audit_record_new(category, component, evclass, evtype, subject_id, meta_count,
+				  metas);
+
+	if (!record) {
+		ERROR("Failed to create audit record");
+		mem_free(metas);
+		goto out;
+	}
+
+	DEBUG("Logging audit message %s",
+	      protobuf_c_text_to_string((ProtobufCMessage *)record, NULL) ?
+		      protobuf_c_text_to_string((ProtobufCMessage *)record, NULL) :
+		      "");
+
+	c = audit_get_log_container(uuid);
+
+	if (c) {
+		if (0 != (ret = audit_write_file(container_get_uuid(c), record))) {
+			ERROR("Failed to store audit log for container %s to file",
+			      uuid_string(container_get_uuid(c)));
+			goto out;
+		}
+	} else {
+		ERROR("No audit logging container available, will log to file %s",
+		      AUDIT_DEFAULT_CONTAINER);
+		uuid_t *default_uuid = uuid_new(AUDIT_DEFAULT_CONTAINER);
+		if (0 != (ret = audit_write_file(default_uuid, record))) {
+			ERROR("Failed to store audit log to file");
+			uuid_free(default_uuid);
+			goto out;
+		}
+		uuid_free(default_uuid);
+	}
+
+	if (c && (container_audit_get_processing_ack(c))) {
+		TRACE("Already processing ACK, do not notify container again");
+		goto out;
+	}
+
+	if (c && (CONTAINER_STATE_RUNNING == container_get_state(c))) {
+		bool processing_ack = container_audit_get_processing_ack(c);
+		if (!processing_ack &&
+		    (-1 == container_audit_record_notify(c, audit_remaining_storage(uuid_string(
+								    container_get_uuid(c)))))) {
+			ERROR("Failed to notify container about new audit record");
+		}
+	}
+
+out:
+	//if (record)
+	//	audit_record_free(record);
+	protobuf_free_message((ProtobufCMessage *)record);
+
+	return ret;
+}
+
+int
+audit_set_size(uint32_t size)
+{
+	AUDIT_STORAGE = size * 1024 * 1024;
+
+	return 0;
+}

--- a/daemon/audit.h
+++ b/daemon/audit.h
@@ -1,0 +1,75 @@
+/*
+ * This file is part of trust|me
+ * Copyright(c) 2013 - 2020 Fraunhofer AISEC
+ * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 (GPL 2), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * The full GNU General Public License is included in this distribution in
+ * the file called "COPYING".
+ *
+ * Contact Information:
+ * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ */
+
+#ifndef AUDIT_H
+#define AUDIT_H
+
+#include "container.h"
+
+typedef enum { CONTAINER, C0 } AUDIT_MODE;
+
+typedef enum { INFO, WARN, ERROR, FATAL } AUDIT_SEVERITY;
+
+typedef enum { SUCCESS, FAIL } AUDIT_RESULT;
+
+typedef enum { SUA, FUA, SSA, FSA, RLE } AUDIT_CATEGORY;
+
+typedef enum {
+	GUESTOS_MGMT,
+	TOKEN_MGMT,
+	CONTAINER_MGMT,
+	CONTAINER_ISOLATION,
+	TPM_COMM
+} AUDIT_EVENTCLASS;
+
+typedef enum { COMMAND, INTERNAL, TOKEN, UPDATE } AUDIT_EVENTTYPE;
+
+typedef enum { CMLD, SCD, TPM2D } AUDIT_COMPONENT;
+
+const char *
+audit_evcategory_to_string(AUDIT_CATEGORY c);
+
+const char *
+audit_evclass_to_string(AUDIT_EVENTCLASS c);
+
+const char *
+audit_evtype_to_string(AUDIT_EVENTTYPE t);
+
+const char *
+audit_severity_to_string(AUDIT_SEVERITY s);
+
+const char *
+audit_component_to_string(AUDIT_COMPONENT c);
+
+int
+audit_set_size(uint32_t size);
+
+int
+audit_log_event(const uuid_t *uuid, AUDIT_CATEGORY category, AUDIT_COMPONENT component,
+		AUDIT_EVENTCLASS evclass, const char *evtype, const char *subject_id,
+		int meta_count, ...);
+
+int
+audit_process_ack(const container_t *audit, const char *ack);
+
+#endif /* AUDIT_H */

--- a/daemon/c_audit.c
+++ b/daemon/c_audit.c
@@ -1,0 +1,119 @@
+/*
+ * This file is part of trust|me
+ * Copyright(c) 2013 - 2020 Fraunhofer AISEC
+ * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 (GPL 2), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * The full GNU General Public License is included in this distribution in
+ * the file called "COPYING".
+ *
+ * Contact Information:
+ * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include "c_audit.h"
+
+#include "cmld.h"
+#include "smartcard.h"
+#include "common/mem.h"
+#include "common/uuid.h"
+#include "common/str.h"
+#include "common/macro.h"
+#include "common/dir.h"
+#include "common/file.h"
+#include "common/protobuf.h"
+
+#include <string.h>
+#include <time.h>
+#include <google/protobuf-c/protobuf-c-text.h>
+
+#undef LOGF_LOG_MIN_PRIO
+#define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE
+
+struct c_audit {
+	const container_t *container;
+	char *last_ack;
+	bool processing_ack;
+};
+
+int
+c_audit_start_child(c_audit_t *audit)
+{
+	sleep(30);
+
+	if (!file_exists("/proc/self/audit_containerid"))
+		return 0;
+
+	if (0 < file_printf("/proc/self/audit_containerid", "%llu",
+			    uuid_get_node(container_get_uuid(audit->container)))) {
+		ERROR("Failed to set audit container ID");
+		//TODO FIXME
+		//return -1;
+	}
+
+	return 0;
+}
+
+c_audit_t *
+c_audit_new(const container_t *container)
+{
+	ASSERT(container);
+
+	c_audit_t *audit = mem_new0(c_audit_t, 1);
+
+	audit->container = container;
+
+	TRACE("Node ID test: %lx", uuid_get_node(container_get_uuid(container)));
+
+	audit->container = container;
+	audit->last_ack = mem_strdup("");
+	audit->processing_ack = false;
+
+	return audit;
+}
+
+const char *
+c_audit_get_last_ack(const c_audit_t *audit)
+{
+	ASSERT(audit);
+	return audit->last_ack;
+}
+
+void
+c_audit_set_last_ack(c_audit_t *audit, char *last_ack)
+{
+	ASSERT(audit);
+
+	if (audit->last_ack)
+		mem_free(audit->last_ack);
+
+	audit->last_ack = last_ack;
+}
+
+bool
+c_audit_get_processing_ack(const c_audit_t *audit)
+{
+	ASSERT(audit);
+	return audit->processing_ack;
+}
+
+void
+c_audit_set_processing_ack(c_audit_t *audit, bool processing_ack)
+{
+	ASSERT(audit);
+	audit->processing_ack = processing_ack;
+}

--- a/daemon/c_audit.h
+++ b/daemon/c_audit.h
@@ -1,0 +1,50 @@
+/*
+ * This file is part of trust|me
+ * Copyright(c) 2013 - 2020 Fraunhofer AISEC
+ * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 (GPL 2), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * The full GNU General Public License is included in this distribution in
+ * the file called "COPYING".
+ *
+ * Contact Information:
+ * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ */
+
+#ifndef C_AUDIT_H
+#define C_AUDIT_H
+
+#include "container.h"
+#include "audit.h"
+
+typedef struct c_audit c_audit_t;
+
+c_audit_t *
+c_audit_new(const container_t *container);
+
+int
+c_audit_start_child(c_audit_t *audit);
+
+const char *
+c_audit_get_last_ack(const c_audit_t *audit);
+
+void
+c_audit_set_last_ack(c_audit_t *audit, char *last_ack);
+
+bool
+c_audit_get_processing_ack(const c_audit_t *audit);
+
+void
+c_audit_set_processing_ack(c_audit_t *audit, bool processing_ack);
+
+#endif /* C_AUDIT_H */

--- a/daemon/c_cap.c
+++ b/daemon/c_cap.c
@@ -71,7 +71,7 @@ c_cap_set_current_process(const container_t *container)
 	/* 28 */ C_CAP_DROP(CAP_LEASE);
 
 	///* 29 */ C_CAP_DROP(CAP_AUDIT_WRITE); /* needed for console/X11 login */
-	///* 30 */ C_CAP_DROP(CAP_AUDIT_CONTROL); /* needed by logd */
+	/* 30 */ C_CAP_DROP(CAP_AUDIT_CONTROL);
 
 	/* 31 */ C_CAP_DROP(CAP_SETFCAP);
 

--- a/daemon/c_service.h
+++ b/daemon/c_service.h
@@ -47,6 +47,9 @@ typedef enum {
 	//C_SERVICE_MESSAGE_WALLPAPER,     // explicit request for current wallpaper
 	C_SERVICE_MESSAGE_AUDIO_SUSPEND,
 	C_SERVICE_MESSAGE_AUDIO_RESUME,
+	C_SERVICE_MESSAGE_AUDIT_NOTIFY,
+	C_SERVICE_MESSAGE_AUDIT_RECORD,
+	C_SERVICE_MESSAGE_AUDIT_COMPLETE,
 	C_SERVICE_MESSAGE_NOTIFICATION
 } c_service_message_t;
 
@@ -113,6 +116,21 @@ int
 c_service_start_pre_exec(c_service_t *service);
 
 /**
+ * Send packed audit record to service.
+*/
+int
+c_service_audit_send_record(c_service_t *service, const uint8_t *buf, const uint32_t buflen);
+
+/**
+ * Notify container about stored audit events.
+ * @param service The service object of the associated container.
+ * @param 	remaining_audit storage capacity
+ * @return  the length of the serialized message (without length prefix)
+*/
+int
+c_service_audit_notify(c_service_t *service, uint64_t remaining_storage);
+
+/**
  * Sends a message to the Trustme Service. If the message induces a response
  * from the Trustme Service (e.g., wallpaper), the response will be delivered
  * asynchronously as a separate message. In this case, this module should invoke
@@ -127,6 +145,6 @@ c_service_start_pre_exec(c_service_t *service);
  *         On error, -1 is returned.
  */
 int
-c_service_send_message(c_service_t *service, c_service_message_t message);
+c_service_send_message(c_service_t *service, c_service_message_t message, const char *msg);
 
 #endif /* C_SERVICE_H */

--- a/daemon/c_service.proto
+++ b/daemon/c_service.proto
@@ -27,6 +27,21 @@ option java_package = "de.fraunhofer.aisec.trustme.service";
 
 import "container.proto";
 
+
+
+message AuditRecord {
+	message Meta {
+		required string key = 1;
+		required string value = 2;
+	};
+
+	required int64 timestamp = 1;
+	required string type = 2;
+	optional string subject_id = 3;
+
+	repeated Meta meta = 4;
+}
+
 message CmldToServiceMessage {
 	enum Code {
 		SHUTDOWN = 1;
@@ -44,6 +59,10 @@ message CmldToServiceMessage {
 
 		CONTAINER_CFG_NAME = 17;
 		CONTAINER_CFG_DNS = 18;
+
+		AUDIT_NOTIFY = 19;
+		AUDIT_RECORD = 20;
+		AUDIT_COMPLETE = 21;
 	}
 	required Code code = 1;
 
@@ -54,7 +73,10 @@ message CmldToServiceMessage {
 	optional bool wifi_user_enabled = 12;
 	optional string container_cfg_name = 13;
 	optional string container_cfg_dns = 14;
-}
+	optional string msg = 15;
+	optional AuditRecord audit_record = 16;
+	optional uint64 audit_remaining_storage = 17;
+	}
 
 message ServiceToCmldMessage {
 	enum Code {
@@ -84,6 +106,8 @@ message ServiceToCmldMessage {
 		CONTAINER_CFG_DNS_REQ = 19;
 
 		EXEC_CAP_SYSTIME_PRIV = 20;
+
+		AUDIT_ACK = 21;
 	}
 	required Code code = 1;
 
@@ -97,4 +121,5 @@ message ServiceToCmldMessage {
 	optional bool wifi_user_enabled = 14;
 	optional string captime_exec_path = 15;
 	repeated string captime_exec_param = 16;
+	optional string audit_ack = 17;
 }

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -54,6 +54,7 @@
 #include "uevent.h"
 #include "time.h"
 #include "lxcfs.h"
+#include "audit.h"
 
 #include <stdio.h>
 #include <dirent.h>
@@ -150,7 +151,7 @@ cmld_container_get_c_root_netns()
 }
 
 container_t *
-cmld_container_get_by_uuid(uuid_t *uuid)
+cmld_container_get_by_uuid(const uuid_t *uuid)
 {
 	ASSERT(uuid);
 
@@ -232,6 +233,9 @@ cmld_container_stop_cb(container_t *container, container_callback_t *cb, void *d
 
 	/* unregister observer */
 	container_unregister_observer(container, cb);
+
+	audit_log_event(container_get_uuid(container), SSA, CMLD, CONTAINER_MGMT,
+			"container-stopped", uuid_string(container_get_uuid(container)), 0);
 
 	/* execute on_all_stopped, if all containers are stopped now */
 	if (cmld_containers_are_all_stopped()) {
@@ -811,6 +815,9 @@ int
 cmld_container_start(container_t *container)
 {
 	if (!container) {
+		audit_log_event(container_get_uuid(container), FSA, CMLD, CONTAINER_MGMT,
+				"container-start-not-existing",
+				uuid_string(container_get_uuid(container)), 0);
 		WARN("Container does not exists!");
 		return -1;
 	}
@@ -825,20 +832,32 @@ cmld_container_start(container_t *container)
 
 		// We only support "background-start"...
 		if (!guestos_get_feature_bg_booting(container_get_guestos(container))) {
+			audit_log_event(container_get_uuid(container), FSA, CMLD, CONTAINER_MGMT,
+					"container-start",
+					uuid_string(container_get_uuid(container)), 0);
 			WARN("Guest OS of the container %s does not support background booting",
 			     container_get_description(container));
 			return -1;
 		}
 		if (container_start(container)) {
+			audit_log_event(container_get_uuid(container), FSA, CMLD, CONTAINER_MGMT,
+					"container-start",
+					uuid_string(container_get_uuid(container)), 0);
 			WARN("Start of background container %s failed",
 			     container_get_description(container));
 			return -1;
 		}
 		time_register_clock_check();
 	} else {
+		audit_log_event(container_get_uuid(container), FSA, CMLD, CONTAINER_MGMT,
+				"container-start-already-running",
+				uuid_string(container_get_uuid(container)), 0);
 		DEBUG("Container %s has been already started",
 		      container_get_description(container));
 	}
+
+	audit_log_event(container_get_uuid(container), SSA, CMLD, CONTAINER_MGMT, "container-start",
+			uuid_string(container_get_uuid(container)), 0);
 	return 0;
 }
 
@@ -851,8 +870,19 @@ cmld_container_change_pin(control_t *control, container_t *container, const char
 	ASSERT(passwd);
 	ASSERT(newpasswd);
 
-	return smartcard_container_change_pin(cmld_smartcard, control, container, passwd,
-					      newpasswd);
+	int rc = smartcard_container_change_pin(cmld_smartcard, control, container, passwd,
+						newpasswd);
+
+	if (!rc)
+		audit_log_event(container_get_uuid(container), SSA, CMLD, CONTAINER_MGMT,
+				"container-change-pin", uuid_string(container_get_uuid(container)),
+				0);
+	else
+		audit_log_event(container_get_uuid(container), FSA, CMLD, CONTAINER_MGMT,
+				"container-change-pin", uuid_string(container_get_uuid(container)),
+				0);
+
+	return rc;
 }
 
 int
@@ -956,6 +986,9 @@ cmld_shutdown_container_cb(container_t *container, container_callback_t *cb, UNU
 	/* all containers are down, so shut down */
 	DEBUG("Device shutdown: last container down; shutdown now");
 
+	audit_log_event(container_get_uuid(container), SSA, CMLD, CONTAINER_MGMT, "shutdown",
+			uuid_string(container_get_uuid(container)), 0);
+
 #ifndef TRUSTME_DEBUG
 	reboot_reboot(POWER_OFF);
 	// should never arrive here, but in case the shutdown fails somehow, we exit
@@ -978,6 +1011,8 @@ cmld_shutdown_a0_cb(container_t *a0, container_callback_t *cb, UNUSED void *data
 	      a0_state == CONTAINER_STATE_ZOMBIE)) {
 		return;
 	}
+	audit_log_event(container_get_uuid(a0), SSA, CMLD, CONTAINER_MGMT, "shutdown-c0-start",
+			uuid_string(container_get_uuid(a0)), 0);
 
 	DEBUG("Device shutdown: a0 went down or shutting down, checking others before shutdown");
 
@@ -1010,6 +1045,8 @@ cmld_shutdown_a0_cb(container_t *a0, container_callback_t *cb, UNUSED void *data
 	if (shutdown_now && !cmld_hostedmode) {
 		/* all containers are down, so shut down */
 		DEBUG("Device shutdown: all containers already down; shutdown now");
+		audit_log_event(container_get_uuid(a0), SSA, CMLD, CONTAINER_MGMT, "shutdown",
+				uuid_string(container_get_uuid(a0)), 0);
 #ifndef TRUSTME_DEBUG
 		reboot_reboot(POWER_OFF);
 		// should never arrive here, but in case the shutdown fails somehow, we exit
@@ -1061,7 +1098,7 @@ cmld_init_a0(const char *path, const char *c0os)
 				       privileged, a0_os, NULL, a0_images_folder, a0_mnt,
 				       a0_ram_limit, 0xffffff00, 0, false, NULL,
 				       cmld_get_device_host_dns(), NULL, NULL, NULL, NULL, NULL,
-				       NULL, 0, NULL, CONTAINER_TOKEN_TYPE_NONE, false);
+				       NULL, 0, NULL, CONTAINER_TOKEN_TYPE_NONE, NULL);
 
 	/* depending on the storage of the a0 pointer, do ONE of the following: */
 	/* store a0 as first element of the cmld_containers_list */
@@ -1098,20 +1135,33 @@ cmld_start_a0(container_t *new_a0)
 	}
 
 	container_set_key(new_a0, A0_KEY);
-	if (container_start(new_a0))
+	if (container_start(new_a0)) {
+		audit_log_event(uuid_new("00000000-0000-0000-0000-000000000000"), FSA, CMLD,
+				CONTAINER_MGMT, "co-start", "00000000-0000-0000-0000-000000000000",
+				0);
 		FATAL("Could not start management container");
+	}
 
 	/* register an observer to capture the shutdown command for the special container a0 */
 	if (!container_register_observer(new_a0, &cmld_shutdown_a0_cb, NULL)) {
 		WARN("Could not register observer shutdown callback for a0");
+
+		audit_log_event(uuid_new("00000000-0000-0000-0000-000000000000"), FSA, CMLD,
+				CONTAINER_MGMT, "c0-start", "00000000-0000-0000-0000-000000000000",
+				0);
 		return -1;
 	}
 	/* register an observer to capture the reboot command for the special container a0 */
 	if (!container_register_observer(new_a0, &cmld_reboot_a0_cb, NULL)) {
 		WARN("Could not register observer reboot callback for a0");
+		audit_log_event(uuid_new("00000000-0000-0000-0000-000000000000"), FSA, CMLD,
+				CONTAINER_MGMT, "c0-start", "00000000-0000-0000-0000-000000000000",
+				0);
 		return -1;
 	}
 
+	audit_log_event(uuid_new("00000000-0000-0000-0000-000000000000"), SSA, CMLD, CONTAINER_MGMT,
+			"c0-start", "00000000-0000-0000-0000-000000000000", 0);
 	return 0;
 }
 
@@ -1168,8 +1218,9 @@ cmld_init(const char *path)
 
 	const char *device_path = DEFAULT_CONF_BASE_PATH "/" CMLD_PATH_DEVICE_CONF;
 	device_config_t *device_config = device_config_new(device_path);
-	if (!device_config)
-		WARN("Could not initialize device config");
+
+	// set max audit log file size
+	audit_set_size(device_config_get_audit_size(device_config));
 
 	// set hostedmode, which disables some configuration
 	cmld_hostedmode = device_config_get_hostedmode(device_config);
@@ -1331,16 +1382,23 @@ cmld_container_create_from_config(const uint8_t *config, size_t config_len, uint
 		container_new(path, NULL, config, config_len, sig, sig_len, cert, cert_len);
 	if (c) {
 		if (0 != cmld_container_token_init(c)) {
+			audit_log_event(container_get_uuid(c), FSA, CMLD, CONTAINER_MGMT,
+					"container-create-token-uninit",
+					uuid_string(container_get_uuid(c)), 0);
 			ERROR("Could not initialize token associated with container %s (uuid=%s). Aborting creation",
 			      container_get_name(c), uuid_string(container_get_uuid(c)));
 			cmld_container_destroy(c);
 			c = NULL;
 		} else {
 			cmld_containers_list = list_append(cmld_containers_list, c);
+			audit_log_event(container_get_uuid(c), SSA, CMLD, CONTAINER_MGMT,
+					"container-create", uuid_string(container_get_uuid(c)), 0);
 			INFO("Created container %s (uuid=%s).", container_get_name(c),
 			     uuid_string(container_get_uuid(c)));
 		}
 	} else {
+		audit_log_event(container_get_uuid(c), FSA, CMLD, CONTAINER_MGMT,
+				"container-create", uuid_string(container_get_uuid(c)), 0);
 		WARN("Could not create new container object from config");
 	}
 	mem_free(path);
@@ -1366,10 +1424,19 @@ cmld_container_destroy_cb(container_t *container, container_callback_t *cb, UNUS
 	/* remove keyfile */
 	if (0 != smartcard_remove_keyfile(cmld_smartcard, container)) {
 		ERROR("Failed to remove keyfile. Continuing to remove container anyway.");
+		audit_log_event(container_get_uuid(container), FSA, CMLD, CONTAINER_MGMT,
+				"container-remove-keyfile",
+				uuid_string(container_get_uuid(container)), 0);
+	} else {
+		audit_log_event(container_get_uuid(container), SSA, CMLD, CONTAINER_MGMT,
+				"container-remove-keyfile",
+				uuid_string(container_get_uuid(container)), 0);
 	}
 
 	/* destroy the container */
 	if (container_destroy(container) < 0) {
+		audit_log_event(container_get_uuid(container), FSA, CMLD, CONTAINER_MGMT,
+				"container-remove", uuid_string(container_get_uuid(container)), 0);
 		ERROR("Could not destroy container");
 		container_set_state(container, CONTAINER_STATE_ZOMBIE);
 		return;
@@ -1377,6 +1444,8 @@ cmld_container_destroy_cb(container_t *container, container_callback_t *cb, UNUS
 
 	/* cleanup container */
 	cmld_containers_list = list_remove(cmld_containers_list, container);
+	audit_log_event(container_get_uuid(container), SSA, CMLD, CONTAINER_MGMT,
+			"container-remove", uuid_string(container_get_uuid(container)), 0);
 	container_free(container);
 }
 
@@ -1394,6 +1463,9 @@ cmld_container_destroy(container_t *container)
 
 		/* Register observer to wait for completed container_stop */
 		if (!container_register_observer(container, &cmld_container_destroy_cb, NULL)) {
+			audit_log_event(container_get_uuid(container), FSA, CMLD, CONTAINER_MGMT,
+					"container-remove",
+					uuid_string(container_get_uuid(container)), 0);
 			DEBUG("Could not register destroy callback");
 			return -1;
 		}
@@ -1416,6 +1488,10 @@ cmld_container_stop(container_t *container)
 	      (container_get_state(container) == CONTAINER_STATE_SETUP))) {
 		ERROR("Container %s not running, unable to stop",
 		      container_get_description(container));
+
+		audit_log_event(container_get_uuid(container), FSA, CMLD, CONTAINER_MGMT,
+				"container-stop-failed", uuid_string(container_get_uuid(container)),
+				0);
 		return -1;
 	}
 

--- a/daemon/cmld.h
+++ b/daemon/cmld.h
@@ -159,7 +159,7 @@ void
 cmld_wipe_device();
 
 container_t *
-cmld_container_get_by_uuid(uuid_t *uuid);
+cmld_container_get_by_uuid(const uuid_t *uuid);
 
 container_t *
 cmld_container_get_by_token_serial(const char *serial);

--- a/daemon/container.h
+++ b/daemon/container.h
@@ -145,7 +145,8 @@ enum container_error {
 	CONTAINER_ERROR_DEVNS,
 	CONTAINER_ERROR_USER,
 	CONTAINER_ERROR_FIFO,
-	CONTAINER_ERROR_TIME
+	CONTAINER_ERROR_TIME,
+	CONTAINER_ERROR_AUDIT
 };
 
 typedef enum {
@@ -920,4 +921,55 @@ container_exec_cap_systime(const container_t *container, char *const *argv);
 bool
 container_get_usb_pin_entry(const container_t *container);
 
+/**
+ * Send audit record to container
+ */
+int
+container_audit_record_notify(const container_t *container, uint64_t remaining_storage);
+
+/**
+ * Returns the last ACK hash that has been received from this container
+ */
+const char *
+container_audit_get_last_ack(const container_t *container);
+
+/**
+ * Stores the last ACKi hash that has been received for this container.
+ */
+void
+container_audit_set_last_ack(const container_t *container, char *last_ack);
+
+/**
+ * Returns wether an ACK is currently being processed for this container
+ */
+int
+container_audit_get_processing_ack(const container_t *container);
+
+/**
+ * Stores if an ACK hash is currently being processed for this container
+ */
+
+void
+container_audit_set_processing_ack(const container_t *container, bool processing_ack);
+
+/**
+ * Send audit record to container
+ */
+int
+container_audit_record_notify(const container_t *container, uint64_t remaining_storage);
+
+/**
+ * Send audit event to container
+ */
+int
+container_audit_record_send(const container_t *container, const uint8_t *buf, uint32_t buflen);
+
+/**
+ * Process audit record ACK received from a container
+ */
+int
+container_audit_process_ack(const container_t *container, const char *ack);
+
+int
+container_audit_notify_complete(const container_t *container);
 #endif /* CONTAINER_H */

--- a/daemon/device.proto
+++ b/daemon/device.proto
@@ -61,4 +61,7 @@ message DeviceConfig {
 	required bool hostedmode = 14 [default = false];
 
 	optional bool signed_configs = 15 [default = false];
+
+	// max size of audit log per logging sink in MB
+	optional uint64 audit_size = 16 [default = 0];
 }

--- a/daemon/device_config.c
+++ b/daemon/device_config.c
@@ -55,7 +55,7 @@ device_config_new(const char *path)
 		DEBUG("Loading device config from \"%s\".", file);
 
 		cfg = (DeviceConfig *)protobuf_message_new_from_textfile(
-			file, &device_config__descriptor);
+			file, &device_config__descriptor, false);
 		if (!cfg) {
 			WARN("Failed loading device config from file \"%s\". Reverting to default values.",
 			     file);
@@ -234,4 +234,13 @@ device_config_get_signed_configs(const device_config_t *config)
 	ASSERT(config->cfg);
 
 	return config->cfg->signed_configs;
+}
+
+bool
+device_config_get_audit_size(const device_config_t *config)
+{
+	ASSERT(config);
+	ASSERT(config->cfg);
+
+	return config->cfg->audit_size;
 }

--- a/daemon/device_config.h
+++ b/daemon/device_config.h
@@ -106,4 +106,7 @@ device_config_get_hostedmode(const device_config_t *config);
 
 bool
 device_config_get_signed_configs(const device_config_t *config);
+
+bool
+device_config_get_audit_size(const device_config_t *config);
 #endif /* DEVICE_H */

--- a/daemon/guestos_config.c
+++ b/daemon/guestos_config.c
@@ -42,7 +42,7 @@ guestos_config_new_from_file(const char *file)
 	DEBUG("Loading GuestOS config from \"%s\".", file);
 
 	GuestOSConfig *cfg = (GuestOSConfig *)protobuf_message_new_from_textfile(
-		file, &guest_osconfig__descriptor);
+		file, &guest_osconfig__descriptor, false);
 	if (!cfg) {
 		ERROR("Failed loading GuestOS config from file \"%s\".", file);
 	}

--- a/daemon/mount.c
+++ b/daemon/mount.c
@@ -25,6 +25,7 @@
 #include <sched.h>
 
 #include "mount.h"
+#include "smartcard.h"
 
 #include "common/macro.h"
 #include "common/mem.h"
@@ -238,36 +239,6 @@ mount_entry_get_mount_data(const mount_entry_t *mntent)
 	return mntent->mount_data;
 }
 
-static bool
-match_hash(const char *hash_name, size_t hash_len, const char *img_name, const char *expected_hash,
-	   const char *hash)
-{
-	ASSERT(hash_name);
-	ASSERT(img_name);
-
-	if (!hash) {
-		ERROR("Checking image %s.img with %s: empty hash value", img_name, hash_name);
-		return false;
-	}
-	if (!expected_hash) {
-		ERROR("Checking image %s.img with %s: reference hash value for image is missing",
-		      img_name, hash_name);
-		return false;
-	}
-	size_t len = strlen(expected_hash);
-	if (len != 2 * hash_len) {
-		ERROR("Checking image %s.img with %s: invalid hash length %zu/2, expected %zu/2 bytes",
-		      img_name, hash_name, len, 2 * hash_len);
-		return false;
-	}
-	if (strncasecmp(expected_hash, hash, len + 1)) {
-		DEBUG("Checking image %s.img with %s: hash mismatch", img_name, hash_name);
-		return false;
-	}
-	DEBUG("Checking image %s.img with %s: hashes match", img_name, hash_name);
-	return true;
-}
-
 bool
 mount_entry_match_sha1(const mount_entry_t *e, const char *hash)
 {
@@ -275,7 +246,10 @@ mount_entry_match_sha1(const mount_entry_t *e, const char *hash)
 
 	const char *img_name = mount_entry_get_img(e);
 	const char *expected = mount_entry_get_sha1(e);
-	return match_hash("SHA1", 20, img_name, expected, hash);
+
+	DEBUG("Checking image %s.img with expected SHA1 hash %s, actual hash: %s", img_name,
+	      expected, hash);
+	return match_hash(20, expected, hash);
 }
 
 bool
@@ -285,7 +259,9 @@ mount_entry_match_sha256(const mount_entry_t *e, const char *hash)
 
 	const char *img_name = mount_entry_get_img(e);
 	const char *expected = mount_entry_get_sha256(e);
-	return match_hash("SHA256", 32, img_name, expected, hash);
+	DEBUG("Checking image %s.img with expected SHA256 hash %s, actual hash: %s", img_name,
+	      expected, hash);
+	return match_hash(32, expected, hash);
 }
 
 bool

--- a/daemon/scd.proto
+++ b/daemon/scd.proto
@@ -62,6 +62,7 @@ message DaemonToToken {
 
 		// crypto commands unrelated to actual secure element (FIXME move elsewhere?!)
 		CRYPTO_HASH_FILE = 50;		// compute hash for file [hash_file]
+		CRYPTO_HASH_BUF = 51;		// compute hash for given buffer [hash_buf
 		CRYPTO_VERIFY_FILE = 60;	// verify certificate and signature on data given in [verify_*_file]
 		CRYPTO_VERIFY_BUF = 61;	// verify certificate and signature on data given in [verify_*_buf]
 

--- a/daemon/smartcard.h
+++ b/daemon/smartcard.h
@@ -24,6 +24,7 @@
 #ifndef SMARTCARD_H
 #define SMARTCARD_H
 
+#include "cmld.h"
 #include "container.h"
 #include "control.h"
 #include "stdbool.h"
@@ -140,33 +141,10 @@ smartcard_remove_keyfile(smartcard_t *smartcard, const container_t *container);
 typedef enum smartcard_crypto_hashalgo { SHA1, SHA256, SHA512 } smartcard_crypto_hashalgo_t;
 
 /**
- * Callback function for receiving the result of a hash operation.
+ * Callback function for receiving the result of a file hash operation.
  */
 typedef void (*smartcard_crypto_hash_callback_t)(const char *hash_string, const char *hash_file,
 						 smartcard_crypto_hashalgo_t hash_algo, void *data);
-
-/**
- * Requests the scd to hash the given file and report the hash to the given callback.
- *
- * @param file the file to hash
- * @param hashalgo the hash algorithm to use
- * @param cb the callback to receive the result
- * @param data custom data parameter to pass to the callback
- * @return 0 if the hash request was sent and the callback is expected to be called, -1 otherwise
- */
-int
-smartcard_crypto_hash_file(const char *file, smartcard_crypto_hashalgo_t hashalgo,
-			   smartcard_crypto_hash_callback_t cb, void *data);
-
-/**
- * Requests the scd to hash the given file, wait for the result and directly return it.
- *
- * @param file the file to hash
- * @param hashalgo the hash algorithm to use
- * @return pointer to a newly allocated string with the hash value, or NULL on error
- */
-char *
-smartcard_crypto_hash_file_block_new(const char *file, smartcard_crypto_hashalgo_t hashalgo);
 
 /**
  * Result of a signature verification.
@@ -194,6 +172,43 @@ typedef void (*smartcard_crypto_verify_buf_callback_t)(
 	smartcard_crypto_verify_result_t verify_result, unsigned char *data_buf,
 	size_t data_buf_len, unsigned char *sig_buf, size_t sig_buf_len, unsigned char *cert_buf,
 	size_t cert_buf_len, smartcard_crypto_hashalgo_t hash_algo, void *data);
+
+/**
+ * Requests the scd to hash the given file and report the hash to the given callback.
+ *
+ * @param file the file to hash
+ * @param hashalgo the hash algorithm to use
+ * @param cb the callback to receive the result
+ * @param data custom data parameter to pass to the callback
+ * @return 0 if the hash request was sent and the callback is expected to be called, -1 otherwise
+ */
+int
+smartcard_crypto_hash_file(const char *file, smartcard_crypto_hashalgo_t hashalgo,
+			   smartcard_crypto_hash_callback_t cb, void *data);
+
+/**
+ * Requests the scd to hash the given buffer and report the hash to the given callback.
+ *
+ * @param verify_buf the buffer to hash
+ * @param verify_buf_len the length of the buffer to hash
+ * @param hashalgo the hash algorithm to use
+ * @param cb the callback to receive the result
+ * @param data custom data parameter to pass to the callback
+ * @return 0 if the hash request was sent and the callback is expected to be called, -1 otherwise
+ */
+int
+smartcard_crypto_hash_buf(unsigned char *data_buf, size_t data_buf_len,
+			  smartcard_crypto_hashalgo_t hashalgo, smartcard_crypto_hash_callback_t cb,
+			  void *data);
+/**
+ * Requests the scd to hash the given file, wait for the result and directly return it.
+ *
+ * @param file the file to hash
+ * @param hashalgo the hash algorithm to use
+ * @return pointer to a newly allocated string with the hash value, or NULL on error
+ */
+char *
+smartcard_crypto_hash_file_block_new(const char *file, smartcard_crypto_hashalgo_t hashalgo);
 
 /**
  * Requests the scd to verify the signature on the given datafile using the given certificate
@@ -299,5 +314,17 @@ smartcard_push_cert(smartcard_t *smartcard, control_t *control, uint8_t *cert, s
  */
 bool
 smartcard_cert_has_valid_format(unsigned char *cert_buf, size_t cert_buf_len);
+
+/**
+ * Checks whether two given hashes match and returns the result
+ *
+ * @param hash_name The name of the hash algorithm used
+ * @param hash_len The length if the given hashes
+ * @param expected_hash The expected hash
+ * @param hash The hash to verify
+ */
+
+bool
+match_hash(size_t hash_len, const char *expected_hash, const char *hash);
 
 #endif /* SMARTCARD_H */

--- a/daemon/uevent.c
+++ b/daemon/uevent.c
@@ -395,6 +395,7 @@ uevent_replace_devpath_new(const char *str, const char *oldstr, const char *news
 {
 	char *ptr_old = NULL;
 	int len_diff = strlen(newstr) - strlen(oldstr);
+	//sleep(60);
 
 	if (!(ptr_old = strstr(str, oldstr))) {
 		DEBUG("Could not find %s in %s", oldstr, str);
@@ -402,7 +403,7 @@ uevent_replace_devpath_new(const char *str, const char *oldstr, const char *news
 	}
 
 	unsigned int off_old;
-	char *str_replaced = mem_alloc0(strlen(str) + len_diff);
+	char *str_replaced = mem_alloc0((strlen(str) + 1) + len_diff);
 	unsigned int pos_new = 0;
 
 	off_old = ptr_old - str;

--- a/scd/scd.c
+++ b/scd/scd.c
@@ -202,7 +202,7 @@ provisioning_mode()
 			}
 
 			DeviceConfig *dev_cfg = (DeviceConfig *)protobuf_message_new_from_textfile(
-				DEVICE_CONF, &device_config__descriptor);
+				DEVICE_CONF, &device_config__descriptor, false);
 
 			if (!dev_cfg) {
 				FATAL("Failed load device config from file \"%s\"!", DEVICE_CONF);

--- a/scd/token.c
+++ b/scd/token.c
@@ -617,10 +617,6 @@ token_free(scd_token_t *token)
 {
 	IF_NULL_RETURN(token);
 
-#ifdef ENABLESCHSM
-	scd_tokencontrol_free(token);
-#endif
-
 	if (token->token_data) {
 		switch (token->token_data->type) {
 		case (NONE):
@@ -632,6 +628,7 @@ token_free(scd_token_t *token)
 			break;
 #ifdef ENABLESCHSM
 		case (USB):
+			scd_tokencontrol_free(token);
 			usbtoken_free(token->token_data->int_token.usbtoken);
 			break;
 #endif // ENABLESCHSM

--- a/service/Makefile
+++ b/service/Makefile
@@ -28,7 +28,7 @@ AGGRESSIVE_WARNINGS ?= y
 SANITIZERS ?= n
 
 LOCAL_CFLAGS := -std=gnu99 -Icommon -I.. -I../include -O2 -pedantic
-LOCAL_CFLAGS += -Wall -Wextra -Wcast-align -Wformat -Wformat-security -fstack-protector-all -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -fpic -pie
+LOCAL_CFLAGS += -Wall -Wextra -Wcast-align -Wformat -Wformat-security -fstack-protector-all -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -fpic -pie -O0
 # set for sending boot complete protobuf message only
 #LOCAL_CFLAGS += -DBOOT_COMPLETE_ONLY
 ifeq ($(CC),gcc)
@@ -73,7 +73,8 @@ SRC_FILES_EXEC_CAP_SYSTIME := \
 LD_LIB_FLAGS := \
 	-Lcommon -lcommon_full \
 	-lprotobuf-c \
-	-lprotobuf-c-text
+	-lprotobuf-c-text \
+	-pthread
 
 .PHONY: all
 all: service exec_cap_systime


### PR DESCRIPTION
This PR adds audit capabilities to the CML.
The main contributions are the audit record creation and handling functions in the new file audit.c
and the a new container submodule to hold container-specific state regarding the delivery of audit events contained in c_audit.c.

Two record delivery mechanisms, C0 and CONTAINER, are implemented to suit different use cases.
The C0 logging mode causes all audit records to be delivered to the management container C0.
The CONTAINER logging mode causes audit record delivery to the container that triggered the creation of the respective record.
Switching between the two modes is possible at compile time by setting the LOGMODE variable in audit.c

If event delivery to a particular container is not possible, e.g. because it is not running or no logger is available inside the target container, events are stored to disk in a logfile for each target container.
The maximum size of these log files can be set using the new device.conf field 'audit_size'.
By default, audit_size is zero s.t. auditing is disabled in standard builds if not expliicitly activated.

Also, the cservice has been modified in order to receive the audit records inside containers.
To this end, the c_service enters an event loop waiting for audit events.
If it is started with PID 1, an event handling process is forked, just before entering the signal handling loop.
Starting the cservice with any other PID causes it to directly enter the event handling loop without performing any further actions.
Thereby, it can be launched using systemd, busybox init or similiar init systems in order to receive audit events in a given container.