### PR TITLE
daemon/audit: audit subsystem

### DIFF
--- a/common/protobuf.c
+++ b/common/protobuf.c
@@ -39,12 +39,30 @@
 
 // TODO update naming scheme
 
-ssize_t
-protobuf_send_message(int fd, const ProtobufCMessage *message)
+uint32_t
+protobuf_pack_message_new(const ProtobufCMessage *message, uint8_t **ptr)
 {
 	ASSERT(message);
+	ASSERT(ptr);
 
-	uint32_t buflen = protobuf_c_message_get_packed_size(message);
+	uint32_t packed_len = protobuf_c_message_get_packed_size(message);
+	uint8_t *packed = mem_alloc(packed_len);
+
+	TRACE("Packed size: %d", packed_len);
+
+	uint32_t actual_len = protobuf_c_message_pack(message, packed);
+	ASSERT(actual_len == packed_len);
+
+	*ptr = packed;
+
+	return actual_len;
+}
+
+ssize_t
+protobuf_send_message_packed(int fd, const uint8_t *buf, uint32_t buflen)
+{
+	ASSERT(buf);
+
 	IF_FALSE_RETVAL(buflen < PROTOBUF_MAX_MESSAGE_SIZE, -1);
 
 	ssize_t bytes_sent = fd_write(fd, (char *)&(uint32_t){ htonl(buflen) }, sizeof(uint32_t));
@@ -59,14 +77,9 @@ protobuf_send_message(int fd, const ProtobufCMessage *message)
 	if (buflen == 0)
 		return 0;
 
-	uint8_t *buf = mem_alloc(buflen);
-	uint32_t actual_len = protobuf_c_message_pack(message, buf);
-	ASSERT(actual_len == buflen);
-
 	// TODO sending large messages: might have to send multiple chunks
 	// need good (generic?!) solution that interacts nicely with event handling!
 	bytes_sent = fd_write(fd, (char *)buf, buflen);
-	mem_free(buf);
 	if (-1 == bytes_sent)
 		goto error_write;
 	fsync(fd); // make sure all data is written so that receiving client unblocks
@@ -80,20 +93,44 @@ error_write:
 	return -1;
 }
 
-ProtobufCMessage *
-protobuf_recv_message(int fd, const ProtobufCMessageDescriptor *descriptor)
+ssize_t
+protobuf_send_message(int fd, const ProtobufCMessage *message)
 {
-	ASSERT(descriptor);
+	ASSERT(message);
 
+	uint8_t *buf = NULL;
+	uint32_t buflen = protobuf_pack_message_new(message, &buf);
+
+	if (!(buflen < PROTOBUF_MAX_MESSAGE_SIZE)) {
+		ERROR("Packed message exceeds PROTOBUF_MAX_MESSAGE_SIZE");
+		if (buf)
+			mem_free(buf);
+
+		return -1;
+	}
+
+	if (-1 == protobuf_send_message_packed(fd, buf, buflen)) {
+		ERROR_ERRNO("Failed to write packed protobuf message to fd %d.", fd);
+		return -1;
+	}
+
+	return buflen;
+}
+
+uint8_t *
+protobuf_recv_message_packed_new(int fd, ssize_t *ret_len)
+{
+	ASSERT(ret_len);
 	uint32_t buflen = 0;
 	ssize_t bytes_read;
 	do {
-		bytes_read = fd_read(fd, (char *)&buflen, sizeof(buflen));
+		bytes_read = fd_read(fd, (char *)&buflen, sizeof(uint32_t));
 	} while (-1 == bytes_read && errno == EINTR);
 	if (-1 == bytes_read)
 		goto error_read;
 	if (0 == bytes_read) { // EOF / remote end closed the connection
 		DEBUG("client on fd %d closed connection.", fd);
+		*ret_len = -1;
 		return NULL;
 	}
 	buflen = ntohl(buflen);
@@ -101,14 +138,15 @@ protobuf_recv_message(int fd, const ProtobufCMessageDescriptor *descriptor)
 	      bytes_read, sizeof(buflen), buflen);
 	if (((size_t)bytes_read != sizeof(buflen))) {
 		ERROR("Protocol violation!");
+		*ret_len = -1;
 		return NULL;
 	}
 	IF_FALSE_RETVAL(buflen < PROTOBUF_MAX_MESSAGE_SIZE, NULL);
 
-	// zero length data represents a message with all default values
-	// => use unpack to construct it (and initialize it with these defaults)
-	if (buflen == 0)
-		return protobuf_c_message_unpack(descriptor, NULL, 0, NULL);
+	if (0 == buflen) {
+		*ret_len = 0;
+		return NULL;
+	}
 
 	uint8_t *buf = mem_alloc(buflen);
 	do {
@@ -129,13 +167,48 @@ protobuf_recv_message(int fd, const ProtobufCMessageDescriptor *descriptor)
 	// TODO: what if only part of a message could be read?
 	// need good (generic?!) solution that interacts nicely with event handling!
 
-	ProtobufCMessage *msg = protobuf_c_message_unpack(descriptor, NULL, buflen, buf);
-	mem_free(buf);
-	return msg;
+	*ret_len = bytes_read;
+
+	return buf;
 
 error_read:
 	DEBUG_ERRNO("Failed to read binary protobuf message from fd %d.", fd);
+	*ret_len = -1;
 	return NULL;
+}
+
+ProtobufCMessage *
+protobuf_recv_message(int fd, const ProtobufCMessageDescriptor *descriptor)
+{
+	ASSERT(descriptor);
+
+	ssize_t buflen = 0;
+	uint8_t *buf = protobuf_recv_message_packed_new(fd, &buflen);
+
+	// zero length data represents a message with all default values
+	// => use unpack to construct it (and initialize it with these defaults)
+	if (0 == buflen)
+		return protobuf_c_message_unpack(descriptor, NULL, 0, NULL);
+
+	if (!buf) {
+		ERROR("Failed to receive packed protobuf message");
+		return NULL;
+	}
+
+	ProtobufCMessage *msg = protobuf_c_message_unpack(descriptor, NULL, buflen, buf);
+	mem_free(buf);
+	return msg;
+}
+
+ProtobufCMessage *
+protobuf_unpack_message(const ProtobufCMessageDescriptor *descriptor, uint8_t *buf,
+			uint32_t buf_len)
+{
+	ASSERT(descriptor);
+
+	ProtobufCMessage *msg = protobuf_c_message_unpack(descriptor, NULL, buf_len, buf);
+
+	return msg;
 }
 
 void

--- a/common/protobuf.h
+++ b/common/protobuf.h
@@ -35,6 +35,33 @@
 #include <protobuf-c/protobuf-c.h>
 
 #include <sys/types.h>
+#include <stdbool.h>
+
+/**
+ * Packs the given protobuf message struct
+ * and returns it's binary serialized form.
+ *
+ * The serialized message is prefixed with the length of the actual data.
+ *
+ * @param message   the protobuf message struct to serialize and write
+ * @param ptr       the location to store a pointer to the serialized representation
+ * @return          the length of the serialized message (without length prefix) or -1 on error
+ */
+uint32_t
+protobuf_pack_message_new(const ProtobufCMessage *message, uint8_t **ptr);
+
+/**
+ * Writes the given, serialized protobuf message struct to the given file descriptor
+ * (e.g. a file or socket).
+ *
+ * The serialized message is prefixed with the length of the actual data.
+ *
+ * @param fd        the file descriptor that the serialized message is written to
+ * @param buf       the serialized protobuf message to write
+ * @return          the length of the given message (without length prefix)
+ */
+ssize_t
+protobuf_send_message_packed(int fd, const uint8_t *buf, uint32_t buflen);
 
 /**
  * Writes the given protobuf message struct to the given file descriptor
@@ -63,6 +90,31 @@ protobuf_send_message(int fd, const ProtobufCMessage *message);
  */
 ProtobufCMessage *
 protobuf_recv_message(int fd, const ProtobufCMessageDescriptor *descriptor);
+
+/**
+ * Reads a serialized protobuf message from the given file descriptor
+ * and returns it's packed representation
+ *
+ * The serialized message must be prefixed with the length of the actual data.
+ *
+ * @param fd        the file descriptor that the serialized message is read from
+ * @param msg_len   a pointer where the length of the returned buffer should be stored, -1 on error
+ * @return          a pointer to the received, packed  protobuf message
+ */
+uint8_t *
+protobuf_recv_message_packed_new(int fd, ssize_t *msg_len);
+
+/**
+ * Unpacks the given, packed protobuf message
+ *
+ * @param descriptor    the protobuf message descriptor that defines the message structure
+ * @param buf Buffer containing the packed protobuf message
+ * @param buf_len length of the packed protobuf message
+ * @return the unpacked protobuf message message message to free
+ */
+ProtobufCMessage *
+protobuf_unpack_message(const ProtobufCMessageDescriptor *descriptor, uint8_t *buf,
+			uint32_t buf_len);
 
 /**
  * Frees an unpacked protobuf message struct (e.g. created by protobuf_recv_message()).

--- a/common/uuid.c
+++ b/common/uuid.c
@@ -26,6 +26,8 @@
 #include <string.h>
 #include <strings.h>
 #include <stdlib.h>
+#include <limits.h>
+#include <unistd.h>
 
 #include "common/macro.h"
 #include "common/mem.h"
@@ -172,4 +174,21 @@ uuid_string(const uuid_t *uuid)
 {
 	IF_NULL_RETVAL(uuid, NULL);
 	return uuid->string;
+}
+
+uint64_t
+uuid_get_node(const uuid_t *uuid)
+{
+	ASSERT(uuid);
+
+	uint64_t node = 0;
+
+	// 48-bit correspond to 12 hex characters
+	if (1 != sscanf(uuid->string + strlen(uuid->string) - 12, "%12lx", &node)) {
+		ERROR_ERRNO("Failed to read node ID");
+		DEBUG("Failed to return id");
+		return ULLONG_MAX;
+	}
+
+	return node;
 }

--- a/common/uuid.h
+++ b/common/uuid.h
@@ -32,6 +32,7 @@
 #define UUID_H
 
 #include <stdbool.h>
+#include <stdint.h>
 
 typedef struct uuid uuid_t;
 
@@ -72,5 +73,14 @@ uuid_free(uuid_t *uuid);
  */
 const char *
 uuid_string(const uuid_t *uuid);
