### PR TITLE
daemon/cmld: Remove timout aborting TPM2D connect

### DIFF
--- a/daemon/tss.c
+++ b/daemon/tss.c
@@ -110,7 +110,9 @@ tss_init(void)
 		tss_sock = sock_unix_create_and_connect(SOCK_STREAM, TPM2D_SOCKET);
 		retries++;
 		TRACE("Retry %ld connecting to tpm2d", retries);
-	} while (tss_sock < 0 && retries < 10);
+		printf(".");
+		fflush(stdout);
+	} while (tss_sock < 0);
 
 	return (tss_sock < 0) ? -1 : 0;
 }


### PR DESCRIPTION
On hardware platforms that take longer times to initialize all components
the current timeout causes the cml startup to fail.

Therefore, this commit removes the timeout
to give the platform the time it needs to initialize the TPM2.

Signed-off-by: Felix Wruck <felix.wruck@aisec.fraunhofer.de>