### PR TITLE
common/uuid: Fixed include paths

### DIFF
--- a/common/uuid.c
+++ b/common/uuid.c
@@ -29,8 +29,8 @@
 #include <limits.h>
 #include <unistd.h>
 
-#include "common/macro.h"
-#include "common/mem.h"
+#include "macro.h"
+#include "mem.h"
 
 #include "uuid.h"
 


### PR DESCRIPTION
Removed prepended common/ as the files are in the same folder.
Otherwise, standalone builds linking against the common
library fail

Signed-off-by: Simon Ott <simon.ott@aisec.fraunhofer.de>