+
+/**
+ * Get 48 bit node ID in last Part of uuid
+ *
+ * @param uuid UUID for which the string representation is returned.
+ * @return The node ID as 64 bit unsigned integer
+ */
+uint64_t
+uuid_get_node(const uuid_t *uuid);
 
 #endif /* UUID_H */

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -104,7 +104,9 @@ SRC_FILES := main.c \
 	time.c \
 	hw_$(TRUSTME_HARDWARE).c \
 	lxcfs.c \
-	input.c
+	input.c \
+	audit.c \
+	c_audit.c
 
 protobuf: container.proto control.proto guestos.proto common/logf.proto device.proto scd.proto c_service.proto
 	protoc-c --c_out=. container.proto

--- a/daemon/audit.c
+++ b/daemon/audit.c
@@ -1,0 +1,659 @@
+/*
+ * This file is part of trust|me
+ * Copyright(c) 2013 - 2020 Fraunhofer AISEC
+ * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 (GPL 2), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * The full GNU General Public License is included in this distribution in
+ * the file called "COPYING".
+ *
+ * Contact Information:
+ * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include "audit.h"
+
+#include "cmld.h"
+#include "smartcard.h"
+#include "common/mem.h"
+#include "common/uuid.h"
+#include "common/str.h"
+#include "common/macro.h"
+#include "common/dir.h"
+#include "common/file.h"
+#include "common/protobuf.h"
+
+#include <string.h>
+#include <time.h>
+#include <google/protobuf-c/protobuf-c-text.h>
+
+//TODO implement ACK mechanism fpr all service messages inside c-service.c?
+#ifdef ANDROID
+#include "device/fraunhofer/common/cml/daemon/c_service.pb-c.h"
+#else
+#include "c_service.pb-c.h"
+#endif
+
+#define AUDIT_HASH_ALGO SHA512
+#define AUDIT_HASH_ALGO_LEN 64
+
+#define AUDIT_DEFAULT_CONTAINER "00000000-0000-0000-0000-000000000000"
+
+#define AUDIT_DELIMITER "-----\n"
+
+//#undef LOGF_LOG_MIN_PRIO
+//#define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE
+
+#define AUDIT_LOGDIR "/data/audit"
+
+uint64_t AUDIT_STORAGE = 0;
+
+const char *evcategory[] = { "SUA", "FUA", "SSA", "FSA", "RLE" };
+const char *evclass[] = { "GUESTOS_MGMT", "TOKEN_MGMT", "CONTAINER_MGMT", "CONTAINER_ISOLATION",
+			  "TPM_COMM" };
+const char *component[] = { "CMLD", "SCD", "TPM2D" };
+const char *result[] = { "SUCCESS", "FAIL" };
+
+static AUDIT_MODE LOGMODE = CONTAINER;
+
+typedef struct {
+	char *key;
+	char *value;
+} audit_meta_t;
+
+static container_t *
+audit_get_log_container(const uuid_t *uuid)
+{
+	container_t *c = NULL;
+
+	if (uuid && LOGMODE == CONTAINER) {
+		c = cmld_container_get_by_uuid(uuid);
+	}
+
+	if (!c) {
+		c = cmld_containers_get_a0();
+	}
+
+	return c;
+}
+
+static char *
+audit_log_file_new(const char *uuid)
+{
+	if (C0 == LOGMODE)
+		return mem_printf("%s/%s.log", AUDIT_LOGDIR, AUDIT_DEFAULT_CONTAINER);
+	else
+		return mem_printf("%s/%s.log", AUDIT_LOGDIR, uuid);
+}
+
+static uint64_t
+audit_remaining_storage(const char *uuid)
+{
+	char *file = audit_log_file_new(uuid);
+	off_t size = file_size(file);
+
+	mem_free(file);
+
+	if (!file_exists(file)) {
+		return AUDIT_STORAGE;
+	}
+
+	if (0 > size) {
+		ERROR_ERRNO("Failed to retrieve size of audit log file");
+		return 0;
+	}
+
+	if ((uint64_t)size > AUDIT_STORAGE) {
+		ERROR("Detected audit log overflow");
+		return 0;
+	}
+
+	return AUDIT_STORAGE - size;
+}
+
+static const char *
+audit_category_to_string(AUDIT_CATEGORY c)
+{
+	return evcategory[c];
+}
+
+static const char *
+audit_evclass_to_string(AUDIT_EVENTCLASS c)
+{
+	return evclass[c];
+}
+
+static const char *
+audit_component_to_string(AUDIT_COMPONENT c)
+{
+	return component[c];
+}
+
+static void
+audit_send_record_cb(const char *hash_string, const char *hash_file,
+		     UNUSED smartcard_crypto_hashalgo_t hash_algo, void *data)
+{
+	if (!hash_string) {
+		ERROR("audit_send_record_cb: hash_string was empty");
+		return;
+	}
+
+	if (!hash_file) {
+		ERROR("audit_send_record_cb: hash_file was empty");
+		return;
+	}
+
+	if (!data) {
+		ERROR("audit_send_record_cb: No container given");
+		return;
+	}
+
+	const container_t *c = (const container_t *)data;
+	ASSERT(c);
+
+	uint32_t buf_len = file_size(hash_file);
+	uint8_t *buf = mem_alloc0(buf_len);
+
+	int read = file_read(hash_file, (char *)buf, buf_len);
+
+	if (read < 0 || buf_len != (unsigned int)read) {
+		ERROR("Processing SCD response: read %u bytes, expected %u", read, buf_len);
+		goto out;
+	}
+
+	TRACE("Got hash from SCD for file %s: %s", hash_file, hash_string);
+
+	container_audit_set_processing_ack(c, false);
+
+	if (unlink(hash_file)) {
+		ERROR_ERRNO("Failed to unlink %s", hash_file);
+	}
+
+	if (0 > container_audit_record_send(c, buf, buf_len)) {
+		ERROR("Failed to send audit record to container");
+		goto out;
+	}
+
+	container_audit_set_last_ack(c, mem_strdup(hash_string));
+	TRACE("Sent audit record with ID %s to container %s", container_audit_get_last_ack(c),
+	      uuid_string(container_get_uuid(c)));
+	//sleep(30);
+
+out:
+	mem_free(buf);
+}
+
+static AuditRecord *
+audit_record_new(AUDIT_CATEGORY category, AUDIT_COMPONENT component, AUDIT_EVENTCLASS evclass,
+		 const char *evtype, const char *subject_id, int meta_length,
+		 AuditRecord__Meta **metas)
+{
+	AuditRecord *s = mem_new0(AuditRecord, 1);
+
+	audit_record__init(s);
+
+	char *type = mem_printf("%s.%s.%s.%s", audit_category_to_string(category),
+				audit_component_to_string(component),
+				audit_evclass_to_string(evclass), evtype);
+	s->timestamp = time(NULL);
+
+	if (EFAULT == errno) {
+		ERROR_ERRNO("Failed to get current time");
+		return NULL;
+	}
+
+	s->type = type;
+
+	if (subject_id)
+		s->subject_id = mem_strdup(subject_id);
+
+	s->n_meta = meta_length;
+	s->meta = metas;
+
+	return s;
+}
+
+static AuditRecord *
+audit_record_from_textfile_new(const char *filename, const ProtobufCMessageDescriptor *descriptor,
+			       bool purge)
+{
+	ASSERT(filename);
+	ASSERT(descriptor);
+
+	FILE *file = fopen(filename, "r");
+	if (!file) {
+		WARN_ERRNO("Could not open file \"%s\" for reading.", filename);
+		return NULL;
+	}
+
+	ssize_t size = file_size(filename);
+
+	if (0 > size) {
+		ERROR("Failed to retrieve size of audit record log");
+		return NULL;
+	}
+
+	// read file up to delimiter
+	char *buf = mem_alloc0(size + 1);
+	size_t read = 0;
+	bool delim_found = false;
+
+	while (!delim_found && read < (size_t)size) {
+		ssize_t current = 0;
+		size_t n = 0;
+		char *line = NULL;
+
+		if (0 > (current = getline(&line, &n, file))) {
+			ERROR_ERRNO("Failed to read line from file");
+			fclose(file);
+			goto out;
+		}
+
+		if (read + current > (size_t)size) {
+			ERROR("File was changed while reading");
+			fclose(file);
+			goto out;
+		}
+
+		// if delimiter line was read, stop further processing
+		if (!strcmp(AUDIT_DELIMITER, line)) {
+			delim_found = true;
+			continue;
+		}
+
+		memcpy(buf + read, line, current);
+		read += current;
+	}
+	fclose(file);
+
+	// parse record from file
+	AuditRecord *record;
+	if (0 == size) {
+		INFO("Read audit record with default values");
+		record = (AuditRecord *)mem_new0(AuditRecord, 1);
+		audit_record__init(record);
+		goto out;
+	} else {
+		record = (AuditRecord *)protobuf_message_new_from_buf((uint8_t *)buf, read,
+								      descriptor);
+	}
+
+	if (!record) {
+		ERROR("Failed to parse text protobuf message (%s) from file \"%s\".",
+		      descriptor->name ? descriptor->name : "UNKNOWN", filename);
+		goto out;
+	}
+
+	if (purge) {
+		// delete record from file
+		if (read + strlen(AUDIT_DELIMITER) == (size_t)size) {
+			DEBUG("Audit log empty, removing file");
+			if (-1 == unlink(filename)) {
+				ERROR_ERRNO("Failed to remove audit log file");
+			}
+			goto out;
+		}
+
+		char *filebuf = file_read_new(filename, AUDIT_STORAGE);
+
+		if (!filebuf) {
+			ERROR("Failed to read audit log file");
+			goto out;
+		}
+
+		size_t offset = read + strlen(AUDIT_DELIMITER);
+		if (-1 == file_write(filename, filebuf + offset, strlen(filebuf + offset))) {
+			ERROR_ERRNO("Failed to remove message from file: %s", filename);
+		}
+		mem_free(filebuf);
+	}
+
+out:
+	if (buf)
+		mem_free(buf);
+
+	return (AuditRecord *)record;
+}
+
+static int
+audit_write_file(const uuid_t *uuid, const AuditRecord *msg)
+{
+	int ret = -1;
+
+	char *dir = mem_printf("%s/audit", AUDIT_LOGDIR);
+
+	if (!file_is_dir(dir) && dir_mkdir_p(dir, 0600)) {
+		ERROR("Failed to create logdir");
+		mem_free(dir);
+		return -1;
+	}
+	mem_free(dir);
+
+	char *file = audit_log_file_new(uuid_string(uuid));
+
+	char *msg_text = protobuf_c_text_to_string((ProtobufCMessage *)msg, NULL);
+
+	//TODO send error message
+	if (audit_remaining_storage(uuid_string(uuid)) <
+	    (strlen(msg_text) + strlen(AUDIT_DELIMITER))) {
+		container_t *c = cmld_container_get_by_uuid(uuid);
+
+		TRACE("Trying to notify container %s about stored audit events, remaining storage: %ld",
+		      (uuid_string(uuid)), audit_remaining_storage(uuid_string(uuid)));
+		if ((!c) || (-1 == container_audit_record_notify(
+					   c, audit_remaining_storage(uuid_string(uuid))))) {
+			ERROR("Failed to notify container about audit log overflow");
+		}
+		ERROR("Failed to store audit record: max. log size exceeded");
+		goto out;
+	}
+
+	TRACE("Logging audit record to file: %s", file);
+	if (0 > file_write_append(file, msg_text, strlen(msg_text))) {
+		ERROR("Failed to log audit message to file: %s", file);
+		goto out;
+	}
+
+	if (0 > file_write_append(file, "-----\n", strlen("-----\n"))) {
+		ERROR("Failed to log audit message to file: %s", msg_text);
+		goto out;
+	}
+
+	ret = 0;
+
+out:
+	mem_free(file);
+
+	return ret;
+}
+
+static AuditRecord *
+audit_next_record_new(const container_t *container, bool purge)
+{
+	AuditRecord *r;
+
+	char *file = audit_log_file_new(uuid_string(container_get_uuid(container)));
+
+	if (!file_exists(file)) {
+		ERROR("Failed to read audit record: no file");
+		mem_free(file);
+		return NULL;
+	}
+
+	r = (AuditRecord *)audit_record_from_textfile_new(file, &audit_record__descriptor, purge);
+
+	mem_free(file);
+
+	return r;
+}
+
+static int
+audit_do_send_record(const container_t *c, AuditRecord *record)
+{
+	int ret = -1;
+
+	char tmpfile[strlen(AUDIT_LOGDIR) + 14];
+	if (0 >= sprintf(tmpfile, "%s/%s", AUDIT_LOGDIR, "audit_XXXXXX")) {
+		ERROR_ERRNO("Failed to prepare temporary filename");
+		return -1;
+	}
+
+	if (!strcmp("", mktemp(tmpfile))) {
+		ERROR_ERRNO("Failed to generate temporary filename");
+		return -1;
+	}
+
+	CmldToServiceMessage *message_proto = mem_new0(CmldToServiceMessage, 1);
+	cmld_to_service_message__init(message_proto);
+	message_proto->code = CMLD_TO_SERVICE_MESSAGE__CODE__AUDIT_RECORD;
+
+	message_proto->audit_record = record;
+
+	uint8_t *packed;
+	uint32_t packed_len = protobuf_pack_message_new((ProtobufCMessage *)message_proto, &packed);
+
+	//	audit_record_free(record);
+	//	mem_free(message_proto);
+
+	protobuf_free_message((ProtobufCMessage *)message_proto);
+
+	if (!packed) {
+		ERROR("Failed to pack protobuf message");
+		goto out;
+	}
+
+	if (-1 == file_write(tmpfile, (char *)packed, packed_len)) {
+		ERROR("Failed to write packed message to file.");
+		mem_free(packed);
+		goto out;
+	}
+	mem_free(packed);
+
+	TRACE("Requesting scd to hash serialized protobuf message at %s", tmpfile);
+
+	// this state is needed s.t. additional ACKs from container arriving while scd is hashing the file
+	// do not lead to multiple transmissions of the same record
+	container_audit_set_processing_ack(c, true);
+
+	if (smartcard_crypto_hash_file(tmpfile, AUDIT_HASH_ALGO, audit_send_record_cb, (void *)c)) {
+		container_audit_set_processing_ack(c, false);
+		str_t *dump = str_hexdump_new((unsigned char *)packed, (int)packed_len);
+		ERROR("Failed to request hashing of record to be sent with length %u: %s.",
+		      packed_len, str_buffer(dump));
+		mem_free(dump);
+	}
+
+	ret = 0;
+out:
+
+	return ret;
+}
+
+static int
+audit_send_next_stored(const container_t *c)
+{
+	if (!c)
+		return -1;
+
+	char *file = audit_log_file_new(uuid_string(container_get_uuid(c)));
+
+	if (!file_exists(file)) {
+		DEBUG("Sent all stored audit messages");
+		mem_free(file);
+
+		if (0 > container_audit_notify_complete(c)) {
+			ERROR("Failed to notify container that all records were sent");
+			return -1;
+		}
+
+		container_audit_set_last_ack(c, NULL);
+		container_audit_set_processing_ack(c, false);
+
+		return 0;
+	}
+	mem_free(file);
+
+	AuditRecord *record;
+	if (!(record = audit_next_record_new(c, false))) {
+		ERROR("Could not read next audit record");
+		return -1;
+	}
+
+	if (audit_do_send_record(c, record)) {
+		ERROR("Failed to send next stored audit record");
+		mem_free(record);
+		return -1;
+	}
+	mem_free(record);
+
+	return 0;
+}
+
+int
+audit_process_ack(const container_t *c, const char *ack)
+{
+	ASSERT(c);
+
+	if (!AUDIT_STORAGE) {
+		DEBUG("Got ACK from container but AUDIT_STORAGE is zero, ignoring...");
+		return 0;
+	}
+
+	if (C0 == LOGMODE && strcmp(AUDIT_DEFAULT_CONTAINER, uuid_string(container_get_uuid(c)))) {
+		DEBUG("Got ACK from container %s, but LOGMODE is C0, ignoring...",
+		      uuid_string(container_get_uuid(c)));
+		return -1;
+	}
+
+	if (!ack) {
+		ERROR("Got audit ACK missing hash from container %s",
+		      uuid_string(container_get_uuid(c)));
+	}
+
+	if (container_audit_get_processing_ack(c)) {
+		TRACE("Already processing ACK for container %s, ignoring additional ACK",
+		      uuid_string(container_get_uuid(c)));
+		return 0;
+	}
+
+	TRACE("Got audit record ACK from container %s: %s", uuid_string(container_get_uuid(c)),
+	      ack);
+
+	if (match_hash(AUDIT_HASH_ALGO_LEN, container_audit_get_last_ack(c), ack)) {
+		TRACE("ACK hash matched last sent record %s", container_audit_get_last_ack(c));
+
+		AuditRecord *record = audit_next_record_new(c, true);
+
+		if (!record) {
+			ERROR("Failed to delete audit record %s", ack);
+			return -1;
+		}
+
+		mem_free(record);
+		TRACE("Cleaned up ack'ed record");
+
+		container_audit_set_last_ack(c, mem_strdup(""));
+	} else {
+		WARN("ACK from container %s did not match last sent audit record, try to send last stored record again",
+		     uuid_string(container_get_uuid(c)));
+	}
+
+	return audit_send_next_stored(c);
+}
+
+int
+audit_log_event(const uuid_t *uuid, AUDIT_CATEGORY category, AUDIT_COMPONENT component,
+		AUDIT_EVENTCLASS evclass, const char *evtype, const char *subject_id,
+		int meta_count, ...)
+{
+	container_t *c = NULL;
+	AuditRecord *record = NULL;
+	AuditRecord__Meta **metas = NULL;
+	int ret = 0;
+
+	if (!AUDIT_STORAGE) {
+		TRACE("Attempt to log audit message but AUDIT_STORAGE is zero, skipping...");
+		return 0;
+	}
+
+	if (0 < meta_count) {
+		if (0 != (meta_count % 2)) {
+			ERROR("Odd number of variadic arguments, aborting...");
+			return -1;
+		}
+
+		va_list ap;
+
+		va_start(ap, meta_count);
+
+		metas = mem_alloc0((meta_count / 2) * sizeof(AuditRecord__Meta *));
+		for (int i = 0; i < meta_count / 2; i++) {
+			metas[i] = mem_alloc0(sizeof(AuditRecord__Meta));
+
+			audit_record__meta__init(metas[i]);
+
+			metas[i]->key = mem_strdup(va_arg(ap, const char *));
+			metas[i]->value = mem_strdup(va_arg(ap, const char *));
+		}
+
+		va_end(ap);
+		meta_count /= 2;
+	}
+
+	record = audit_record_new(category, component, evclass, evtype, subject_id, meta_count,
+				  metas);
+
+	if (!record) {
+		ERROR("Failed to create audit record");
+		mem_free(metas);
+		goto out;
+	}
+
+	DEBUG("Logging audit message %s",
+	      protobuf_c_text_to_string((ProtobufCMessage *)record, NULL) ?
+		      protobuf_c_text_to_string((ProtobufCMessage *)record, NULL) :
+		      "");
+
+	c = audit_get_log_container(uuid);
+
+	if (c) {
+		if (0 != (ret = audit_write_file(container_get_uuid(c), record))) {
+			ERROR("Failed to store audit log for container %s to file",
+			      uuid_string(container_get_uuid(c)));
+			goto out;
+		}
+	} else {
+		ERROR("No audit logging container available, will log to file %s",
+		      AUDIT_DEFAULT_CONTAINER);
+		uuid_t *default_uuid = uuid_new(AUDIT_DEFAULT_CONTAINER);
+		if (0 != (ret = audit_write_file(default_uuid, record))) {
+			ERROR("Failed to store audit log to file");
+			uuid_free(default_uuid);
+			goto out;
+		}
+		uuid_free(default_uuid);
+	}
+
+	if (c && (container_audit_get_processing_ack(c))) {
+		TRACE("Already processing ACK, do not notify container again");
+		goto out;
+	}
+
+	if (c && (CONTAINER_STATE_RUNNING == container_get_state(c))) {
+		bool processing_ack = container_audit_get_processing_ack(c);
+		if (!processing_ack &&
+		    (-1 == container_audit_record_notify(c, audit_remaining_storage(uuid_string(
+								    container_get_uuid(c)))))) {
+			ERROR("Failed to notify container about new audit record");
+		}
+	}
+
+out:
+	//if (record)
+	//	audit_record_free(record);
+	protobuf_free_message((ProtobufCMessage *)record);
+
+	return ret;
+}
+
+int
+audit_set_size(uint32_t size)
+{
+	AUDIT_STORAGE = size * 1024 * 1024;
+
+	return 0;
+}

--- a/daemon/audit.h
+++ b/daemon/audit.h
@@ -1,0 +1,56 @@
+/*
+ * This file is part of trust|me
+ * Copyright(c) 2013 - 2021 Fraunhofer AISEC
+ * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 (GPL 2), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * The full GNU General Public License is included in this distribution in
+ * the file called "COPYING".
+ *
+ * Contact Information:
+ * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ */
+
+#ifndef AUDIT_H
+#define AUDIT_H
+
+#include "container.h"
+
+typedef enum { CONTAINER, C0 } AUDIT_MODE;
+
+typedef enum { SUA, FUA, SSA, FSA, RLE } AUDIT_CATEGORY;
+
+typedef enum {
+	GUESTOS_MGMT,
+	TOKEN_MGMT,
+	CONTAINER_MGMT,
+	CONTAINER_ISOLATION,
+	TPM_COMM
+} AUDIT_EVENTCLASS;
+
+typedef enum { COMMAND, INTERNAL, TOKEN, UPDATE } AUDIT_EVENTTYPE;
+
+typedef enum { CMLD, SCD, TPM2D } AUDIT_COMPONENT;
+
+int
+audit_set_size(uint32_t size);
+
+int
+audit_log_event(const uuid_t *uuid, AUDIT_CATEGORY category, AUDIT_COMPONENT component,
+		AUDIT_EVENTCLASS evclass, const char *evtype, const char *subject_id,
+		int meta_count, ...);
+
+int
+audit_process_ack(const container_t *audit, const char *ack);
+
+#endif /* AUDIT_H */

