### PR TITLE
daemon/container, c_cgroups: Add simple cpu core assignment

### DIFF
--- a/daemon/c_net.h
+++ b/daemon/c_net.h
@@ -42,8 +42,7 @@ typedef struct c_net c_net_t;
  * Creates a new instances of the c_net structure, which should be done by a container
  */
 c_net_t *
-c_net_new(container_t *container, bool net_ns, list_t *vnet_cfg_list, list_t *nw_mv_name_list,
-	  uint16_t adb_port);
+c_net_new(container_t *container, bool net_ns, list_t *vnet_cfg_list, list_t *nw_mv_name_list);
 
 /**
  * Frees the struct

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -1108,7 +1108,7 @@ cmld_init_a0(const char *path, const char *c0os)
 	container_t *new_a0 =
 		container_new_internal(a0_uuid, "a0", CONTAINER_TYPE_CONTAINER, false, a0_ns_net,
 				       privileged, a0_os, NULL, a0_images_folder, a0_mnt,
-				       a0_ram_limit, 0xffffff00, false, NULL,
+				       a0_ram_limit, NULL, 0xffffff00, false, NULL,
 				       cmld_get_device_host_dns(), NULL, NULL, NULL, NULL, NULL,
 				       NULL, 0, NULL, CONTAINER_TOKEN_TYPE_NONE, false);
 

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -1108,7 +1108,7 @@ cmld_init_a0(const char *path, const char *c0os)
 	container_t *new_a0 =
 		container_new_internal(a0_uuid, "a0", CONTAINER_TYPE_CONTAINER, false, a0_ns_net,
 				       privileged, a0_os, NULL, a0_images_folder, a0_mnt,
-				       a0_ram_limit, 0xffffff00, 0, false, NULL,
+				       a0_ram_limit, 0xffffff00, false, NULL,
 				       cmld_get_device_host_dns(), NULL, NULL, NULL, NULL, NULL,
 				       NULL, 0, NULL, CONTAINER_TOKEN_TYPE_NONE, false);
 

--- a/daemon/container.c
+++ b/daemon/container.c
@@ -123,6 +123,7 @@ struct container {
 	uint32_t color;
 	bool allow_autostart;
 	unsigned int ram_limit; /* maximum RAM space the container may use */
+	char *cpus_allowed;
 
 	container_connectivity_t connectivity;
 	bool airplane_mode;
