### PR TITLE
Audit refactoring + fixes

### DIFF
--- a/common/audit.c
+++ b/common/audit.c
@@ -76,7 +76,7 @@ audit_kernel_send(nl_sock_t *audit_sock, int type, const void *data, size_t len)
 	nl_msg_set_flags(audit_msg, NLM_F_REQUEST | NLM_F_ACK);
 	nl_msg_set_buf_unaligned(audit_msg, (char *)data, len);
 
-	ret = nl_msg_send_kernel_verify(audit_sock, audit_msg);
+	ret = nl_msg_send_kernel(audit_sock, audit_msg);
 
 	nl_msg_free(audit_msg);
 	return ret;
@@ -151,6 +151,8 @@ audit_kernel_log_event(const char *type, const char *subject_id, int meta_count,
 	}
 
 	ret = audit_kernel_log_record(record);
+
+	TRACE("Logged record to kernel audit buffer");
 
 out:
 	protobuf_free_message((ProtobufCMessage *)record);

--- a/common/audit.h
+++ b/common/audit.h
@@ -43,31 +43,14 @@
 
 typedef enum { CONTAINER, C0 } AUDIT_MODE;
 
-typedef enum { SUA, FUA, SSA, FSA, RLE } AUDIT_CATEGORY;
-
-typedef enum {
-	GUESTOS_MGMT,
-	TOKEN_MGMT,
-	CONTAINER_MGMT,
-	CONTAINER_ISOLATION,
-	TPM_COMM,
-	KAUDIT,
-} AUDIT_EVENTCLASS;
-
-typedef enum { COMMAND, INTERNAL, TOKEN, UPDATE } AUDIT_EVENTTYPE;
-
-typedef enum { CMLD, SCD, TPM2D } AUDIT_COMPONENT;
-
 AuditRecord *