--- a/daemon/c_audit.c
+++ b/daemon/c_audit.c
@@ -1,0 +1,117 @@
+/*
+ * This file is part of trust|me
+ * Copyright(c) 2013 - 2021 Fraunhofer AISEC
+ * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 (GPL 2), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * The full GNU General Public License is included in this distribution in
+ * the file called "COPYING".
+ *
+ * Contact Information:
+ * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ */
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include "c_audit.h"
+
+#include "cmld.h"
+#include "smartcard.h"
+#include "common/mem.h"
+#include "common/uuid.h"
+#include "common/str.h"
+#include "common/macro.h"
+#include "common/dir.h"
+#include "common/file.h"
+#include "common/protobuf.h"
+
+#include <string.h>
+#include <time.h>
+#include <google/protobuf-c/protobuf-c-text.h>
+
+//#undef LOGF_LOG_MIN_PRIO
+//#define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE
+
+struct c_audit {
+	const container_t *container;
+	char *last_ack;
+	bool processing_ack;
+};
+
+int
+c_audit_start_child(c_audit_t *audit)
+{
+	if (!file_exists("/proc/self/audit_containerid"))
+		return 0;
+
+	if (0 < file_printf("/proc/self/audit_containerid", "%llu",
+			    uuid_get_node(container_get_uuid(audit->container)))) {
+		ERROR("Failed to set audit container ID");
+		//TODO FIXME
+		//return -1;
+	}
+
+	return 0;
+}
+
+c_audit_t *
+c_audit_new(const container_t *container)
+{
+	ASSERT(container);
+
+	c_audit_t *audit = mem_new0(c_audit_t, 1);
+
+	audit->container = container;
+
+	TRACE("Node ID test: %lx", uuid_get_node(container_get_uuid(container)));
+
+	audit->container = container;
+	audit->last_ack = mem_strdup("");
+	audit->processing_ack = false;
+
+	return audit;
+}
+
+const char *
+c_audit_get_last_ack(const c_audit_t *audit)
+{
+	ASSERT(audit);
+	return audit->last_ack;
+}
+
+void
+c_audit_set_last_ack(c_audit_t *audit, char *last_ack)
+{
+	ASSERT(audit);
+
+	if (audit->last_ack)
+		mem_free(audit->last_ack);
+
+	audit->last_ack = last_ack;
+}
+
+bool
+c_audit_get_processing_ack(const c_audit_t *audit)
+{
+	ASSERT(audit);
+	return audit->processing_ack;
+}
+
+void
+c_audit_set_processing_ack(c_audit_t *audit, bool processing_ack)
+{
+	ASSERT(audit);
+	audit->processing_ack = processing_ack;
+}

