### PR TITLE
uevent: properly handle coldboot for containers 

### DIFF
--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -561,7 +561,7 @@ cmld_container_boot_complete_cb(container_t *container, container_callback_t *cb
 			network_enable_ip_forwarding();
 		// fixup device nodes in userns by triggering uevent forwarding of coldboot events
 		if (container_has_userns(container))
-			uevent_udev_trigger_coldboot();
+			uevent_udev_trigger_coldboot(container);
 		container_unregister_observer(container, cb);
 
 		DEBUG("Freeing key of container %s", container_get_name(container));
@@ -874,7 +874,7 @@ cmld_a0_boot_complete_cb(container_t *container, container_callback_t *cb, UNUSE
 		cmld_rename_logfiles();
 		// fixup device nodes in userns by triggering uevent forwarding of coldboot events
 		if (container_has_userns(container))
-			uevent_udev_trigger_coldboot();
+			uevent_udev_trigger_coldboot(container);
 		container_unregister_observer(container, cb);
 
 		for (list_t *l = cmld_containers_list; l; l = l->next) {

--- a/daemon/uevent.c
+++ b/daemon/uevent.c
@@ -951,6 +951,17 @@ uevent_init()
 		return -1;
 	}
 
+	// Initially rename all physical interfaces before starting uevent handling.
+	for (list_t *l = cmld_get_netif_phys_list(); l; l = l->next) {
+		const char *ifname = l->data;
+		const char *prefix = (network_interface_is_wifi(ifname)) ? "wlan" : "eth";
+		char *if_name_new = uevent_rename_ifi_new(ifname, prefix);
+		if (if_name_new) {
+			mem_free(l->data);
+			l->data = if_name_new;
+		}
+	}
+
 	/* find the udevd started by cml's init */
 	pid_t udevd_pid = proc_find(1, "systemd-udevd");
 	pid_t eudevd_pid = proc_find(1, "udevd");

--- a/daemon/uevent.h
+++ b/daemon/uevent.h
@@ -34,6 +34,7 @@
 #include <stdint.h>
 
 #include "container.h"
+#include "uuid.h"
 
 #define UEVENT_BUF_LEN 64 * 1024
 
@@ -115,10 +116,14 @@ int
 uevent_unregister_netdev(container_t *container, uint8_t mac[6]);
 
 /**
-  * Trigger cold boot events to allow user namespaced containers to fixup
-  * their device nodes by udevd in container
-  */
+ * Trigger cold boot events to allow user namespaced containers to fixup
+ * their device nodes by udevd in container.
+ * Internally the uuid of the container is used for synthetic events
+ * to allow directing events to corresponding container only.
+ *
+ * @param container container for which the cold boot is triggered.
+ */
 void
-uevent_udev_trigger_coldboot(void);
+uevent_udev_trigger_coldboot(container_t *container);
 
 #endif /* UEVENT_H */


### PR DESCRIPTION
Instead of just trigger coldboot events by exec of udevadm trigger, walk
through sysfs and trigger synthetic events only for allowed devices.
Internally the uuid of the container is used to trigger synthetic events
to allow injecting the resulting events to the corresponding container
only.