### PR TITLE
Jenkinsfile: use branch from jenkins instead of zeus + bugfix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
    stages {
       stage('Repo') {
 	 steps {
-             sh 'repo init -u https://github.com/trustm3/trustme_main.git -b zeus -m yocto-x86-genericx86-64.xml'
+             sh 'repo init -u https://github.com/trustm3/trustme_main.git -b ${CHANGE_TARGET} -m yocto-x86-genericx86-64.xml'
              sh 'mkdir -p .repo/local_manifests'
              sh '''
                 echo "<?xml version=\\\"1.0\\\" encoding=\\\"UTF-8\\\"?>" > .repo/local_manifests/jenkins.xml


### PR DESCRIPTION
- Jenkinsfile: We checkout the corresponding branch in the trustme_main repo.
- bugfix: common/cryptfs: replaced fsync by O_DRIECT during integrity format