--- a/daemon/c_audit.h
+++ b/daemon/c_audit.h
@@ -1,0 +1,50 @@
+/*
+ * This file is part of trust|me
+ * Copyright(c) 2013 - 2021 Fraunhofer AISEC
+ * Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms and conditions of the GNU General Public License,
+ * version 2 (GPL 2), as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL 2 license for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses/>
+ *
+ * The full GNU General Public License is included in this distribution in
+ * the file called "COPYING".
+ *
+ * Contact Information:
+ * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
+ */
+
+#ifndef C_AUDIT_H
+#define C_AUDIT_H
+
+#include "container.h"
+#include "audit.h"
+
+typedef struct c_audit c_audit_t;
+
+c_audit_t *
+c_audit_new(const container_t *container);
+
+int
+c_audit_start_child(c_audit_t *audit);
+
+const char *
+c_audit_get_last_ack(const c_audit_t *audit);
+
+void
+c_audit_set_last_ack(c_audit_t *audit, char *last_ack);
+
+bool
+c_audit_get_processing_ack(const c_audit_t *audit);
+
+void
+c_audit_set_processing_ack(c_audit_t *audit, bool processing_ack);
+
+#endif /* C_AUDIT_H */

--- a/daemon/c_cap.c
+++ b/daemon/c_cap.c
@@ -71,7 +71,7 @@ c_cap_set_current_process(const container_t *container)
 	/* 28 */ C_CAP_DROP(CAP_LEASE);
 
 	///* 29 */ C_CAP_DROP(CAP_AUDIT_WRITE); /* needed for console/X11 login */
-	///* 30 */ C_CAP_DROP(CAP_AUDIT_CONTROL); /* needed by logd */
+	/* 30 */ C_CAP_DROP(CAP_AUDIT_CONTROL);
 
 	/* 31 */ C_CAP_DROP(CAP_SETFCAP);
 

