### PR TITLE
Jenkinsfile: Fixed typo in variable manifest_branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
              sh '''
                 manifest_branch=${CHANGE_TARGET}
                 if [ -z "${manifest_branch}" ]; then
-                   mainfest_branch=${BRANCH_NAME}
+                   manifest_branch=${BRANCH_NAME}
                 fi
                 repo init -u https://github.com/trustm3/trustme_main.git -b ${manifest_branch} -m yocto-x86-genericx86-64.xml
              '''


### PR DESCRIPTION
This fixes a typo which caused an empty manifest_branch variable.

Signed-off-by: Michael Weiß <michael.weiss@aisec.fraunhofer.de>