-audit_record_new(AUDIT_CATEGORY category, AUDIT_COMPONENT component, AUDIT_EVENTCLASS evclass,
-		 const char *evtype, const char *subject_id, int meta_length,
+audit_record_new(const char *type, const char *subject_id, int meta_length,
 		 AuditRecord__Meta **metas);
 
 int
 audit_kernel_send(nl_sock_t *audit_sock, int type, const void *data, size_t len);
 
 int
-audit_kernel_log_event(AUDIT_CATEGORY category, AUDIT_COMPONENT component, AUDIT_EVENTCLASS evclass,
-		       const char *evtype, const char *subject_id, int meta_count, ...);
+audit_kernel_log_event(const char *type, const char *subject_id, int meta_count, ...);
 
 #endif /* COMMON_AUDIT_H */

--- a/daemon/audit.c
+++ b/daemon/audit.c
@@ -75,6 +75,30 @@ typedef struct {
 	char *value;
 } audit_meta_t;
 
+const char *evcategory[] = { "SUA", "FUA", "SSA", "FSA", "RLE" };
+const char *evclass[] = { "GUESTOS_MGMT",	 "TOKEN_MGMT", "CONTAINER_MGMT",
+			  "CONTAINER_ISOLATION", "TPM_COMM",   "KAUDIT" };
+const char *component[] = { "CMLD", "SCD", "TPM2D" };
+const char *result[] = { "SUCCESS", "FAIL" };
+
+static const char *
+audit_category_to_string(AUDIT_CATEGORY c)
+{
+	return evcategory[c];
+}
+
+static const char *
+audit_evclass_to_string(AUDIT_EVENTCLASS c)
+{
+	return evclass[c];
+}
+
+static const char *
+audit_component_to_string(AUDIT_COMPONENT c)
+{
+	return component[c];
+}
+
 static container_t *
 audit_get_log_container(const uuid_t *uuid)
 {
@@ -588,8 +612,12 @@ audit_log_event(const uuid_t *uuid, AUDIT_CATEGORY category, AUDIT_COMPONENT com
 		meta_count /= 2;
 	}
 
-	record = audit_record_new(category, component, evclass, evtype, subject_id, meta_count,
-				  metas);
+	char *type = mem_printf("%s.%s.%s.%s", audit_category_to_string(category),
+				audit_component_to_string(component),
+				audit_evclass_to_string(evclass), evtype);
+
+	record = audit_record_new(type, subject_id, meta_count, metas);
+	mem_free(type);
 
 	if (!record) {
 		ERROR("Failed to create audit record");

--- a/daemon/audit.c
+++ b/daemon/audit.c
@@ -706,6 +706,8 @@ audit_init(uint32_t size)
 {
 	AUDIT_STORAGE = size * 1024 * 1024;
 
+	TRACE("Initializing audit subsystem");
+
 	/* Open audit netlink socket */
 	nl_sock_t *audit_sock;
 	if (!(audit_sock = nl_sock_default_new(NETLINK_AUDIT))) {
@@ -720,6 +722,10 @@ audit_init(uint32_t size)
 		return -1;
 	}
 
+	event_io_t *audit_io_event = event_io_new(nl_sock_get_fd(audit_sock), EVENT_IO_READ,
+						  &audit_kernel_handle_log, audit_sock);
+	event_add_io(audit_io_event);
+
 	/* Register message handler for audit logs */
 	if (fd_make_non_blocking(nl_sock_get_fd(audit_sock))) {
 		ERROR("Could not set fd of audit netlink socket to non blocking!");
@@ -727,8 +733,5 @@ audit_init(uint32_t size)
 		return -1;
 	}
 
-	event_io_t *audit_io_event = event_io_new(nl_sock_get_fd(audit_sock), EVENT_IO_READ,
-						  &audit_kernel_handle_log, audit_sock);
-	event_add_io(audit_io_event);
 	return 0;
 }

--- a/daemon/audit.h
+++ b/daemon/audit.h
@@ -27,6 +27,21 @@
 #include "container.h"
 #include "common/audit.h"
 
+typedef enum { SUA, FUA, SSA, FSA, RLE } AUDIT_CATEGORY;
+
+typedef enum {
+	GUESTOS_MGMT,
+	TOKEN_MGMT,
+	CONTAINER_MGMT,
+	CONTAINER_ISOLATION,
+	TPM_COMM,
+	KAUDIT,
+} AUDIT_EVENTCLASS;
+
+typedef enum { COMMAND, INTERNAL, TOKEN, UPDATE } AUDIT_EVENTTYPE;
+
+typedef enum { CMLD, SCD, TPM2D } AUDIT_COMPONENT;
+
 int
 audit_log_event(const uuid_t *uuid, AUDIT_CATEGORY category, AUDIT_COMPONENT component,
 		AUDIT_EVENTCLASS evclass, const char *evtype, const char *subject_id,

--- a/service/service.c
+++ b/service/service.c
@@ -38,6 +38,7 @@
 #include "common/fd.h"
 #include "common/dir.h"
 #include "common/str.h"
+#include "common/audit.h"
 
 #include <unistd.h>
 #include <sys/types.h>
@@ -249,6 +250,10 @@ static void
 service_cb_recv_message(int fd, unsigned events, event_io_t *io, UNUSED void *data)
 {
 	DEBUG("Received message from cmld");
+	int kernlog =
+		audit_kernel_log_event("SSA.CONTAINER.SERVICE.recv_cmld_message", "theservice", 0);
+	ERROR("kernel audit log attempt returned %d", kernlog);
+
 	static bool awaiting_record = false;
 
 	uint8_t *buf = NULL;

--- a/service/service.c
+++ b/service/service.c
@@ -38,7 +38,6 @@
 #include "common/fd.h"
 #include "common/dir.h"
 #include "common/str.h"
-#include "common/audit.h"
 
 #include <unistd.h>
 #include <sys/types.h>
@@ -250,10 +249,6 @@ static void
 service_cb_recv_message(int fd, unsigned events, event_io_t *io, UNUSED void *data)
 {
 	DEBUG("Received message from cmld");
-	int kernlog =
-		audit_kernel_log_event("SSA.CONTAINER.SERVICE.recv_cmld_message", "theservice", 0);
-	ERROR("kernel audit log attempt returned %d", kernlog);
-
 	static bool awaiting_record = false;
 
 	uint8_t *buf = NULL;


### PR DESCRIPTION
This PR moves the CML specific portions of the audit code in libcommon to the CML.
Especially, the enums defining the CML specific audit event types are moved to the daemon code.
Instead, the audit record generation code now expects the audit event type as char pointer.

Also, a missing netlink ACK during registration as auditd via netlink on some platforms is worked around by this commit.