--- a/daemon/c_service.c
+++ b/daemon/c_service.c
@@ -122,7 +122,6 @@ c_service_handle_received_message(c_service_t *service, const ServiceToCmldMessa
 	switch (message->code) {
 	case SERVICE_TO_CMLD_MESSAGE__CODE__BOOT_COMPLETED:
 		container_set_state(service->container, CONTAINER_STATE_RUNNING);
-
 		break;
 
 	case SERVICE_TO_CMLD_MESSAGE__CODE__AUDIO_SUSPEND_COMPLETED:

--- a/daemon/c_service.h
+++ b/daemon/c_service.h
@@ -47,6 +47,9 @@ typedef enum {
 	//C_SERVICE_MESSAGE_WALLPAPER,     // explicit request for current wallpaper
 	C_SERVICE_MESSAGE_AUDIO_SUSPEND,
 	C_SERVICE_MESSAGE_AUDIO_RESUME,
+	C_SERVICE_MESSAGE_AUDIT_NOTIFY,
+	C_SERVICE_MESSAGE_AUDIT_RECORD,
+	C_SERVICE_MESSAGE_AUDIT_COMPLETE,
 	C_SERVICE_MESSAGE_NOTIFICATION
 } c_service_message_t;
 
@@ -111,6 +114,25 @@ c_service_start_child(c_service_t *service);
  */
 int
 c_service_start_pre_exec(c_service_t *service);
+
+/**
+ * Send packed audit record to service.
+ * @param service The service object of the associated container.
+ * @param buf packed protobuf message to be send
+ * @param buf_len length of the packed protobuf message
+ * @return 0 on success, -1 otherwise
+*/
+int
+c_service_audit_send_record(c_service_t *service, const uint8_t *buf, const uint32_t buf_len);
+
+/**
+ * Notify container about stored audit events.
+ * @param service The service object of the associated container.
+ * @param remaining_audit storage capacity
+ * @return the length of the serialized message (without length prefix)
+*/
+int
+c_service_audit_notify(c_service_t *service, uint64_t remaining_storage);
 
 /**
  * Sends a message to the Trustme Service. If the message induces a response

--- a/daemon/c_service.proto
+++ b/daemon/c_service.proto
@@ -27,6 +27,19 @@ option java_package = "de.fraunhofer.aisec.trustme.service";
 
 import "container.proto";
 
+message AuditRecord {
+	message Meta {
+		required string key = 1;
+		required string value = 2;
+	};
+
+	required int64 timestamp = 1;
+	required string type = 2;
+	optional string subject_id = 3;
+
+	repeated Meta meta = 4;
+}
+
 message CmldToServiceMessage {
 	enum Code {
 		SHUTDOWN = 1;
@@ -44,6 +57,10 @@ message CmldToServiceMessage {
 
 		CONTAINER_CFG_NAME = 17;
 		CONTAINER_CFG_DNS = 18;
+
+		AUDIT_NOTIFY = 19;
+		AUDIT_RECORD = 20;
+		AUDIT_COMPLETE = 21;
 	}
 	required Code code = 1;
 
@@ -54,6 +71,9 @@ message CmldToServiceMessage {
 	optional bool wifi_user_enabled = 12;
 	optional string container_cfg_name = 13;
 	optional string container_cfg_dns = 14;
+	optional string msg = 15;
+	optional AuditRecord audit_record = 16;
+	optional uint64 audit_remaining_storage = 17;
 }
 
 message ServiceToCmldMessage {
@@ -84,6 +104,8 @@ message ServiceToCmldMessage {
 		CONTAINER_CFG_DNS_REQ = 19;
 
 		EXEC_CAP_SYSTIME_PRIV = 20;
+
+		AUDIT_ACK = 21;
 	}
 	required Code code = 1;
 
@@ -97,4 +119,5 @@ message ServiceToCmldMessage {
 	optional bool wifi_user_enabled = 14;
 	optional string captime_exec_path = 15;
 	repeated string captime_exec_param = 16;
+	optional string audit_ack = 17;
 }

--- a/daemon/cmld.h
+++ b/daemon/cmld.h
@@ -159,7 +159,7 @@ void
 cmld_wipe_device();
 
 container_t *
-cmld_container_get_by_uuid(uuid_t *uuid);
+cmld_container_get_by_uuid(const uuid_t *uuid);
 
 container_t *
 cmld_container_get_by_token_serial(const char *serial);

--- a/daemon/container.h
+++ b/daemon/container.h
@@ -145,7 +145,8 @@ enum container_error {
 	CONTAINER_ERROR_DEVNS,
 	CONTAINER_ERROR_USER,
 	CONTAINER_ERROR_FIFO,
-	CONTAINER_ERROR_TIME
+	CONTAINER_ERROR_TIME,
+	CONTAINER_ERROR_AUDIT
 };
 
 typedef enum {
@@ -920,4 +921,55 @@ container_exec_cap_systime(const container_t *container, char *const *argv);
 bool
 container_get_usb_pin_entry(const container_t *container);
 
+/**
+ * Send audit record to container
+ */
+int
+container_audit_record_notify(const container_t *container, uint64_t remaining_storage);
+
+/**
+ * Returns the last ACK hash that has been received from this container
+ */
+const char *
+container_audit_get_last_ack(const container_t *container);
+
+/**
+ * Stores the last ACKi hash that has been received for this container.
+ */
+void
+container_audit_set_last_ack(const container_t *container, char *last_ack);
+
+/**
+ * Returns wether an ACK is currently being processed for this container
+ */
+int
+container_audit_get_processing_ack(const container_t *container);
+
+/**
+ * Stores if an ACK hash is currently being processed for this container
+ */
+
+void
+container_audit_set_processing_ack(const container_t *container, bool processing_ack);
+
+/**
+ * Send audit record to container
+ */
+int
+container_audit_record_notify(const container_t *container, uint64_t remaining_storage);
+
+/**
+ * Send audit event to container
+ */
+int
+container_audit_record_send(const container_t *container, const uint8_t *buf, uint32_t buflen);
+
+/**
+ * Process audit record ACK received from a container
+ */
+int
+container_audit_process_ack(const container_t *container, const char *ack);
+
+int
+container_audit_notify_complete(const container_t *container);
 #endif /* CONTAINER_H */

--- a/daemon/control.c
+++ b/daemon/control.c
@@ -38,6 +38,7 @@
 #include "smartcard.h"
 #include "input.h"
 #include "uevent.h"
+#include "audit.h"
 
 //#define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE
 #include "common/macro.h"
@@ -1195,6 +1196,9 @@ control_handle_message(control_t *control, const ControllerToDaemon *msg, int fd
 	} break;
 	case CONTROLLER_TO_DAEMON__COMMAND__CONTAINER_START: {
 		if (NULL == container) {
+			audit_log_event(container_get_uuid(container), FSA, CMLD, CONTAINER_MGMT,
+					"container-start-not-existing",
+					uuid_string(container_get_uuid(container)), 0);
 			WARN("Container does not exist!");
 			res = control_send_message(CONTROL_RESPONSE_CONTAINER_START_EEXIST, fd);
 			break;

--- a/daemon/device.proto
+++ b/daemon/device.proto
@@ -61,4 +61,7 @@ message DeviceConfig {
 	required bool hostedmode = 14 [default = false];
 
 	optional bool signed_configs = 15 [default = false];
+
+	// max size of audit log per logging sink in MB
+	optional uint64 audit_size = 16 [default = 0];
 }

--- a/daemon/device_config.c
+++ b/daemon/device_config.c
@@ -55,7 +55,7 @@ device_config_new(const char *path)
 		DEBUG("Loading device config from \"%s\".", file);
 
 		cfg = (DeviceConfig *)protobuf_message_new_from_textfile(
-			file, &device_config__descriptor, false);
+			file, &device_config__descriptor);
 		if (!cfg) {
 			WARN("Failed loading device config from file \"%s\". Reverting to default values.",
 			     file);

--- a/daemon/device_config.c
+++ b/daemon/device_config.c
@@ -55,7 +55,7 @@ device_config_new(const char *path)
 		DEBUG("Loading device config from \"%s\".", file);
 
 		cfg = (DeviceConfig *)protobuf_message_new_from_textfile(
-			file, &device_config__descriptor);
+			file, &device_config__descriptor, false);
 		if (!cfg) {
 			WARN("Failed loading device config from file \"%s\". Reverting to default values.",
 			     file);
@@ -234,4 +234,13 @@ device_config_get_signed_configs(const device_config_t *config)
 	ASSERT(config->cfg);
 
 	return config->cfg->signed_configs;
+}
+
+bool
+device_config_get_audit_size(const device_config_t *config)
+{
+	ASSERT(config);
+	ASSERT(config->cfg);
+
+	return config->cfg->audit_size;
 }

--- a/daemon/device_config.h
+++ b/daemon/device_config.h
@@ -106,4 +106,7 @@ device_config_get_hostedmode(const device_config_t *config);
 
 bool
 device_config_get_signed_configs(const device_config_t *config);
+
+bool
+device_config_get_audit_size(const device_config_t *config);
 #endif /* DEVICE_H */

--- a/daemon/mount.c
+++ b/daemon/mount.c
@@ -25,6 +25,7 @@
 #include <sched.h>
 
 #include "mount.h"
+#include "smartcard.h"
 
 #include "common/macro.h"
 #include "common/mem.h"
@@ -238,36 +239,6 @@ mount_entry_get_mount_data(const mount_entry_t *mntent)
 	return mntent->mount_data;
 }
 
-static bool
-match_hash(const char *hash_name, size_t hash_len, const char *img_name, const char *expected_hash,
-	   const char *hash)
-{
-	ASSERT(hash_name);
-	ASSERT(img_name);
-
-	if (!hash) {
-		ERROR("Checking image %s.img with %s: empty hash value", img_name, hash_name);
-		return false;
-	}
-	if (!expected_hash) {
-		ERROR("Checking image %s.img with %s: reference hash value for image is missing",
-		      img_name, hash_name);
-		return false;
-	}
-	size_t len = strlen(expected_hash);
-	if (len != 2 * hash_len) {
-		ERROR("Checking image %s.img with %s: invalid hash length %zu/2, expected %zu/2 bytes",
-		      img_name, hash_name, len, 2 * hash_len);
-		return false;
-	}
-	if (strncasecmp(expected_hash, hash, len + 1)) {
-		DEBUG("Checking image %s.img with %s: hash mismatch", img_name, hash_name);
-		return false;
-	}
-	DEBUG("Checking image %s.img with %s: hashes match", img_name, hash_name);
-	return true;
-}
-
 bool
 mount_entry_match_sha1(const mount_entry_t *e, const char *hash)
 {
@@ -275,7 +246,10 @@ mount_entry_match_sha1(const mount_entry_t *e, const char *hash)
 
 	const char *img_name = mount_entry_get_img(e);
 	const char *expected = mount_entry_get_sha1(e);
-	return match_hash("SHA1", 20, img_name, expected, hash);
+
+	DEBUG("Checking image %s.img with expected SHA1 hash %s, actual hash: %s", img_name,
+	      expected, hash);
+	return match_hash(20, expected, hash);
 }
 
 bool
@@ -285,7 +259,9 @@ mount_entry_match_sha256(const mount_entry_t *e, const char *hash)
 
 	const char *img_name = mount_entry_get_img(e);
 	const char *expected = mount_entry_get_sha256(e);
-	return match_hash("SHA256", 32, img_name, expected, hash);
+	DEBUG("Checking image %s.img with expected SHA256 hash %s, actual hash: %s", img_name,
+	      expected, hash);
+	return match_hash(32, expected, hash);
 }
 
 bool

--- a/daemon/smartcard.c
+++ b/daemon/smartcard.c
@@ -1544,3 +1544,29 @@ smartcard_push_cert(smartcard_t *smartcard, control_t *control, uint8_t *cert, s
 error:
 	control_send_message(CONTROL_RESPONSE_DEVICE_CERT_ERROR, control_get_client_sock(control));
 }
+
+bool
+match_hash(size_t hash_len, const char *expected_hash, const char *hash)
+{
+	if (!hash) {
+		ERROR("Empty hash value");
+		return false;
+	}
+	if (!expected_hash) {
+		ERROR("Reference hash value for image is missing");
+		return false;
+	}
+
+	//TODO harden against hash algorithms with NULL bytes in digest
+	size_t len = strlen(expected_hash);
+	if (len != 2 * hash_len) {
+		ERROR("Invalid hash length %zu/2, expected %zu/2 bytes", len, 2 * hash_len);
+		return false;
+	}
+	if (strncasecmp(expected_hash, hash, len + 1)) {
+		DEBUG("Hash mismatch");
+		return false;
+	}
+	DEBUG("Hashes match");
+	return true;
+}

--- a/daemon/smartcard.c
+++ b/daemon/smartcard.c
@@ -27,10 +27,10 @@
 #include "scd.pb-c.h"
 #endif
 
-#include "cmld.h"
 #include "smartcard.h"
 #include "hardware.h"
 #include "control.h"
+#include "audit.h"
 
 #include "common/macro.h"
 #include "common/event.h"
@@ -293,6 +293,9 @@ smartcard_cb_start_container(int fd, unsigned events, event_io_t *io, void *data
 
 		switch (msg->code) {
 		case TOKEN_TO_DAEMON__CODE__LOCK_FAILED: {
+			audit_log_event(container_get_uuid(startdata->container), FSA, CMLD,
+					TOKEN_MGMT, "lock",
+					uuid_string(container_get_uuid(startdata->container)), 0);
 			WARN("Locking the token failed.");
 			control_send_message(CONTROL_RESPONSE_CONTAINER_START_LOCK_FAILED, resp_fd);
 			done = true;
@@ -303,6 +306,9 @@ smartcard_cb_start_container(int fd, unsigned events, event_io_t *io, void *data
 			done = true;
 		} break;
 		case TOKEN_TO_DAEMON__CODE__UNLOCK_FAILED: {
+			audit_log_event(container_get_uuid(startdata->container), FSA, CMLD,
+					TOKEN_MGMT, "unlock",
+					uuid_string(container_get_uuid(startdata->container)), 0);
 			WARN("Unlocking the token failed.");
 			control_send_message(CONTROL_RESPONSE_CONTAINER_START_UNLOCK_FAILED,
 					     resp_fd);
@@ -310,17 +316,26 @@ smartcard_cb_start_container(int fd, unsigned events, event_io_t *io, void *data
 		} break;
 		case TOKEN_TO_DAEMON__CODE__PASSWD_WRONG: {
 			WARN("Unlocking the token failed (wrong PIN/passphrase).");
+			audit_log_event(container_get_uuid(startdata->container), FSA, CMLD,
+					TOKEN_MGMT, "unlock-wrong-pin",
+					uuid_string(container_get_uuid(startdata->container)), 0);
 			control_send_message(CONTROL_RESPONSE_CONTAINER_START_PASSWD_WRONG,
 					     resp_fd);
 			done = true;
 		} break;
 		case TOKEN_TO_DAEMON__CODE__LOCKED_TILL_REBOOT: {
 			WARN("Unlocking the token failed (locked till reboot).");
+			audit_log_event(container_get_uuid(startdata->container), FSA, CMLD,
+					TOKEN_MGMT, "locked-until-reboot",
+					uuid_string(container_get_uuid(startdata->container)), 0);
 			control_send_message(CONTROL_RESPONSE_CONTAINER_LOCKED_TILL_REBOOT,
 					     resp_fd);
 			done = true;
 		} break;
 		case TOKEN_TO_DAEMON__CODE__UNLOCK_SUCCESSFUL: {
+			audit_log_event(container_get_uuid(startdata->container), SSA, CMLD,
+					TOKEN_MGMT, "unlock-successful",
+					uuid_string(container_get_uuid(startdata->container)), 0);
 			char *keyfile =
 				mem_printf("%s/%s.key", startdata->smartcard->path,
 					   uuid_string(container_get_uuid(startdata->container)));
@@ -331,9 +346,19 @@ smartcard_cb_start_container(int fd, unsigned events, event_io_t *io, void *data
 				int keylen = file_read(keyfile, (char *)key, sizeof(key));
 				DEBUG("Length of existing key: %d", keylen);
 				if (keylen < 0) {
+					audit_log_event(container_get_uuid(startdata->container),
+							FSA, CMLD, TOKEN_MGMT, "read-wrapped-key",
+							uuid_string(container_get_uuid(
+								startdata->container)),
+							0);
 					ERROR("Failed to read key from file for container!");
 					break;
 				}
+
+				audit_log_event(
+					container_get_uuid(startdata->container), SSA, CMLD,
+					TOKEN_MGMT, "read-wrapped-key",
+					uuid_string(container_get_uuid(startdata->container)), 0);
 				// unwrap via scd
 				DaemonToToken out = DAEMON_TO_TOKEN__INIT;
 				out.code = DAEMON_TO_TOKEN__CODE__UNWRAP_KEY;
@@ -371,9 +396,19 @@ smartcard_cb_start_container(int fd, unsigned events, event_io_t *io, void *data
 				int keylen = hardware_get_random(key, sizeof(key));
 				DEBUG("SCD: keylen=%d, sizeof(key)=%zu", keylen, sizeof(key));
 				if (keylen != sizeof(key)) {
+					audit_log_event(container_get_uuid(startdata->container),
+							FSA, CMLD, TOKEN_MGMT,
+							"gen-container-key-rng-error",
+							uuid_string(container_get_uuid(
+								startdata->container)),
+							0);
 					ERROR("Failed to generate key for container, due to RNG Error!");
 					break;
 				}
+				audit_log_event(
+					container_get_uuid(startdata->container), SSA, CMLD,
+					TOKEN_MGMT, "gen-container-key",
+					uuid_string(container_get_uuid(startdata->container)), 0);
 				// set the key
 				char *ascii_key = bytes_to_string_new(key, keylen);
 				container_set_key(startdata->container, ascii_key);
@@ -422,11 +457,18 @@ smartcard_cb_start_container(int fd, unsigned events, event_io_t *io, void *data
 			mem_free(out.token_uuid);
 			if (!msg->has_unwrapped_key) {
 				WARN("Expected derived key, but none was returned!");
+				audit_log_event(
+					container_get_uuid(startdata->container), FSA, CMLD,
+					TOKEN_MGMT, "unwrap-container-key",
+					uuid_string(container_get_uuid(startdata->container)), 0);
 				control_send_message(CONTROL_RESPONSE_CONTAINER_START_EINTERNAL,
 						     resp_fd);
 				break;
 			}
 			// set the key
+			audit_log_event(container_get_uuid(startdata->container), SSA, CMLD,
+					TOKEN_MGMT, "unwrap-container-key",
+					uuid_string(container_get_uuid(startdata->container)), 0);
 			TRACE("Successfully retrieved unwrapped key from SCD");
 			char *ascii_key = bytes_to_string_new(msg->unwrapped_key.data,
 							      msg->unwrapped_key.len);
@@ -452,10 +494,17 @@ smartcard_cb_start_container(int fd, unsigned events, event_io_t *io, void *data
 			mem_free(out.token_uuid);
 			// save wrapped key
 			if (!msg->has_wrapped_key) {
+				audit_log_event(
+					container_get_uuid(startdata->container), FSA, CMLD,
+					TOKEN_MGMT, "wrap-key",
+					uuid_string(container_get_uuid(startdata->container)), 0);
 				WARN("Expected wrapped key, but none was returned!");
 				break;
 			}
 			ASSERT(msg->wrapped_key.len < TOKEN_MAX_WRAPPED_KEY_LEN);
+			audit_log_event(container_get_uuid(startdata->container), SSA, CMLD,
+					TOKEN_MGMT, "wrap-key",
+					uuid_string(container_get_uuid(startdata->container)), 0);
 			char *keyfile =
 				mem_printf("%s/%s.key", startdata->smartcard->path,
 					   uuid_string(container_get_uuid(startdata->container)));
@@ -463,9 +512,16 @@ smartcard_cb_start_container(int fd, unsigned events, event_io_t *io, void *data
 			int bytes_written = file_write(keyfile, (char *)msg->wrapped_key.data,
 						       msg->wrapped_key.len);
 			if (bytes_written != (int)msg->wrapped_key.len) {
+				audit_log_event(
+					container_get_uuid(startdata->container), FSA, CMLD,
+					TOKEN_MGMT, "store-wrapped-key",
+					uuid_string(container_get_uuid(startdata->container)), 0);
 				ERROR("Failed to store key for container %s to %s!",
 				      container_get_name(startdata->container), keyfile);
 			}
+			audit_log_event(container_get_uuid(startdata->container), SSA, CMLD,
+					TOKEN_MGMT, "store-wrapped-key",
+					uuid_string(container_get_uuid(startdata->container)), 0);
 			TRACE("Stored wrapped key on disk successfully");
 			// delete wrapped key from RAM
 			memset(msg->wrapped_key.data, 0, msg->wrapped_key.len);
@@ -580,6 +636,9 @@ smartcard_container_ctrl_handler(smartcard_t *smartcard, control_t *control, con
 	int resp_fd = control_get_client_sock(startdata->control);
 
 	if (!container_get_token_is_init(container)) {
+		audit_log_event(container_get_uuid(startdata->container), FSA, CMLD, TOKEN_MGMT,
+				"token-uninitialized",
+				uuid_string(container_get_uuid(startdata->container)), 0);
 		ERROR("The token that is associated with the container has not been initialized!");
 		control_send_message(CONTROL_RESPONSE_CONTAINER_TOKEN_UNINITIALIZED, resp_fd);
 		goto err;
@@ -587,6 +646,9 @@ smartcard_container_ctrl_handler(smartcard_t *smartcard, control_t *control, con
 
 	if (!container_get_token_is_linked_to_device(container)) {
 		ERROR("The token that is associated with this container must be paired to the device first");
+		audit_log_event(container_get_uuid(startdata->container), FSA, CMLD, TOKEN_MGMT,
+				"token-not-paired",
+				uuid_string(container_get_uuid(startdata->container)), 0);
 		control_send_message(CONTROL_RESPONSE_CONTAINER_TOKEN_UNPAIRED, resp_fd);
 		goto err;
 	}
@@ -594,10 +656,16 @@ smartcard_container_ctrl_handler(smartcard_t *smartcard, control_t *control, con
 	unsigned char pair_sec[MAX_PAIR_SEC_LEN];
 	pair_sec_len = smartcard_get_pairing_secret(smartcard, pair_sec, sizeof(pair_sec));
 	if (pair_sec_len < 0) {
+		audit_log_event(container_get_uuid(startdata->container), FSA, CMLD, TOKEN_MGMT,
+				"read-pairing-secret",
+				uuid_string(container_get_uuid(startdata->container)), 0);
 		ERROR("Could not retrieve pairing secret");
 		control_send_message(CONTROL_RESPONSE_CONTAINER_START_EINTERNAL, resp_fd);
 		goto err;
 	}
+	audit_log_event(container_get_uuid(startdata->container), SSA, CMLD, TOKEN_MGMT,
+			"read-pairing-secret",
+			uuid_string(container_get_uuid(startdata->container)), 0);
 
 	// TODO register timer if socket does not respond
 	event_io_t *event = NULL;
@@ -703,7 +771,7 @@ smartcard_cb_container_change_pin(int fd, unsigned events, event_io_t *io, void 
 {
 	smartcard_startdata_t *startdata = data;
 	int resp_fd = control_get_client_sock(startdata->control);
-	int rc;
+	int rc = -1;
 
 	if (events & EVENT_IO_READ) {
 		TokenToDaemon *msg =
@@ -995,7 +1063,7 @@ smartcard_remove_keyfile(smartcard_t *smartcard, const container_t *container)
 	}
 
 	if (0 != remove(keyfile)) {
-		ERROR("Failed to remove keyfile");
+		ERROR_ERRNO("Failed to remove keyfile");
 		goto out;
 	}
 
@@ -1156,6 +1224,8 @@ smartcard_cb_crypto(int fd, unsigned events, event_io_t *io, void *data)
 	crypto_callback_task_t *task = data;
 	ASSERT(task);
 
+	TRACE("Received message from SCD");
+
 	// TODO outsource socket/fd/events handling
 	if (events & EVENT_IO_READ) {
 		// use protobuf for communication with scd
@@ -1168,9 +1238,13 @@ smartcard_cb_crypto(int fd, unsigned events, event_io_t *io, void *data)
 		switch (msg->code) {
 		// deal with CRYPTO_HASH_* cases
 		case TOKEN_TO_DAEMON__CODE__CRYPTO_HASH_OK:
+			TRACE("Received HASH_OK message, ");
 			if (msg->has_hash_value) {
 				char *hash = bytes_to_string_new(msg->hash_value.data,
 								 msg->hash_value.len);
+
+				TRACE("Received hash for file %s: %s",
+				      task->hash_file ? task->hash_file : "<empty>", hash);
 				task->hash_complete(hash, task->hash_file, task->hash_algo,
 						    task->data);
 				if (hash != NULL) {
@@ -1179,6 +1253,7 @@ smartcard_cb_crypto(int fd, unsigned events, event_io_t *io, void *data)
 				break;
 			}
 			task->hash_complete(NULL, task->hash_file, task->hash_algo, task->data);
+
 			ERROR("Missing hash_value in CRYPTO_HASH_OK response!"); // fallthrough
 		case TOKEN_TO_DAEMON__CODE__CRYPTO_HASH_ERROR:
 			task->hash_complete(NULL, task->hash_file, task->hash_algo, task->data);
@@ -1285,6 +1360,9 @@ smartcard_crypto_hash_file(const char *file, smartcard_crypto_hashalgo_t hashalg
 	out.has_hash_algo = true;
 	out.hash_algo = smartcard_hashalgo_to_proto(hashalgo);
 	out.hash_file = task->hash_file;
+
+	TRACE("Requesting scd to hash file at %s", task->hash_file);
+
 	if (smartcard_send_crypto(&out, task) < 0) {
 		crypto_callback_task_free(task);
 		return -1;

--- a/daemon/smartcard.h
+++ b/daemon/smartcard.h
@@ -24,6 +24,7 @@
 #ifndef SMARTCARD_H
 #define SMARTCARD_H
 
+#include "cmld.h"
 #include "container.h"
 #include "control.h"
 #include "stdbool.h"
@@ -299,5 +300,17 @@ smartcard_push_cert(smartcard_t *smartcard, control_t *control, uint8_t *cert, s
  */
 bool
 smartcard_cert_has_valid_format(unsigned char *cert_buf, size_t cert_buf_len);
+
+/**
+ * Checks whether two given hashes match and returns the result
+ *
+ * @param hash_name The name of the hash algorithm used
+ * @param hash_len The length if the given hashes
+ * @param expected_hash The expected hash
+ * @param hash The hash to verify
+ */
+
+bool
+match_hash(size_t hash_len, const char *expected_hash, const char *hash);
 
 #endif /* SMARTCARD_H */

--- a/daemon/uevent.c
+++ b/daemon/uevent.c
@@ -402,7 +402,7 @@ uevent_replace_devpath_new(const char *str, const char *oldstr, const char *news
 	}
 
 	unsigned int off_old;
-	char *str_replaced = mem_alloc0(strlen(str) + len_diff);
+	char *str_replaced = mem_alloc0((strlen(str) + 1) + len_diff);
 	unsigned int pos_new = 0;
 
 	off_old = ptr_old - str;

--- a/scd/token.c
+++ b/scd/token.c
@@ -617,10 +617,6 @@ token_free(scd_token_t *token)
 {
 	IF_NULL_RETURN(token);
 
-#ifdef ENABLESCHSM
-	scd_tokencontrol_free(token);
-#endif
-
 	if (token->token_data) {
 		switch (token->token_data->type) {
 		case (NONE):
@@ -632,6 +628,7 @@ token_free(scd_token_t *token)
 			break;
 #ifdef ENABLESCHSM
 		case (USB):
+			scd_tokencontrol_free(token);
 			usbtoken_free(token->token_data->int_token.usbtoken);
 			break;
 #endif // ENABLESCHSM

--- a/service/service.c
+++ b/service/service.c
@@ -26,6 +26,7 @@
 #else
 #include "c_service.pb-c.h"
 #endif
+#include <google/protobuf-c/protobuf-c-text.h>
 
 #include "common/macro.h"
 #include "common/mem.h"
@@ -34,6 +35,9 @@
 #include "common/protobuf.h"
 #include "common/sock.h"
 #include "common/event.h"
+#include "common/fd.h"
+#include "common/dir.h"
+#include "common/str.h"
 
 #include <unistd.h>
 #include <sys/types.h>
@@ -46,7 +50,14 @@
 // clang-format off
 #define SERVICE_SOCKET SOCK_PATH(service)
 // clang-format on
-#define LOGFILE_PATH "/var/log/container.log"
+
+#define LOGFILE_DIR "/tmp/log/"
+#define AUDIT_LOGDIR "/var/log/cmld_audit/"
+
+//#undef LOGF_LOG_MIN_PRIO
+//#define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE
+
+char *LAST_AUDIT_HASH;
 
 static logf_handler_t *service_logfile_handler = NULL;
 
@@ -157,26 +168,276 @@ service_fork_execvp(char *prog, char **argv)
 	return 0;
 }
 
-int
-main(int argc, char **argv)
+static int
+process_audit_record(CmldToServiceMessage *msg, uint8_t *buf, uint32_t buf_len)
 {
-	logf_register(&logf_file_write, stdout);
-	bool do_init = getpid() == 1;
+	ASSERT(msg);
 
-	if (!do_init && argc > 1) {
-		FATAL("Not running as init, so we do not accept parameters for child process!");
+	int ret = -1;
+
+	char tmpfile[17] = "/tmp/audit_XXXXXX";
+
+	if (!strcmp("", mktemp(tmpfile))) {
+		ERROR_ERRNO("Failed to generate temporary filename");
+		return -1;
 	}
 
-	service_logfile_handler = logf_register(&logf_file_write, logf_file_new(LOGFILE_PATH));
-	logf_handler_set_prio(service_logfile_handler, LOGF_PRIO_TRACE);
+	//TODO find reason why received buffer contains trailing null byte
+	if (0 > file_write(tmpfile, (char *)buf, buf_len)) {
+		ERROR("Failed to write file");
 
+		if (unlink(tmpfile))
+			ERROR_ERRNO("Failed to unlink %s", tmpfile);
+
+		return ret;
+	}
+
+	char *cmd = mem_printf("sha512sum /%s", tmpfile);
+	FILE *hash_file = popen(cmd, "r");
+	char *hash_buf = mem_alloc0(129);
+
+	if (!fgets(hash_buf, 129, hash_file)) {
+		ERROR("Hash length was smaller than 64 bytes");
+		fclose(hash_file);
+		mem_free(hash_buf);
+		goto out;
+	}
+	fclose(hash_file);
+
+	if (!file_is_dir(AUDIT_LOGDIR) && dir_mkdir_p(AUDIT_LOGDIR, 0600)) {
+		ERROR("Failed to create audit log directory");
+	} else if (msg->audit_record) {
+		char *record =
+			protobuf_c_text_to_string((ProtobufCMessage *)msg->audit_record, NULL);
+		TRACE("Storing audit record %s", record);
+		file_write_append(AUDIT_LOGDIR "/audit.log", record, strlen(record));
+
+		mem_free(LAST_AUDIT_HASH);
+		LAST_AUDIT_HASH = hash_buf;
+		ret = 0;
+	} else {
+		WARN("Got empty audit message from cmld");
+	}
+
+out:
+	if (unlink(tmpfile))
+		ERROR_ERRNO("Failed to unlink %s", tmpfile);
+
+	return ret;
+}
+
+static int
+audit_send_ack(int sock, const char *hash)
+{
+	ServiceToCmldMessage auditmsg = SERVICE_TO_CMLD_MESSAGE__INIT;
+	auditmsg.code = SERVICE_TO_CMLD_MESSAGE__CODE__AUDIT_ACK;
+
+	if (hash) {
+		auditmsg.audit_ack = mem_strdup((char *)hash);
+	}
+
+	ssize_t msg_size = protobuf_send_message(sock, (ProtobufCMessage *)&auditmsg);
+	if (msg_size < 0)
+		WARN("Could not request audit event delivery, error: %zd\n", msg_size);
+
+	mem_free(auditmsg.audit_ack);
+
+	return 0;
+}
+
+static void
+service_cb_recv_message(int fd, unsigned events, event_io_t *io, UNUSED void *data)
+{
+	DEBUG("Received message from cmld");
+	static bool awaiting_record = false;
+
+	uint8_t *buf = NULL;
+	CmldToServiceMessage *msg = NULL;
+
+	if (events & EVENT_IO_READ) {
+		ssize_t buf_len = 0;
+		buf = protobuf_recv_message_packed_new(fd, &buf_len);
+
+		if (!buf) {
+			ERROR("Failed to receive message from cmld");
+			return;
+		}
+
+		msg = (CmldToServiceMessage *)protobuf_unpack_message(
+			&cmld_to_service_message__descriptor, buf, buf_len);
+
+		if (!msg) {
+			ERROR("Failed to decode protobuf message");
+			goto out;
+		}
+
+		if (CMLD_TO_SERVICE_MESSAGE__CODE__AUDIT_NOTIFY == msg->code) {
+			if (awaiting_record) {
+				TRACE("Got AUDIT_NOTIFY but already awaiting a record, ignoring...");
+			} else {
+				TRACE("New audit records available, remaining storage: %ld, start fetching...",
+				      msg->audit_remaining_storage);
+
+				if (0 != audit_send_ack(fd, LAST_AUDIT_HASH)) {
+					ERROR("Failed to send ack to cmld");
+				} else {
+					awaiting_record = true;
+				}
+			}
+		} else if (CMLD_TO_SERVICE_MESSAGE__CODE__AUDIT_RECORD == msg->code) {
+			TRACE("Got audit record from cmld");
+
+			awaiting_record = false;
+			if (0 != process_audit_record(msg, buf, buf_len)) {
+				ERROR("Failed to process audit record");
+			}
+
+			// if processing of the last record failed,
+			// send ACK with old hash to trigger delivery again
+			if (0 != audit_send_ack(fd, LAST_AUDIT_HASH)) {
+				ERROR("Failed to send ack to cmld");
+			} else {
+				awaiting_record = true;
+			}
+
+			goto out;
+		} else if (CMLD_TO_SERVICE_MESSAGE__CODE__AUDIT_COMPLETE == msg->code) {
+			TRACE("Fetched all available audit records");
+			awaiting_record = false;
+
+			goto out;
+		} else {
+			ERROR_ERRNO("Received message with unknown code from cmld");
+		}
+	}
+
+	if (events & EVENT_IO_EXCEPT) {
+		WARN("CML connection Error");
+		event_remove_io(io);
+		event_io_free(io);
+		close(fd);
+
+		return;
+	}
+
+out:
+	if (buf)
+		mem_free(buf);
+	if (msg)
+		protobuf_free_message((ProtobufCMessage *)msg);
+
+	return;
+}
+
+static int
+open_service_socket()
+{
 	const char *socket_file = SERVICE_SOCKET;
-	if (!file_exists(socket_file))
-		FATAL("Could not find socket file %s. Aborting.", socket_file);
+	if (!file_exists(socket_file)) {
+		ERROR("Could not find socket file %s.", socket_file);
+		return -1;
+	}
 
 	int sock = sock_unix_create_and_connect(SOCK_STREAM, socket_file);
 	if (sock < 0) {
-		FATAL("Could not connect to service on socket file %s. Aborting.", socket_file);
+		ERROR("Could not connect to service on socket file %s.", socket_file);
+		return -1;
+	}
+
+	return sock;
+}
+
+static int
+container_close_all_fds_cb(UNUSED const char *path, const char *file, UNUSED void *data)
+{
+	int fd = atoi(file);
+
+	DEBUG("Closing file descriptor %d", fd);
+
+	if (close(fd) < 0)
+		WARN_ERRNO("Could not close file descriptor %d", fd);
+
+	return 0;
+}
+
+static int
+service_close_all_fds()
+{
+	if (dir_foreach("/proc/self/fd", &container_close_all_fds_cb, NULL) < 0) {
+		WARN("Could not open /proc/self/fd directory, /proc not mounted?");
+		return -1;
+	}
+
+	return 0;
+}
+
+static void
+fork_service_message_handler()
+{
+	int pid = fork();
+
+	if (-1 == pid) {
+		ERROR("Failed to fork service handler");
+	} else if (0 == pid) {
+		if (service_close_all_fds()) {
+			ERROR("Failed to close parent fds.");
+		}
+
+		FILE *stream = logf_file_new(LOGFILE_DIR "service-handler");
+		service_logfile_handler = logf_register(&logf_file_write, stream);
+		logf_handler_set_prio(service_logfile_handler, LOGF_PRIO_TRACE);
+
+		int sock;
+		if (-1 == (sock = open_service_socket())) {
+			FATAL("Failed to open service socket. Aborting.");
+		}
+
+		LAST_AUDIT_HASH = mem_strdup(
+			"00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
+
+		int *sock_ptr = mem_alloc(sizeof(int));
+		*sock_ptr = sock;
+
+		WARN("Registering logf handler");
+
+		/* register socket for receiving data */
+		fd_make_non_blocking(sock);
+
+		if (0 != audit_send_ack(*sock_ptr, LAST_AUDIT_HASH)) {
+			ERROR("Failed to send ack to cmld");
+		}
+
+		event_io_t *event =
+			event_io_new(*sock_ptr, EVENT_IO_READ, service_cb_recv_message, NULL);
+		event_add_io(event);
+
+		event_loop();
+
+		// this should never be reached
+		ERROR("Failed to enter event loop");
+		exit(EXIT_FAILURE);
+	}
+}
+
+int
+main(int argc, char **argv)
+{
+	bool do_init;
+	int sock;
+
+	if (dir_mkdir_p(LOGFILE_DIR, 0755)) {
+		ERROR("Failed to create logging directoy");
+	}
+
+	event_init();
+
+	DEBUG("Registering file logger");
+	service_logfile_handler =
+		logf_register(&logf_file_write, logf_file_new(LOGFILE_DIR "service-init"));
+	logf_handler_set_prio(service_logfile_handler, LOGF_PRIO_TRACE);
+
+	if (-1 == (sock = open_service_socket())) {
+		FATAL("Failed to open service socket. Aborting...");
 	}
 
 #ifndef BOOT_COMPLETE_ONLY
@@ -203,10 +464,17 @@ main(int argc, char **argv)
 		WARN("Could not send boot complete msg!, error: %zd\n", msg_size);
 
 	// closing socket to cmld
-	close(sock);
+	if (-1 == close(sock)) {
+		ERROR_ERRNO("Failed to close service socket");
+	}
 
-	if (!do_init)
-		return 0;
+	// if we are not running as init, just open the cml-service socket and handle messages
+	if (!(do_init = (getpid() == 1))) {
+		DEBUG("Not running as init, launching service message handler");
+		fork_service_message_handler();
+
+		exit(EXIT_SUCCESS);
+	}
 
 	if (argc < 2) {
 		INFO("Running as init, not starting any child!");
@@ -217,6 +485,8 @@ main(int argc, char **argv)
 	} else if (service_fork_execvp(argv[1], &argv[1])) {
 		WARN("Error starting child!");
 	}
+
+	fork_service_message_handler();
 
 	INFO("Going to handle signals ...");
 	dumb_init_signal_handler();


### PR DESCRIPTION
This PR adds audit capabilities to the CML.
The main contributions are the audit record creation and handling functions in the new file audit.c
and the a new container submodule to hold container-specific state regarding the delivery of audit events contained in c_audit.c.
Besides, supporting changes in the libcommon, scd and cservice have been made. These changes are described in the respective commit messages.

Two record delivery mechanisms, C0 and CONTAINER, are implemented to suit different use cases.
The C0 logging mode causes all audit records to be delivered to the management container C0.
The CONTAINER logging mode causes audit record delivery to the container that triggered the creation of the respective record.
Switching between the two modes is possible at compile time by setting the LOGMODE variable in audit.c

If event delivery to a particular container is not possible, e.g. because it is not running or no logger is available inside the target container, events are stored to disk in a logfile for each target container.
The maximum size of these log files can be set using the new device.conf field 'audit_size'.
By default, audit_size is zero s.t. auditing is disabled in standard builds if not expliicitly activated.

Also, the cservice has been modified in order to receive the audit records inside containers.
To this end, the c_service enters an event loop waiting for audit events.
If it is started with PID 1, an event handling process is forked, just before entering the signal handling loop.
Starting the cservice with any other PID causes it to directly enter the event handling loop without performing any further actions.
Thereby, it can be launched using systemd, busybox init or similiar init systems in order to receive audit events in a given container.