### PR TITLE
daemon/control: Reduced Control Command Interface in CC Mode

### DIFF
--- a/daemon/control.c
+++ b/daemon/control.c
@@ -719,6 +719,34 @@ control_handle_container_stop(control_t *control, container_t *container,
 static bool
 control_check_command(control_t *control, const ControllerToDaemon *msg)
 {
+#ifdef CC_MODE
+	/* filter all unused command codes using a whitelist; generate a clientside .proto
+	 * which only includes allowed messsages
+	 */
+	if (!((msg->command == CONTROLLER_TO_DAEMON__COMMAND__LIST_GUESTOS_CONFIGS) ||
+	      (msg->command == CONTROLLER_TO_DAEMON__COMMAND__LIST_CONTAINERS) ||
+	      (msg->command == CONTROLLER_TO_DAEMON__COMMAND__GET_CONTAINER_STATUS) ||
+	      (msg->command == CONTROLLER_TO_DAEMON__COMMAND__GET_CONTAINER_CONFIG) ||
+	      (msg->command == CONTROLLER_TO_DAEMON__COMMAND__PUSH_GUESTOS_CONFIG) ||
+	      (msg->command == CONTROLLER_TO_DAEMON__COMMAND__RELOAD_CONTAINERS) ||
+	      (msg->command == CONTROLLER_TO_DAEMON__COMMAND__CREATE_CONTAINER) ||
+	      (msg->command == CONTROLLER_TO_DAEMON__COMMAND__REMOVE_CONTAINER) ||
+	      (msg->command == CONTROLLER_TO_DAEMON__COMMAND__REGISTER_NEWCA) ||
+	      (msg->command == CONTROLLER_TO_DAEMON__COMMAND__REBOOT_DEVICE) ||
+	      (msg->command == CONTROLLER_TO_DAEMON__COMMAND__SET_PROVISIONED) ||
+	      (msg->command == CONTROLLER_TO_DAEMON__COMMAND__PULL_DEVICE_CSR) ||
+	      (msg->command == CONTROLLER_TO_DAEMON__COMMAND__PUSH_DEVICE_CERT) ||
+	      (msg->command == CONTROLLER_TO_DAEMON__COMMAND__CONTAINER_START) ||
+	      (msg->command == CONTROLLER_TO_DAEMON__COMMAND__CONTAINER_STOP) ||
+	      (msg->command == CONTROLLER_TO_DAEMON__COMMAND__CONTAINER_LIST_IFACES) ||
+	      (msg->command == CONTROLLER_TO_DAEMON__COMMAND__CONTAINER_UPDATE_CONFIG) ||
+	      (msg->command == CONTROLLER_TO_DAEMON__COMMAND__CONTAINER_CHANGE_TOKEN_PIN) ||
+	      (msg->command == CONTROLLER_TO_DAEMON__COMMAND__CONTAINER_CMLD_HANDLES_PIN))) {
+		TRACE("Received command %d is invalid in CC mode", msg->command);
+		return false;
+	}
+#endif
+
 	if (!control->privileged) {
 		// Device is in unprivileged mode, only allow subset of commands
 		if ((msg->command == CONTROLLER_TO_DAEMON__COMMAND__LIST_GUESTOS_CONFIGS) ||
@@ -737,7 +765,6 @@ control_check_command(control_t *control, const ControllerToDaemon *msg)
 		TRACE("Device is not provisioned or in hosted mode, all commands are accepted");
 		return true;
 	}
-
 	// Device is in privileged provisioned mode, only allow subset of commands
 	if ((msg->command == CONTROLLER_TO_DAEMON__COMMAND__LIST_CONTAINERS) ||
 	    (msg->command == CONTROLLER_TO_DAEMON__COMMAND__CONTAINER_CHANGE_TOKEN_PIN) ||
@@ -746,7 +773,8 @@ control_check_command(control_t *control, const ControllerToDaemon *msg)
 	    (msg->command == CONTROLLER_TO_DAEMON__COMMAND__CONTAINER_UPDATE_CONFIG) ||
 	    (msg->command == CONTROLLER_TO_DAEMON__COMMAND__GET_CONTAINER_STATUS) ||
 	    (msg->command == CONTROLLER_TO_DAEMON__COMMAND__CONTAINER_CMLD_HANDLES_PIN) ||
-	    (msg->command == CONTROLLER_TO_DAEMON__COMMAND__CONTAINER_STOP)) {
+	    (msg->command == CONTROLLER_TO_DAEMON__COMMAND__CONTAINER_STOP) ||
+	    (msg->command == CONTROLLER_TO_DAEMON__COMMAND__PUSH_GUESTOS_CONFIG)) {
 		TRACE("Received command %d is valid in provisioned mode", msg->command);
 		return true;
 	}


### PR DESCRIPTION
Reduced the commands that are allowed to be send over the
control interface when executing the CC Mode.

Signed-off-by: Florian Jakobsmeier <florian.jakobsmeier@aisec.fraunhofer.de>