### PR TITLE
common/cryptfs: Propper dm_crypt device setup on integrity device

### DIFF
--- a/common/cryptfs.h
+++ b/common/cryptfs.h
@@ -39,7 +39,7 @@ cryptfs_get_device_path_new(const char *label);
 
 char *
 cryptfs_setup_volume_new(const char *label, const char *real_blk_dev, const char *ascii_key,
-			 bool integrity);
+			 const char *meta_blk_dev);
 
 int
 cryptfs_delete_blk_dev(const char *name);

--- a/daemon/smartcard.c
+++ b/daemon/smartcard.c
@@ -51,7 +51,7 @@
 // clang-format on
 
 // TODO: centrally define key length in container or other module?
-#define TOKEN_KEY_LEN 64 // actual encryption key
+#define TOKEN_KEY_LEN 96 // actual encryption key + hmac key
 #define TOKEN_MAX_WRAPPED_KEY_LEN 4096
 
 #define MAX_PAIR_SEC_LEN 8

--- a/tpm2d/nvmcrypt.c
+++ b/tpm2d/nvmcrypt.c
@@ -226,7 +226,7 @@ nvmcrypt_dm_setup(const char *device_path, const char *fde_pw)
 
 	INFO("Setting up crypto device mapping for %s to %s", device_path, dev_name);
 
-	char *mapped_path = cryptfs_setup_volume_new(dev_name, device_path, ascii_key, false);
+	char *mapped_path = cryptfs_setup_volume_new(dev_name, device_path, ascii_key, NULL);
 
 	if (mapped_path == NULL) {
 		ERROR("Failed to setup device mapping for %s", device_path);


### PR DESCRIPTION
1. This is the real fix for integrity device setup and also inverts the
Quick-Fix (commit b7238cd5e889fca73eb2144e55472c7117754aa3).
2. We now use a separate meta device for integrity data
3. Further, we switched authenticated encryption scheme to HMAC XTS