### PR TITLE
daemon/cmld: create missing cml's socket dir for control socket

### DIFF
--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -1315,7 +1315,9 @@ cmld_init(const char *path)
 	 * callback (via event_) and parses incoming commands
 	 * and calls the corresponding function in the cmld module,
 	 * e.g. cmld_switch_container */
-	//control_cmld_cli = control_local_new(config_get_cmld_cli_sock_path(config));
+	if (dir_mkdir_p(CMLD_SOCKET_DIR, 0755) < 0) {
+		FATAL("Could not create directory for cmld_cli control socket");
+	}
 	cmld_control_cml = control_local_new(CMLD_CONTROL_SOCKET);
 	if (!cmld_control_cml) {
 		FATAL("Could not init cmld_cli control socket");


### PR DESCRIPTION
Recently introduced move of scd start to cmld's smartcard subsystem
caused that CMLD_SOCKET_DIR is not created if tpm2d or scd is started by
init before cmld start. Thus, the creation of the cmld control cli
socket caused a FATAL abort. We now create that directory before the
cmld cli control socket is created.

Signed-off-by: Michael Weiß <michael.weiss@aisec.fraunhofer.de>