### PR TITLE
common/cryptfs: fixed wrong sanity check macro

### DIFF
--- a/common/cryptfs.c
+++ b/common/cryptfs.c
@@ -653,7 +653,7 @@ cryptfs_setup_volume_new(const char *label, const char *real_blkdev, const char 
 	// do dmcrypt device setup only
 
 	/* Use only the first 64 hex digits of master key for 512 bit xts mode */
-	IF_FALSE_RETVAL(strlen(key) < 65, NULL);
+	IF_TRUE_RETVAL(strlen(key) < 65, NULL);
 	char enc_key[65];
 	snprintf(enc_key, 65, "%s", key);
 


### PR DESCRIPTION
Lately changes to common/cryptfs introduced a sanity check about
key length during creation of a crypt only volume.  Instead of
IF_FALSE_RETVAL, IF_TRUE_RETVAl has to be used here.

Signed-off-by: Michael Weiß <michael.weiss@aisec.fraunhofer.de>