### PR TITLE
c_net: Fix veth cleanup in c0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -109,6 +109,7 @@ pipeline {
                     echo "INHERIT += \\\"own-mirrors\\\"" >> conf/local.conf
                     echo "BB_GENERATE_MIRROR_TARBALLS = \\\"1\\\"" >> conf/local.conf
 
+                    bitbake -f -c do_cleanall trustx-cml
                     bitbake trustx-cml-initramfs multiconfig:container:trustx-core
                     bitbake trustx-cml
                 '''


### PR DESCRIPTION
Currently, the veth cleanup code for c0 joins the net namespace only.
As the cleanup code determines existense of an interface based on /sys/class/net
it is necessary to also join the mount namespace of c0
s.t. the sysfs reflects the interfaces present in the net namespace.

Also, the cleanup routine is currently called twice,
this commit removes the additional loop.

Signed-off-by: Felix Wruck <felix.wruck@aisec.fraunhofer.de>