### PR TITLE
Startup and proper cleanup of tpm2d and scd

### DIFF
--- a/daemon/Makefile_lsb
+++ b/daemon/Makefile_lsb
@@ -25,7 +25,8 @@ include Makefile
 
 LOCAL_CFLAGS += -DDEFAULT_BASE_PATH=\"/var/lib/cml\" \
 		-DLOGFILE_DIR=\"/var/log/cml\" \
-		-DDEFAULT_CONF_BASE_PATH=\"/etc/cml\"
+		-DDEFAULT_CONF_BASE_PATH=\"/etc/cml\" \
+		-DSCD_BINARY_NAME=\"cml-scd\"
 
 SBINDIR := /usr/sbin
 install:

--- a/daemon/Makefile_lsb
+++ b/daemon/Makefile_lsb
@@ -27,6 +27,7 @@ LOCAL_CFLAGS += -DDEFAULT_BASE_PATH=\"/var/lib/cml\" \
 		-DLOGFILE_DIR=\"/var/log/cml\" \
 		-DDEFAULT_CONF_BASE_PATH=\"/etc/cml\" \
 		-DSCD_BINARY_NAME=\"cml-scd\"
+		-DTPM2D_BINARY_NAME=\"cml-tpm2d\"
 
 SBINDIR := /usr/sbin
 install:

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -1622,3 +1622,35 @@ cmld_token_detach(char *devpath)
 
 	return 0;
 }
+
+void
+cmld_cleanup(void)
+{
+	for (list_t *l = cmld_containers_list; l; l = l->next) {
+		container_t *container = l->data;
+		container_free(container);
+	}
+	list_delete(cmld_containers_list);
+
+	if (cmld_control_mdm)
+		control_free(cmld_control_mdm);
+	if (cmld_control_gui)
+		control_free(cmld_control_gui);
+	if (cmld_control_cml)
+		control_free(cmld_control_cml);
+
+	if (cmld_smartcard)
+		smartcard_free(cmld_smartcard);
+
+	mem_free(cmld_device_uuid);
+	mem_free(cmld_device_update_base_url);
+	mem_free(cmld_device_host_dns);
+	mem_free(cmld_c0os_name);
+	mem_free(cmld_shared_data_dir);
+
+	for (list_t *l = cmld_netif_phys_list; l; l = l->next) {
+		char *name = l->data;
+		mem_free(name);
+	}
+	list_delete(cmld_netif_phys_list);
+}

