### PR TITLE
daemon/audit,c_audit: restructured and fixed protobuf memory handling

### DIFF
--- a/daemon/c_audit.c
+++ b/daemon/c_audit.c
@@ -89,7 +89,7 @@ c_audit_new(const container_t *container)
 	return audit;
 }
 
-const char *
+char *
 c_audit_get_last_ack(const c_audit_t *audit)
 {
 	ASSERT(audit);
@@ -97,14 +97,15 @@ c_audit_get_last_ack(const c_audit_t *audit)
 }
 
 void
-c_audit_set_last_ack(c_audit_t *audit, char *last_ack)
+c_audit_set_last_ack(c_audit_t *audit, const char *last_ack)
 {
 	ASSERT(audit);
+	ASSERT(last_ack);
 
 	if (audit->last_ack)
 		mem_free(audit->last_ack);
 
-	audit->last_ack = last_ack;
+	audit->last_ack = mem_strdup(last_ack);
 }
 
 bool

--- a/daemon/c_audit.h
+++ b/daemon/c_audit.h
@@ -35,11 +35,11 @@ c_audit_new(const container_t *container);
 int
 c_audit_start_post_clone(c_audit_t *audit);
 
-const char *
+char *
 c_audit_get_last_ack(const c_audit_t *audit);
 
 void
-c_audit_set_last_ack(c_audit_t *audit, char *last_ack);
+c_audit_set_last_ack(c_audit_t *audit, const char *last_ack);
 
 bool
 c_audit_get_processing_ack(const c_audit_t *audit);

--- a/daemon/c_service.c
+++ b/daemon/c_service.c
@@ -544,7 +544,7 @@ c_service_audit_send_record(c_service_t *service, const uint8_t *buf, uint32_t b
 {
 	ASSERT(service);
 
-	TRACE("Trying to send packed audit record to container %s",
+	TRACE("Trying to send packed audit record of size %u to container %s", buf_len,
 	      uuid_string(container_get_uuid(service->container)));
 
 	if (-1 == protobuf_send_message_packed(service->sock_connected, buf, buf_len)) {

--- a/daemon/container.c
+++ b/daemon/container.c
@@ -931,7 +931,7 @@ container_audit_get_last_ack(const container_t *container)
 }
 
 void
-container_audit_set_last_ack(const container_t *container, char *last_ack)
+container_audit_set_last_ack(const container_t *container, const char *last_ack)
 {
 	ASSERT(container);
 	c_audit_set_last_ack(container->audit, last_ack);

--- a/daemon/container.h
+++ b/daemon/container.h
@@ -940,7 +940,7 @@ container_audit_get_last_ack(const container_t *container);
  * Stores the last ACKi hash that has been received for this container.
  */
 void
-container_audit_set_last_ack(const container_t *container, char *last_ack);
+container_audit_set_last_ack(const container_t *container, const char *last_ack);
 
 /**
  * Returns wether an ACK is currently being processed for this container

--- a/service/service.c
+++ b/service/service.c
@@ -403,13 +403,13 @@ fork_service_message_handler()
 		/* register socket for receiving data */
 		fd_make_non_blocking(sock);
 
-		if (0 != audit_send_ack(*sock_ptr, LAST_AUDIT_HASH)) {
-			ERROR("Failed to send ack to cmld");
-		}
-
 		event_io_t *event =
 			event_io_new(*sock_ptr, EVENT_IO_READ, service_cb_recv_message, NULL);
 		event_add_io(event);
+
+		if (0 != audit_send_ack(*sock_ptr, LAST_AUDIT_HASH)) {
+			ERROR("Failed to send ack to cmld");
+		}
 
 		event_loop();
 


### PR DESCRIPTION
mem_free of protobuf structures lead to a memory corruption in the
daemon/audit submodule. We fixed this by resturcteing and using the
corresponding protobuf_free methods to free the protobuf structures.
Further, some frees of buffers allocated by getline and other
memory related cleanups are provided in this commit.

Signed-off-by: Michael Weiß <michael.weiss@aisec.fraunhofer.de>