### PR TITLE
Fixes for token detachment handling + boot time audit message

### DIFF
--- a/daemon/audit.c
+++ b/daemon/audit.c
@@ -76,8 +76,9 @@ typedef struct {
 } audit_meta_t;
 
 const char *evcategory[] = { "SUA", "FUA", "SSA", "FSA", "RLE" };
-const char *evclass[] = { "GUESTOS_MGMT",	 "TOKEN_MGMT", "CONTAINER_MGMT",
-			  "CONTAINER_ISOLATION", "TPM_COMM",   "KAUDIT" };
+const char *evclass[] = { "GENERIC",	    "GUESTOS_MGMT",	   "TOKEN_MGMT",
+			  "CONTAINER_MGMT", "CONTAINER_ISOLATION", "TPM_COMM",
+			  "KAUDIT" };
 const char *component[] = { "CMLD", "SCD", "TPM2D" };
 const char *result[] = { "SUCCESS", "FAIL" };
 

--- a/daemon/audit.h
+++ b/daemon/audit.h
@@ -30,6 +30,7 @@
 typedef enum { SUA, FUA, SSA, FSA, RLE } AUDIT_CATEGORY;
 
 typedef enum {
+	GENERIC,
 	GUESTOS_MGMT,
 	TOKEN_MGMT,
 	CONTAINER_MGMT,

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -55,6 +55,7 @@
 #include "time.h"
 #include "lxcfs.h"
 #include "audit.h"
+#include "time.h"
 
 #include <stdio.h>
 #include <dirent.h>
@@ -1277,6 +1278,10 @@ cmld_init(const char *path)
 	if (time_init() < 0)
 		FATAL("Could not init time module");
 	INFO("time initialized.");
+
+	char *btime = mem_printf("%ld", time_cml(NULL));
+	audit_log_event(NULL, SSA, CMLD, GENERIC, "boot-time", NULL, 2, "time", btime);
+	mem_free(btime);
 
 	if (uevent_init() < 0)
 		FATAL("Could not init uevent module");

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -1690,13 +1690,13 @@ cmld_token_detach(char *devpath)
 
 	container_set_usbtoken_devpath(container, NULL);
 
-	if (smartcard_scd_token_remove_block(container)) {
-		ERROR("Failed to notify scd about token detachment");
-	}
-
 	DEBUG("Stopping Container");
 	if (cmld_container_stop(container)) {
 		ERROR("Could not stop container after token detachment.");
+	}
+
+	if (smartcard_scd_token_remove_block(container)) {
+		ERROR("Failed to notify scd about token detachment");
 	}
 
 	return 0;

--- a/daemon/smartcard.c
+++ b/daemon/smartcard.c
@@ -57,6 +57,9 @@
 #define MAX_PAIR_SEC_LEN 8
 #define PAIR_SEC_FILE_NAME "device_pairing_secret"
 
+//#undef LOGF_LOG_MIN_PRIO
+//#define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE
+
 struct smartcard {
 	int sock;
 	char *path;
@@ -934,6 +937,8 @@ smartcard_update_token_state(container_t *container)
 
 	container_set_token_is_linked_to_device(
 		container, smartcard_container_token_is_provisioned(container));
+
+	DEBUG("Updated Token state: %d", container_get_token_is_linked_to_device(container));
 
 	return 0;
 }

--- a/scd/control.c
+++ b/scd/control.c
@@ -51,6 +51,9 @@
 #define SCD_CONTROL_SOCK_LISTEN_BACKLOG 8
 #define KEY_LENGTH_BYTES 64
 
+//#undef LOGF_LOG_MIN_PRIO
+//#define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE
+
 struct scd_control {
 	int sock; // listen socket fd
 };

--- a/scd/scd.c
+++ b/scd/scd.c
@@ -67,6 +67,9 @@
 #define TOKEN_DEFAULT_NAME "testuser"
 #define TOKEN_DEFAULT_EXT ".p12"
 
+//#undef LOGF_LOG_MIN_PRIO
+//#define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE
+
 static list_t *scd_token_list = NULL;
 
 static scd_control_t *scd_control_cmld = NULL;

--- a/scd/usbtoken.c
+++ b/scd/usbtoken.c
@@ -47,8 +47,8 @@
 
 #define USBTOKEN_SUCCESS 0x9000
 
-#undef LOGF_LOG_MIN_PRIO
-#define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE
+//#undef LOGF_LOG_MIN_PRIO
+//#define LOGF_LOG_MIN_PRIO LOGF_PRIO_TRACE
 
 static unsigned short g_ctn = 0;
 
@@ -353,6 +353,8 @@ usbtoken_init_ctapi_int(usbtoken_t *token, unsigned char *brsp, size_t brsp_len)
 		ERROR("Could not initiate schsm session");
 		goto err;
 	}
+
+	DEBUG("Successfully initialized CTAPI session for reader with serial  %s", token->serial);
 
 	return 0;
 


### PR DESCRIPTION
This PR adds minor fixes.

It moved the USB token deinitialization code that handles token detachments after the container stop to ensure correct token initialization if the token is re-attached.

Also, a audit message reflecting the cmld start time is added and the return values during USB token user authentication is fixed such that the scd responds with the correct message code.
