### PR TITLE
daemon/container: keep GuestOS version of signed container configs

### DIFF
--- a/daemon/container.c
+++ b/daemon/container.c
@@ -530,7 +530,7 @@ container_new(const char *store_path, const uuid_t *existing_uuid, const uint8_t
 
 	current_guestos_version = container_config_get_guestos_version(conf);
 	new_guestos_version = guestos_get_version(os);
-	if (current_guestos_version < new_guestos_version) {
+	if ((current_guestos_version < new_guestos_version) && !cmld_uses_signed_configs()) {
 		INFO("Updating guestos version from %" PRIu64 " to %" PRIu64 " for container %s",
 		     current_guestos_version, new_guestos_version, name);
 		container_config_set_guestos_version(conf, new_guestos_version);


### PR DESCRIPTION
GuestOS version of containers usually would be updated to latest
available GuestOS verison. However, if container configs are signed,
we want to have the GuestOS version fixed as defined in that config.
Thus, we only do the implicit update if we are allowed to also update
the container config.

Signed-off-by: Michael Weiß <michael.weiss@aisec.fraunhofer.de>