### PR TITLE
daemon: Introduce container config signature validation

### DIFF
--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -107,6 +107,7 @@ static char *cmld_shared_data_dir = NULL;
 static list_t *cmld_netif_phys_list = NULL;
 
 static bool cmld_hostedmode = false;
+static bool cmld_signed_configs = false;
 
 static bool cmld_device_provisioned = false;
 
@@ -328,6 +329,12 @@ cmld_is_hostedmode_active(void)
 }
 
 bool
+cmld_uses_signed_configs(void)
+{
+	return cmld_signed_configs;
+}
+
+bool
 cmld_is_device_provisioned(void)
 {
 	return cmld_device_provisioned;
@@ -419,7 +426,7 @@ cmld_load_containers_cb(const char *path, const char *name, UNUSED void *data)
 			cmld_containers_list = list_remove(cmld_containers_list, c);
 			container_free(c);
 		}
-		c = container_new(path, uuid, NULL, 0);
+		c = container_new(path, uuid, NULL, 0, NULL, 0, NULL, 0);
 		if (c) {
 			DEBUG("Loaded config for container %s from %s", container_get_name(c),
 			      name);
@@ -1165,6 +1172,9 @@ cmld_init(const char *path)
 	// set hostedmode, which disables some configuration
 	cmld_hostedmode = device_config_get_hostedmode(device_config);
 
+	// activate signature checking of container configs if enabled
+	cmld_signed_configs = device_config_get_signed_configs(device_config);
+
 	cmld_tune_network(device_config_get_host_addr(device_config),
 			  device_config_get_host_subnet(device_config),
 			  device_config_get_host_if(device_config),
@@ -1307,14 +1317,16 @@ cmld_container_create_clone(container_t *container)
 }
 
 container_t *
-cmld_container_create_from_config(const uint8_t *config, size_t config_len)
+cmld_container_create_from_config(const uint8_t *config, size_t config_len, uint8_t *sig,
+				  size_t sig_len, uint8_t *cert, size_t cert_len)
 {
 	ASSERT(config);
 	ASSERT(config_len);
 	char *path = mem_printf("%s/%s", cmld_path, CMLD_PATH_CONTAINERS_DIR);
 	IF_NULL_RETVAL(path, NULL);
 
-	container_t *c = container_new(path, NULL, config, config_len);
+	container_t *c =
+		container_new(path, NULL, config, config_len, sig, sig_len, cert, cert_len);
 	if (c) {
 		DEBUG("Created container %s (uuid=%s).", container_get_name(c),
 		      uuid_string(container_get_uuid(c)));

--- a/daemon/cmld.h
+++ b/daemon/cmld.h
@@ -80,10 +80,16 @@ cmld_container_create_clone(container_t *container);
  * Create a container by providing a config buffer.
  *
  * @param config The config for the new container in form of a buffer.
+ * @param config_len Length of the given buf.
+ * @param sig buffer containing the signature of the configuration
+ * @param sig_len length of the given sig_buf
+ * @param cert buffer containing the certificate of the configuration
+ * @param cert_len length of the given cert_buf
  * @return The container of the newly created container.
  */
 container_t *
-cmld_container_create_from_config(const uint8_t *config, size_t config_len);
+cmld_container_create_from_config(const uint8_t *config, size_t config_len, uint8_t *sig,
+				  size_t sig_len, uint8_t *cert, size_t cert_len);
 
 /**
  * Create a container from a config file.
@@ -207,6 +213,12 @@ cmld_is_internet_active(void);
  */
 bool
 cmld_is_hostedmode_active(void);
+
+/**
+ * Checks if signed container configs are enabled.
+ */
+bool
+cmld_uses_signed_configs(void);
 
 bool
 cmld_is_device_provisioned(void);

--- a/daemon/container.c
+++ b/daemon/container.c
@@ -451,28 +451,10 @@ container_uuid_is_c0id(const uuid_t *uuid)
 	return ret;
 }
 
-/**
- * Creates a new container object. There are three different cases
- * depending on the combination of the given parameters:
- *
- * uuid && !config: In this case, a container with the given UUID must be already
- * present in the given store_path and is loaded from there.
- *
- * !uuid && config: In this case, the container does NOT yet exist and should be
- * created in the given store_path using the given config buffer and a random
- * UUID.
- *
- * uuid && config: In this case, the container does NOT yet exist and should be
- * created in the given store_path using the given config buffer and the given
- * UUID.
- *
- * @return The new container object or NULL if something went wrong.
- *
- */
 /* TODO Error handling */
 container_t *
 container_new(const char *store_path, const uuid_t *existing_uuid, const uint8_t *config,
-	      size_t config_len)
+	      size_t config_len, uint8_t *sig, size_t sig_len, uint8_t *cert, size_t cert_len)
 {
 	ASSERT(store_path);
 	ASSERT(existing_uuid || config);
@@ -510,7 +492,8 @@ container_new(const char *store_path, const uuid_t *existing_uuid, const uint8_t
 	/********************************
 	 * Translate High Level Config into low-level parameters for internal
 	 * constructor */
-	container_config_t *conf = container_config_new(config_filename, config, config_len);
+	container_config_t *conf = container_config_new(config_filename, config, config_len, sig,
+							sig_len, cert, cert_len);
 
 	if (!conf) {
 		WARN("Could not read config file %s", config_filename);
@@ -2314,7 +2297,9 @@ container_add_net_iface(container_t *container, const char *iface, bool persiste
 	res |= c_net_move_ifi(iface, pid);
 	if (res || !persistent)
 		return res;
-	container_config_t *conf = container_config_new(container->config_filename, NULL, 0);
+
+	container_config_t *conf =
+		container_config_new(container->config_filename, NULL, 0, NULL, 0, NULL, 0);
 	container_config_append_net_ifaces(conf, iface);
 	container_config_write(conf);
 	container_config_free(conf);
@@ -2332,7 +2317,8 @@ container_remove_net_iface(container_t *container, const char *iface, bool persi
 
 	cmld_netif_phys_add_by_name(iface);
 
-	container_config_t *conf = container_config_new(container->config_filename, NULL, 0);
+	container_config_t *conf =
+		container_config_new(container->config_filename, NULL, 0, NULL, 0, NULL, 0);
 	container_config_remove_net_ifaces(conf, iface);
 	container_config_write(conf);
 	container_config_free(conf);
@@ -2408,11 +2394,13 @@ container_get_vnet_runtime_cfg_new(container_t *container)
 }
 
 int
-container_update_config(container_t *container, uint8_t *buf, size_t buf_len)
+container_update_config(container_t *container, uint8_t *buf, size_t buf_len, uint8_t *sig_buf,
+			size_t sig_len, uint8_t *cert_buf, size_t cert_len)
 {
 	ASSERT(container);
 	int ret = -1;
-	container_config_t *conf = container_config_new(container->config_filename, buf, buf_len);
+	container_config_t *conf = container_config_new(container->config_filename, buf, buf_len,
+							sig_buf, sig_len, cert_buf, cert_len);
 	if (conf) {
 		ret = container_config_write(conf);
 		container_config_free(conf);

--- a/daemon/container.h
+++ b/daemon/container.h
@@ -209,10 +209,16 @@ container_new_internal(const uuid_t *uuid, const char *name, container_type_t ty
  * created in the given store_path using the given config buffer and the given
  * UUID.
  *
+ * Optionally sig, cert buffers and length paramters could be set to non zero/NULL
+ * values for signature verification of the corresponding configuration contained
+ * in config buffer.
+ *
+ *
  * @return The new container object or NULL if something went wrong.
  */
 container_t *
-container_new(const char *store_path, const uuid_t *uuid, const uint8_t *config, size_t config_len);
+container_new(const char *store_path, const uuid_t *existing_uuid, const uint8_t *config,
+	      size_t config_len, uint8_t *sig, size_t sig_len, uint8_t *cert, size_t cert_len);
 
 /*
 container_t *
@@ -767,7 +773,8 @@ container_get_vnet_runtime_cfg_new(container_t *container);
  * reload is necessary.
  */
 int
-container_update_config(container_t *container, uint8_t *buf, size_t buf_len);
+container_update_config(container_t *container, uint8_t *buf, size_t buf_len, uint8_t *sig_buf,
+			size_t sig_len, uint8_t *cert_buf, size_t cert_len);
 
 /**
  * Get the list of usb devices which are set in container config.

--- a/daemon/container_config.h
+++ b/daemon/container_config.h
@@ -46,17 +46,24 @@ typedef struct container_config container_config_t;
 /**
  * Create a new container_config object which can be used to parse or write a
  * configuration to a given filename.
+ * Signature/Certificate buffers and corresponding lenght are optional and may
+ * set to zero/NULL if configuration should not be integrity protected.
  *
  * @param filename Representation of the config on disk. Must NOT be NULL. If
- * the file exists it is used to initially fill the container_config object. 
+ * the file exists it is used to initially fill the container_config object.
  * @param buf Config buffer to initialize the config object. If the config
  * file at filename already exists, the config buffer supersedes the content
  * of the config file.
  * @param len Length of the given buf.
+ * @param sig_buf buffer containing the signature of the configuration
+ * @param sig_len length of the given sig_buf
+ * @param cert_buf buffer containing the certificate of the configuration
+ * @param cert_len length of the given cert_buf
  * @return The new container_config_t object or NULL on an error.
  */
 container_config_t *
-container_config_new(const char *file, const uint8_t *buf, size_t len);
+container_config_new(const char *file, const uint8_t *buf, size_t len, uint8_t *sig_buf,
+		     size_t sig_len, uint8_t *cert_buf, size_t cert_len);
 
 /**
  * Release the container_config_t object.

--- a/daemon/control.c
+++ b/daemon/control.c
@@ -984,8 +984,10 @@ control_handle_message(control_t *control, const ControllerToDaemon *msg, int fd
 				WARN("Could not send empty Response to CREATE");
 			break;
 		}
+		// TODO retreive sig and cert from protobuf
 		container_t *c = cmld_container_create_from_config(msg->container_config_file.data,
-								   msg->container_config_file.len);
+								   msg->container_config_file.len,
+								   NULL, 0, NULL, 0);
 		if (NULL == c) {
 			if (protobuf_send_message(fd, (ProtobufCMessage *)&out) < 0)
 				WARN("Could not send empty Response to CREATE");
@@ -1052,8 +1054,9 @@ control_handle_message(control_t *control, const ControllerToDaemon *msg, int fd
 				WARN("Could not send empty Response to UPDATE_CONFIG");
 			break;
 		}
+		// TODO retreive sig and cert from protobuf
 		int res = container_update_config(container, msg->container_config_file.data,
-						  msg->container_config_file.len);
+						  msg->container_config_file.len, NULL, 0, NULL, 0);
 		if (res) {
 			if (protobuf_send_message(fd, (ProtobufCMessage *)&out) < 0)
 				WARN("Could not send empty Response to UPDATE_CONFIG");

--- a/daemon/control.c
+++ b/daemon/control.c
@@ -984,10 +984,19 @@ control_handle_message(control_t *control, const ControllerToDaemon *msg, int fd
 				WARN("Could not send empty Response to CREATE");
 			break;
 		}
-		// TODO retreive sig and cert from protobuf
-		container_t *c = cmld_container_create_from_config(msg->container_config_file.data,
-								   msg->container_config_file.len,
-								   NULL, 0, NULL, 0);
+		container_t *c = NULL;
+		if (msg->has_container_config_signature && msg->has_container_config_certificate) {
+			c = cmld_container_create_from_config(
+				msg->container_config_file.data, msg->container_config_file.len,
+				msg->container_config_signature.data,
+				msg->container_config_signature.len,
+				msg->container_config_certificate.data,
+				msg->container_config_certificate.len);
+		} else {
+			c = cmld_container_create_from_config(msg->container_config_file.data,
+							      msg->container_config_file.len, NULL,
+							      0, NULL, 0);
+		}
 		if (NULL == c) {
 			if (protobuf_send_message(fd, (ProtobufCMessage *)&out) < 0)
 				WARN("Could not send empty Response to CREATE");
@@ -1054,9 +1063,18 @@ control_handle_message(control_t *control, const ControllerToDaemon *msg, int fd
 				WARN("Could not send empty Response to UPDATE_CONFIG");
 			break;
 		}
-		// TODO retreive sig and cert from protobuf
-		int res = container_update_config(container, msg->container_config_file.data,
-						  msg->container_config_file.len, NULL, 0, NULL, 0);
+		if (msg->has_container_config_signature && msg->has_container_config_certificate) {
+			res = container_update_config(container, msg->container_config_file.data,
+						      msg->container_config_file.len,
+						      msg->container_config_signature.data,
+						      msg->container_config_signature.len,
+						      msg->container_config_certificate.data,
+						      msg->container_config_certificate.len);
+		} else {
+			res = container_update_config(container, msg->container_config_file.data,
+						      msg->container_config_file.len, NULL, 0, NULL,
+						      0);
+		}
 		if (res) {
 			if (protobuf_send_message(fd, (ProtobufCMessage *)&out) < 0)
 				WARN("Could not send empty Response to UPDATE_CONFIG");

--- a/daemon/control.proto
+++ b/daemon/control.proto
@@ -204,6 +204,8 @@ message ControllerToDaemon {
 	optional ContainerStartParams container_start_params = 11;	// start parameters for CONTAINER_START
 	optional AssignInterfaceParams assign_iface_params = 12;	// parameter for CONTAINER_ASSIGNIFACE / CONTAINER_UNASSIGNIFACE
 	optional bytes container_config_file = 13;		// new container config for CREATE_CNTAINER
+	optional bytes container_config_signature = 18;		// signature of the container config file
+	optional bytes container_config_certificate = 19;	// sw signing certificate to verify the signature on the container config file
 	optional string exec_command = 14; // command to execute in container context
 	repeated string exec_args = 15; // arguments for command to be executed
 	optional bool exec_pty = 16 [ default = false ]; // assign pty to command

--- a/daemon/device.proto
+++ b/daemon/device.proto
@@ -59,4 +59,6 @@ message DeviceConfig {
 
 	// hostmode
 	required bool hostedmode = 14 [default = false];
+
+	optional bool signed_configs = 15 [default = false];
 }

--- a/daemon/device_config.c
+++ b/daemon/device_config.c
@@ -226,3 +226,12 @@ device_config_get_hostedmode(const device_config_t *config)
 
 	return config->cfg->hostedmode;
 }
+
+bool
+device_config_get_signed_configs(const device_config_t *config)
+{
+	ASSERT(config);
+	ASSERT(config->cfg);
+
+	return config->cfg->signed_configs;
+}

--- a/daemon/device_config.h
+++ b/daemon/device_config.h
@@ -103,4 +103,7 @@ device_config_get_locally_signed_images(const device_config_t *config);
 
 bool
 device_config_get_hostedmode(const device_config_t *config);
+
+bool
+device_config_get_signed_configs(const device_config_t *config);
 #endif /* DEVICE_H */


### PR DESCRIPTION
The API in 'container.c' for container_new() is expanded to also
take buffers for signature and certificate for a container config.
These are given to container_config_new() in 'contrainer_config.c'.
The external API in 'container.c' allows to leave these buffers empty,
and the container_config_new() will deal with reading and storing
corresponding date from/to disk.

The signature verification is also made in container_config_new().
Signature failure result in an empty container object and thus makes
the implementation almost transparent to cmld.c and control.c.

The new feature can be enabled in device.conf 'signed_configs: true'.
Currently, default is set to false to maintain previous behaviour.

Getting signature and certificate through control interface is not
yet implemented and needs to be done in followup commits.
Therefore, container update or creation through control interface do
not work yet if 'signed_configs' is enabled in device.conf.

Signed-off-by: Michael Weiß <michael.weiss@aisec.fraunhofer.de>