### PR TITLE
Audit: kernel audit handling

### DIFF
--- a/daemon/audit.h
+++ b/daemon/audit.h
@@ -53,4 +53,7 @@ audit_log_event(const uuid_t *uuid, AUDIT_CATEGORY category, AUDIT_COMPONENT com
 int
 audit_process_ack(const container_t *audit, const char *ack);
 
+int
+audit_init();
+
 #endif /* AUDIT_H */

--- a/daemon/c_audit.h
+++ b/daemon/c_audit.h
@@ -33,7 +33,7 @@ c_audit_t *
 c_audit_new(const container_t *container);
 
 int
-c_audit_start_child(c_audit_t *audit);
+c_audit_start_post_clone(c_audit_t *audit);
 
 const char *
 c_audit_get_last_ack(const c_audit_t *audit);

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -1255,6 +1255,11 @@ cmld_init(const char *path)
 	else
 		INFO("mounted debugfs");
 
+	if (audit_init() < 0)
+		WARN("Could not init audit module");
+	else
+		INFO("audit initialized.");
+
 #ifdef ANDROID
 	if (power_init() < 0)
 		FATAL("Could not init power module");

--- a/daemon/container.c
+++ b/daemon/container.c
@@ -1170,11 +1170,6 @@ container_start_child(void *data)
 		goto error;
 	}
 
-	if (c_audit_start_child(container->audit) < 0) {
-		ret = CONTAINER_ERROR_AUDIT;
-		goto error;
-	}
-
 	if (c_user_start_child(container->user) < 0) {
 		ret = CONTAINER_ERROR_USER;
 		goto error;
@@ -1631,6 +1626,11 @@ container_start(container_t *container) //, const char *key)
 	/* POST CLONE HOOKS */
 	// execute all necessary c_<module>_start_post_clone hooks
 	// goto error_post_clone on an error
+
+	if (c_audit_start_post_clone(container->audit)) {
+		ret = CONTAINER_ERROR_AUDIT;
+		goto error_post_clone;
+	}
 
 	if (c_cgroups_start_post_clone(container->cgroups)) {
 		ret = CONTAINER_ERROR_CGROUPS;


### PR DESCRIPTION
main commit: daemon/audit: Introduce kernel audit handling

Extended the audit module to register cmld as auditd in the kernel
audit framework. Initially a simple logging to cmld's log file of
kernel audit log records is provided.