@@ -225,11 +226,12 @@ container_t *
 container_new_internal(const uuid_t *uuid, const char *name, container_type_t type, bool ns_usr,
 		       bool ns_net, bool privileged, const guestos_t *os,
 		       const char *config_filename, const char *images_dir, mount_t *mnt,
-		       unsigned int ram_limit, uint32_t color, bool allow_autostart,
-		       list_t *feature_enabled, const char *dns_server, list_t *net_ifaces,
-		       char **allowed_devices, char **assigned_devices, list_t *vnet_cfg_list,
-		       list_t *usbdev_list, char **init_env, size_t init_env_len, list_t *fifo_list,
-		       container_token_type_t ttype, bool usb_pin_entry)
+		       unsigned int ram_limit, const char *cpus_allowed, uint32_t color,
+		       bool allow_autostart, list_t *feature_enabled, const char *dns_server,
+		       list_t *net_ifaces, char **allowed_devices, char **assigned_devices,
+		       list_t *vnet_cfg_list, list_t *usbdev_list, char **init_env,
+		       size_t init_env_len, list_t *fifo_list, container_token_type_t ttype,
+		       bool usb_pin_entry)
 {
 	container_t *container = mem_new0(container_t, 1);
 
@@ -292,6 +294,7 @@ container_new_internal(const uuid_t *uuid, const char *name, container_type_t ty
 	container->phone_number = NULL;
 
 	container->ram_limit = ram_limit;
+	container->cpus_allowed = (cpus_allowed) ? mem_strdup(cpus_allowed) : NULL;
 
 	/* Create submodules */
 	container->user = c_user_new(container, ns_usr);
@@ -465,6 +468,7 @@ container_new(const char *store_path, const uuid_t *existing_uuid, const uint8_t
 	char *images_dir;
 	mount_t *mnt;
 	unsigned int ram_limit;
+	const char *cpus_allowed;
 	uint32_t color;
 	uuid_t *uuid;
 	uint64_t current_guestos_version;
@@ -521,6 +525,9 @@ container_new(const char *store_path, const uuid_t *existing_uuid, const uint8_t
 
 	ram_limit = container_config_get_ram_limit(conf);
 	DEBUG("New containers max ram is %" PRIu32 "", ram_limit);
+
+	cpus_allowed = container_config_get_cpus_allowed(conf);
+	DEBUG("New containers allowed cpu cores are %s", cpus_allowed);
 
 	color = container_config_get_color(conf);
 
@@ -589,12 +596,11 @@ container_new(const char *store_path, const uuid_t *existing_uuid, const uint8_t
 
 	bool usb_pin_entry = container_config_get_usb_pin_entry(conf);
 
-	container_t *c =
-		container_new_internal(uuid, name, type, ns_usr, ns_net, priv, os, config_filename,
-				       images_dir, mnt, ram_limit, color, allow_autostart,
-				       feature_enabled, dns_server, net_ifaces, allowed_devices,
-				       assigned_devices, vnet_cfg_list, usbdev_list, init_env,
-				       init_env_len, fifo_list, ttype, usb_pin_entry);
+	container_t *c = container_new_internal(
+		uuid, name, type, ns_usr, ns_net, priv, os, config_filename, images_dir, mnt,
+		ram_limit, cpus_allowed, color, allow_autostart, feature_enabled, dns_server,
+		net_ifaces, allowed_devices, assigned_devices, vnet_cfg_list, usbdev_list, init_env,
+		init_env_len, fifo_list, ttype, usb_pin_entry);
 	if (c)
 		container_config_write(conf);
 
@@ -632,6 +638,8 @@ container_free(container_t *container)
 
 	if (container->config_filename)
 		mem_free(container->config_filename);
+
+	mem_free(container->cpus_allowed);
 
 	if (container->init_argv) {
 		for (char **arg = container->init_argv; *arg; arg++) {
@@ -2095,6 +2103,14 @@ container_get_ram_limit(const container_t *container)
 	ASSERT(container);
 
 	return container->ram_limit;
+}
+
+const char *
+container_get_cpus_allowed(const container_t *container)
+{
+	ASSERT(container);
+
+	return container->cpus_allowed;
 }
 
 int

--- a/daemon/container.h
+++ b/daemon/container.h
@@ -187,12 +187,11 @@ container_t *
 container_new_internal(const uuid_t *uuid, const char *name, container_type_t type, bool ns_usr,
 		       bool ns_net, bool privileged, const guestos_t *os,
 		       const char *config_filename, const char *images_folder, mount_t *mnt,
-		       unsigned int ram_limit, uint32_t color, uint16_t adb_port,
-		       bool allow_autostart, list_t *feature_enabled, const char *dns_server,
-		       list_t *net_ifaces, char **allowed_devices, char **assigned_devices,
-		       list_t *vnet_cfg_list, list_t *usbdev_list, char **init_env,
-		       size_t init_env_len, list_t *fifo_list, container_token_type_t ttype,
-		       bool usb_pin_entry);
+		       unsigned int ram_limit, uint32_t color, bool allow_autostart,
+		       list_t *feature_enabled, const char *dns_server, list_t *net_ifaces,
+		       char **allowed_devices, char **assigned_devices, list_t *vnet_cfg_list,
+		       list_t *usbdev_list, char **init_env, size_t init_env_len, list_t *fifo_list,
+		       container_token_type_t ttype, bool usb_pin_entry);
 
 /**
  * Creates a new container container object. There are three different cases

--- a/daemon/container.h
+++ b/daemon/container.h
@@ -187,11 +187,12 @@ container_t *
 container_new_internal(const uuid_t *uuid, const char *name, container_type_t type, bool ns_usr,
 		       bool ns_net, bool privileged, const guestos_t *os,
 		       const char *config_filename, const char *images_folder, mount_t *mnt,
-		       unsigned int ram_limit, uint32_t color, bool allow_autostart,
-		       list_t *feature_enabled, const char *dns_server, list_t *net_ifaces,
-		       char **allowed_devices, char **assigned_devices, list_t *vnet_cfg_list,
-		       list_t *usbdev_list, char **init_env, size_t init_env_len, list_t *fifo_list,
-		       container_token_type_t ttype, bool usb_pin_entry);
+		       unsigned int ram_limit, const char *cpus_allowed, uint32_t color,
+		       bool allow_autostart, list_t *feature_enabled, const char *dns_server,
+		       list_t *net_ifaces, char **allowed_devices, char **assigned_devices,
+		       list_t *vnet_cfg_list, list_t *usbdev_list, char **init_env,
+		       size_t init_env_len, list_t *fifo_list, container_token_type_t ttype,
+		       bool usb_pin_entry);
 
 /**
  * Creates a new container container object. There are three different cases
@@ -579,6 +580,9 @@ container_get_ram_limit(const container_t *container);
 
 int
 container_set_ram_limit(container_t *container, unsigned int ram_limit);
+
+const char *
+container_get_cpus_allowed(const container_t *container);
 
 /***************************
  * Submodule Interfaces    *

--- a/daemon/container.proto
+++ b/daemon/container.proto
@@ -89,6 +89,8 @@ message ContainerConfig {
 
 	optional bool userns = 10 [default = true];
 
+	optional string assign_cpus = 11; // cpus "m-n", e.g., "0-1"
+
 	// Flags indicating the allows for containers:
 	optional bool allow_autostart = 17 [default = false];
 	// TODO: add further features as necessary

--- a/daemon/container_config.c
+++ b/daemon/container_config.c
@@ -769,3 +769,11 @@ container_config_get_usb_pin_entry(const container_config_t *config)
 	ASSERT(config->cfg);
 	return config->cfg->usb_pin_entry;
 }
+
+const char *
+container_config_get_cpus_allowed(const container_config_t *config)
+{
+	ASSERT(config);
+	ASSERT(config->cfg);
+	return config->cfg->assign_cpus;
+}

--- a/daemon/container_config.h
+++ b/daemon/container_config.h
@@ -114,6 +114,12 @@ container_config_get_ram_limit(const container_config_t *config);
 void
 container_config_set_ram_limit(container_config_t *config, unsigned int ram_limit);
 
+/**
+ * Get the configured cpus which are assigned to a container.
+ */
+const char *
+container_config_get_cpus_allowed(const container_config_t *config);
+
 void
 container_config_fill_mount(const container_config_t *config, mount_t *mnt);
 #if 0


### PR DESCRIPTION
Provide an option in container config which allows to set a cpu core
assignment for containers. This option is used 1:1 for configuring
the cgroup cpuset subsystem to exclusively assign the provided cpus
in form of "n-m" to the corresponding container.

+ some deprecated code cleanup and bugfixes
