### PR TITLE
daemon/smartcard: Start SCD during smartcard init

### DIFF
--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -28,7 +28,7 @@ SANITIZERS ?= n
 
 TRUSTME_HARDWARE := x86
 
-LOCAL_CFLAGS := -std=gnu99 -Icommon -I.. -I../include -I../tpm2d -pedantic -O2
+LOCAL_CFLAGS := -std=gnu99 -Icommon -I.. -I../include -I../tpm2d -I../scd -pedantic -O2
 LOCAL_CFLAGS += -Wall -Wextra -Wcast-align -Wformat -Wformat-security -fstack-protector-all -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -fpic -pie
 ifeq ($(CC),gcc)
     # clang does not support stack clash protection yet
@@ -41,11 +41,11 @@ endif
 ifeq ($(AGGRESSIVE_WARNINGS),y)
     # on CI (and also for well-behaved developers) warnings should be
     # converted to errors; this helps us redistribute the code base without any pain;
-    # pure builds are better than polluted builds. 
+    # pure builds are better than polluted builds.
     LOCAL_CFLAGS += -Werror
 endif
 ifeq ($(SANITIZERS),y)
-    # if requested, we enable sanitization for easier debugging 
+    # if requested, we enable sanitization for easier debugging
     # this requires libasan libasan-static libubsan libubsan-static
     # to be installed on the build host
     LOCAL_CFLAGS += -lasan -fsanitize=address -fsanitize=undefined -fsanitize-recover=address

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -1338,6 +1338,10 @@ cmld_init(const char *path)
 		WARN("Could not get a valid MDM configuration from config file");
 	}
 
+	char *tokens_path = mem_printf("%s/%s", path, CMLD_PATH_CONTAINER_KEYS_DIR);
+	cmld_smartcard = smartcard_new(tokens_path);
+	mem_free(tokens_path);
+
 	char *guestos_path = mem_printf("%s/%s", path, CMLD_PATH_GUESTOS_DIR);
 	bool allow_locally_signed = device_config_get_locally_signed_images(device_config);
 	if (guestos_mgr_init(guestos_path, allow_locally_signed) < 0 && !cmld_hostedmode)
@@ -1349,10 +1353,6 @@ cmld_init(const char *path)
 	char *containers_path = mem_printf("%s/%s", path, CMLD_PATH_CONTAINERS_DIR);
 	if (mkdir(containers_path, 0700) < 0 && errno != EEXIST)
 		FATAL_ERRNO("Could not mkdir containers directory %s", containers_path);
-
-	char *tokens_path = mem_printf("%s/%s", path, CMLD_PATH_CONTAINER_KEYS_DIR);
-	cmld_smartcard = smartcard_new(tokens_path);
-	mem_free(tokens_path);
 
 	char *keys_path = mem_printf("%s/%s", path, CMLD_PATH_CONTAINER_KEYS_DIR);
 	if (mkdir(containers_path, 0700) < 0 && errno != EEXIST)

--- a/scd/scd_shared.h
+++ b/scd/scd_shared.h
@@ -21,53 +21,30 @@
  * Fraunhofer AISEC <trustme@aisec.fraunhofer.de>
  */
 
-#ifndef SCD_H
-#define SCD_H
+#ifndef SCD_SHARED_H
+#define SCD_SHARED_H
 
-#include "token.h"
+#define PROVISIONING_MODE_FILE "/tmp/_provisioning_"
 
-#ifdef ANDROID
-#else
-#include "scd.pb-c.h"
+#ifndef DEFAULT_BASE_PATH
+#define DEFAULT_BASE_PATH "/data/cml"
+#endif
+#ifndef DEFAULT_CONF_BASE_PATH
+#define DEFAULT_CONF_BASE_PATH "/data/cml"
+#endif
+#ifndef LOGFILE_DIR
+#define LOGFILE_DIR "/data/logs"
 #endif
 
-#include "scd_shared.h"
+// Do not edit! The provisioning script requires this path (also trustme-main.mk and its dummy provsg folder)
+#define SCD_TOKEN_DIR DEFAULT_BASE_PATH "/tokens"
+#define SSIG_ROOT_CERT SCD_TOKEN_DIR "/ssig_rootca.cert"
+#define LOCALCA_ROOT_CERT SCD_TOKEN_DIR "/localca_rootca.cert"
+#define TRUSTED_CA_STORE SCD_TOKEN_DIR "/ca"
 
-/**
- * Returns the type of the token
- */
-scd_tokentype_t
-scd_proto_to_tokentype(const DaemonToToken *msg);
+#define DEVICE_CERT_FILE SCD_TOKEN_DIR "/device.cert"
+#define DEVICE_CSR_FILE SCD_TOKEN_DIR "/device.csr"
+// Only used on platforms without TPM, otherwise TPM-bound key is used
+#define DEVICE_KEY_FILE SCD_TOKEN_DIR "/device.key"
 
-/**
- * Creates a new scd token structure.
- */
-int
-scd_token_new(const DaemonToToken *msg);
-
-/**
- * Returns an existing scd token.
- */
-scd_token_t *
-scd_get_token(scd_tokentype_t type, char *tuuid);
-
-/**
- * Returns an existing scd token.
- * This is a convience wrapper for scd_get_token(scd_token_t type, char *tuuid).
- */
-scd_token_t *
-scd_get_token_from_msg(const DaemonToToken *msg);
-
-/**
- * Frees a generic token structure.
- */
-void
-scd_token_free(scd_token_t *token);
-
-/**
- * Checks provisioning mode.
- */
-bool
-scd_in_provisioning_mode(void);
-
-#endif // SCD_H
+#endif // SCD_SHARED_H


### PR DESCRIPTION
The SCD is now started during cmld and smartcard init.

Signed-off-by: Simon Ott <simon.ott@aisec.fraunhofer.de>