### PR TITLE
VM-container-test.sh: Reduce RAM allocated for VM and introduce lock

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -128,11 +128,13 @@ pipeline {
         }
 
         stage('Functional Test Development Image') {
-            steps {
-                 sh '''
-                     bash ${WORKSPACE}/trustme/cml/scripts/ci/VM-container-tests.sh --dir ${WORKSPACE} --ssh 2229 --kill
-                '''
-            }
+          steps {
+              lock ('functional-test-vm') {
+                   sh '''
+                       bash ${WORKSPACE}/trustme/cml/scripts/ci/VM-container-tests.sh --dir ${WORKSPACE} --ssh 2229 --kill
+                  '''
+              }
+           }
         }
 
         stage('Production Image') {

--- a/scripts/ci/VM-container-tests.sh
+++ b/scripts/ci/VM-container-tests.sh
@@ -210,7 +210,7 @@ cp tmp/deploy/images/genericx86-64/trustme_image/trustmeimage.img trustmeimage.i
 # copy for faster startup
 cp /usr/share/OVMF/OVMF_VARS.fd .
 
-qemu-system-x86_64 -machine accel=kvm,vmport=off -m 1024G -smp 4 -cpu host -bios OVMF.fd \
+qemu-system-x86_64 -machine accel=kvm,vmport=off -m 64G -smp 4 -cpu host -bios OVMF.fd \
   -name trustme-tester,process=${PROCESS_NAME} -nodefaults -nographic \
 	-device virtio-rng-pci,rng=id -object rng-random,id=id,filename=/dev/urandom \
 	-device virtio-scsi-pci,id=scsi -device scsi-hd,drive=hd0 \


### PR DESCRIPTION
Reduce amount of RAM allocated for the VM
to avoid resource conflicts during builds.

Also, this commit limits the amount of concurrently executed VMs
during functional tests to 1 in order to assure correct cleanup.

Signed-off-by: Felix Wruck <felix.wruck@aisec.fraunhofer.de>