--- a/daemon/cmld.h
+++ b/daemon/cmld.h
@@ -65,6 +65,12 @@ int
 cmld_init(const char *path);
 
 /**
+ * Cleans up the CMLD module.
+ */
+void
+cmld_cleanup(void);
+
+/**
  * Reloads all containers from storage path.
  *
  * @return 0 on success, -1 on error

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -36,6 +36,7 @@
 #include "cmld.h"
 #include "hardware.h"
 #include "lxcfs.h"
+#include "tss.h"
 
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -66,6 +67,7 @@ static void
 main_exit(void)
 {
 	lxcfs_cleanup();
+	tss_cleanup();
 	cmld_cleanup();
 	exit(0);
 }

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -66,6 +66,7 @@ static void
 main_exit(void)
 {
 	lxcfs_cleanup();
+	cmld_cleanup();
 	exit(0);
 }
 

--- a/daemon/smartcard.c
+++ b/daemon/smartcard.c
@@ -49,6 +49,10 @@
 #define SCD_CONTROL_SOCKET SOCK_PATH(scd-control)
 // clang-format on
 
+#ifndef SCD_BINARY_NAME
+#define SCD_BINARY_NAME "scd"
+#endif
+
 // TODO: centrally define key length in container or other module?
 #define TOKEN_KEY_LEN 96 // actual encryption key + hmac key
 #define TOKEN_MAX_WRAPPED_KEY_LEN 4096
@@ -1076,20 +1080,20 @@ fork_and_exec_scd(void)
 
 	int status;
 	pid_t pid = fork();
-	char *const param_list[] = { "scd", NULL };
+	char *const param_list[] = { SCD_BINARY_NAME, NULL };
 
 	switch (pid) {
 	case -1:
-		ERROR_ERRNO("Could not fork for scd");
+		ERROR_ERRNO("Could not fork for %s", SCD_BINARY_NAME);
 		return -1;
 	case 0:
 		execvp((const char *)param_list[0], param_list);
-		FATAL_ERRNO("Could not execvp scd");
+		FATAL_ERRNO("Could not execvp %s", SCD_BINARY_NAME);
 		return -1;
 	default:
 		// Just check if the child is alive but do not wait
 		if (waitpid(pid, &status, WNOHANG) != 0) {
-			ERROR("Failed to start scd");
+			ERROR("Failed to start %s", SCD_BINARY_NAME);
 			return -1;
 		}
 		return 0;
@@ -1106,7 +1110,7 @@ smartcard_new(const char *path)
 	if (!file_exists(DEVICE_CERT_FILE)) {
 		INFO("Starting scd in Provisioning / Installing Mode");
 		// Start the SCD in provisioning mode
-		const char *const args[] = { "scd", NULL };
+		const char *const args[] = { SCD_BINARY_NAME, NULL };
 		IF_FALSE_RETVAL_TRACE(proc_fork_and_execvp(args) == 0, NULL);
 	}
 

--- a/daemon/tss.c
+++ b/daemon/tss.c
@@ -37,6 +37,10 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#ifndef TPM2D_BINARY_NAME
+#define TPM2D_BINARY_NAME "tpm2d"
+#endif
+
 static int tss_sock = -1;
 
 /**
@@ -65,20 +69,20 @@ fork_and_exec_tpm2d(void)
 
 	int status;
 	pid_t pid = fork();
-	char *const param_list[] = { "tpm2d", NULL };
+	char *const param_list[] = { "TPM2D_BINARY_NAME", NULL };
 
 	switch (pid) {
 	case -1:
-		ERROR_ERRNO("Could not fork for tpm2d");
+		ERROR_ERRNO("Could not fork for %s", TPM2D_BINARY_NAME);
 		return -1;
 	case 0:
 		execvp((const char *)param_list[0], param_list);
-		FATAL_ERRNO("Could not execvp tpm2d");
+		FATAL_ERRNO("Could not execvp %s", TPM2D_BINARY_NAME);
 		return -1;
 	default:
 		// Just check if the child is alive but do not wait
 		if (waitpid(pid, &status, WNOHANG) != 0) {
-			ERROR("Failed to start tpm2d");
+			ERROR("Failed to start %s", TPM2D_BINARY_NAME);
 			return -1;
 		}
 		return 0;

--- a/daemon/tss.c
+++ b/daemon/tss.c
@@ -62,6 +62,23 @@ tss_hash_algo_get_len_proto(tss_hash_algo_t algo)
 	}
 }
 
+static bool
+tss_is_tpm2d_installed(void)
+{
+	bool found = false;
+	const char *path[] = { "/bin",	    "/sbin",	      "/usr/bin",
+			       "/usr/sbin", "/usr/local/bin", "/usr/local/bin" };
+
+	for (size_t i = 0; i < 6; ++i) {
+		char *binary = mem_printf("%s/%s", path[i], TPM2D_BINARY_NAME);
+		found = file_exists(binary);
+		mem_free(binary);
+		if (found)
+			return true;
+	}
+	return false;
+}
+
 static int
 fork_and_exec_tpm2d(void)
 {
@@ -94,7 +111,7 @@ int
 tss_init(void)
 {
 	// Check if the platform has a TPM module attached
-	if (!file_exists("/dev/tpm0")) {
+	if (!file_exists("/dev/tpm0") || !tss_is_tpm2d_installed()) {
 		WARN("Platform does not support TSS / TPM 2.0");
 		return 0;
 	}

--- a/daemon/tss.h
+++ b/daemon/tss.h
@@ -34,6 +34,12 @@ typedef enum { TSS_SHA1 = 0, TSS_SHA256, TSS_SHA384 } tss_hash_algo_t;
 int
 tss_init(void);
 
+/**
+ * Cleanup the tss submodule, mainly stop tpm2d daemon.
+ */
+void
+tss_cleanup(void);
+
 void
 tss_ml_append(char *filename, uint8_t *filehash, int filehash_len, tss_hash_algo_t hashalgo);
 


### PR DESCRIPTION
Since tpm2d and scd are now started by cmld, those processes needs to be stopped by cmld on exit, too.
This series fixes this and also some other quirks corresponding a clean exit.