### PR TITLE
Refactoring: explicit mem_free0

### DIFF
--- a/common/audit.c
+++ b/common/audit.c
@@ -100,7 +100,7 @@ audit_kernel_log_record(const AuditRecord *msg)
 	nl_sock_t *audit_sock;
 	if (!(audit_sock = nl_sock_default_new(NETLINK_AUDIT))) {
 		ERROR("Failed to allocate audit netlink socket");
-		mem_free(msg_text);
+		mem_free0(msg_text);
 		return -1;
 	}
 	/* send msg to kernel framwork */
@@ -111,7 +111,7 @@ audit_kernel_log_record(const AuditRecord *msg)
 	}
 	/* Close netlink connection */
 	nl_sock_free(audit_sock);
-	mem_free(msg_text);
+	mem_free0(msg_text);
 	return ret;
 }
 
@@ -150,7 +150,7 @@ audit_kernel_log_event(const char *type, const char *subject_id, int meta_count,
 
 	if (!record) {
 		ERROR("Failed to create audit record");
-		mem_free(metas);
+		mem_free0(metas);
 		goto out;
 	}
 
@@ -187,6 +187,6 @@ audit_kernel_write_loginuid(uint32_t uid)
 	}
 
 	close(fd);
-	mem_free(loginuid);
+	mem_free0(loginuid);
 	return ret;
 }

--- a/common/cryptfs.c
+++ b/common/cryptfs.c
@@ -192,7 +192,7 @@ load_integrity_mapping_table(int fd, const char *real_blk_name, const char *meta
 		 DM_INTEGRITY_BUF_SIZE - sizeof(struct dm_ioctl) - sizeof(struct dm_target_spec),
 		 "%s 0 %d J %s", real_blk_name, INTEGRITY_TAG_SIZE, extra_params);
 
-	mem_free(extra_params);
+	mem_free0(extra_params);
 
 	// Set pointer behind parameter
 	integrity_params += strlen(integrity_params) + 1;
@@ -256,7 +256,7 @@ load_crypto_mapping_table(int fd, const char *real_blk_name, const char *master_
 	snprintf(crypt_params,
 		 DM_CRYPT_BUF_SIZE - sizeof(struct dm_ioctl) - sizeof(struct dm_target_spec),
 		 "%s %s 0 %s 0 %s", crypto_type, master_key_ascii, real_blk_name, extra_params);
-	mem_free(extra_params);
+	mem_free0(extra_params);
 
 	crypt_params += strlen(crypt_params) + 1;
 	crypt_params =
@@ -445,7 +445,7 @@ create_device_node(const char *name)
 	int fd = open(DEV_MAPPER, O_RDWR);
 	if (fd < 0) {
 		ERROR_ERRNO("Error opening devmapper");
-		mem_free(buffer);
+		mem_free0(buffer);
 		return NULL;
 	}
 
@@ -456,7 +456,7 @@ create_device_node(const char *name)
 		if (errno != ENXIO) {
 			ERROR_ERRNO("DM_DEV_STATUS ioctl failed for lookup");
 		}
-		mem_free(buffer);
+		mem_free0(buffer);
 		close(fd);
 		return NULL;
 	}
@@ -470,11 +470,11 @@ create_device_node(const char *name)
 	unlink(device);
 	if (mknod(device, S_IFBLK | 00777, io->dev) != 0) {
 		ERROR_ERRNO("Cannot mknod device %s", device);
-		mem_free(buffer);
-		mem_free(device);
+		mem_free0(buffer);
+		mem_free0(device);
 		return NULL;
 	}
-	mem_free(buffer);
+	mem_free0(buffer);
 	return device;
 }
 
@@ -505,7 +505,7 @@ delete_integrity_blk_dev(const char *name)
 	/* remove device node if necessary */
 	char *device = cryptfs_get_device_path_new(name);
 	unlink(device);
-	mem_free(device);
+	mem_free0(device);
 
 	DEBUG("Successfully deleted dm-integrity device");
 	/* We made it here with no errors.  Woot! */
@@ -574,7 +574,7 @@ cryptfs_setup_volume_integrity_new(const char *label, const char *real_blkdev,
 	}
 
 	char *integrity_dev = create_device_node(integrity_dev_label);
-	mem_free(integrity_dev_label);
+	mem_free0(integrity_dev_label);
 	if (!integrity_dev) {
 		ERROR("Could not create device node");
 		return NULL;
@@ -617,8 +617,8 @@ cryptfs_setup_volume_integrity_new(const char *label, const char *real_blkdev,
 	}
 	return crypto_blkdev;
 error:
-	mem_free(integrity_dev_label);
-	mem_free(crypto_blkdev);
+	mem_free0(integrity_dev_label);
+	mem_free0(crypto_blkdev);
 	return NULL;
 }
 
@@ -688,17 +688,17 @@ cryptfs_delete_blk_dev(const char *name)
 	/* remove device node if necessary */
 	char *device = cryptfs_get_device_path_new(name);
 	unlink(device);
-	mem_free(device);
+	mem_free0(device);
 
 	DEBUG("Successfully deleted dm-crypt device");
 
 	char *integrity_dev_name = mem_printf("%s-%s", name, "integrity");
 	if (delete_integrity_blk_dev(integrity_dev_name) < 0) {
-		mem_free(integrity_dev_name);
+		mem_free0(integrity_dev_name);
 		goto error;
 	}
 
-	mem_free(integrity_dev_name);
+	mem_free0(integrity_dev_name);
 
 	/* We made it here with no errors.  Woot! */
 	ret = 0;

--- a/common/dir.c
+++ b/common/dir.c
@@ -106,7 +106,7 @@ dir_mkdir_p(const char *path, mode_t mode)
 	}
 out:
 	umask(old_mask);
-	mem_free(p);
+	mem_free0(p);
 	return ret;
 }
 
@@ -134,7 +134,7 @@ dir_unlink_folder_contents_cb(const char *path, const char *name, UNUSED void *d
 			ret--;
 		}
 	}
-	mem_free(file_to_remove);
+	mem_free0(file_to_remove);
 	return ret;
 }
 
@@ -154,7 +154,7 @@ dir_delete_folder(const char *path, const char *dir_name)
 		ERROR_ERRNO("Could not delete dir %s", dir_to_remove);
 		ret--;
 	}
-	mem_free(dir_to_remove);
+	mem_free0(dir_to_remove);
 
 	return ret;
 }
@@ -178,8 +178,8 @@ dir_copy_params_new(const char *path, const char *name,
 static void
 dir_copy_params_free(dir_copy_params_t *params)
 {
-	mem_free(params->target);
-	mem_free(params);
+	mem_free0(params->target);
+	mem_free0(params);
 }
 
 static int
@@ -223,7 +223,7 @@ dir_copy_folder_contents_cb(const char *path, const char *name, void *data)
 		ret = readlink(file_src, target, s.st_size + 1);
 		if (ret < 0 || ret > s.st_size) {
 			ERROR_ERRNO("Failed to read lnk");
-			mem_free(target);
+			mem_free0(target);
 			ret = -1;
 			break;
 		}
@@ -231,7 +231,7 @@ dir_copy_folder_contents_cb(const char *path, const char *name, void *data)
 
 		if ((ret = symlink(target, file_dst)) < 0)
 			ERROR_ERRNO("Could not create symlink %s at %s", target, file_dst);
-		mem_free(target);
+		mem_free0(target);
 	} break;
 	case S_IFIFO:
 	case S_IFSOCK:
@@ -269,7 +269,7 @@ dir_copy_folder_contents_cb(const char *path, const char *name, void *data)
 	}
 out:
 	dir_copy_params_free(params);
-	mem_free(file_src);
+	mem_free0(file_src);
 	return ret;
 }
 

--- a/common/event.c
+++ b/common/event.c
@@ -235,7 +235,7 @@ event_timer_free(event_timer_t *timer)
 {
 	IF_NULL_RETURN(timer);
 
-	mem_free(timer);
+	mem_free0(timer);
 }
 
 void
@@ -383,7 +383,7 @@ event_io_free(event_io_t *io)
 {
 	IF_NULL_RETURN(io);
 
-	mem_free(io);
+	mem_free0(io);
 }
 
 void
@@ -497,7 +497,7 @@ event_inotify_handler(int wd, const char *path, uint32_t mask)
 			if (path) {
 				char *full_path = mem_printf("%s/%s", inotify->path, path);
 				(inotify->func)(full_path, mask, inotify, inotify->data);
-				mem_free(full_path);
+				mem_free0(full_path);
 			} else {
 				(inotify->func)(inotify->path, mask, inotify, inotify->data);
 			}
@@ -602,9 +602,9 @@ event_inotify_free(event_inotify_t *inotify)
 	IF_NULL_RETURN(inotify);
 
 	if (inotify->path)
-		mem_free(inotify->path);
+		mem_free0(inotify->path);
 
-	mem_free(inotify);
+	mem_free0(inotify);
 }
 
 int
@@ -693,7 +693,7 @@ event_signal_free(event_signal_t *sig)
 {
 	IF_NULL_RETURN(sig);
 
-	mem_free(sig);
+	mem_free0(sig);
 }
 
 void

--- a/common/file.c
+++ b/common/file.c
@@ -89,7 +89,7 @@ file_is_mountpoint(const char *file)
 	ret &= !lstat(parent, &s_parent);
 	ret &= (s.st_dev != s_parent.st_dev);
 
-	mem_free(parent);
+	mem_free0(parent);
 	return ret;
 }
 
@@ -232,7 +232,7 @@ file_printf(const char *file, const char *fmt, ...)
 	va_end(ap);
 
 	ret = file_write(file, buf, -1);
-	mem_free(buf);
+	mem_free0(buf);
 	return ret;
 }
 
@@ -250,7 +250,7 @@ file_printf_append(const char *file, const char *fmt, ...)
 	va_end(ap);
 
 	ret = file_write_append(file, buf, -1);
-	mem_free(buf);
+	mem_free0(buf);
 	return ret;
 }
 
@@ -292,7 +292,7 @@ file_read_new(const char *file, size_t maxlen)
 	int bytes_read;
 
 	if ((bytes_read = file_read(file, maxbuf, maxlen - 1)) < 0) {
-		mem_free(maxbuf);
+		mem_free0(maxbuf);
 		return NULL;
 	}
 
@@ -300,7 +300,7 @@ file_read_new(const char *file, size_t maxlen)
 	maxbuf[bytes_read] = '\0';
 
 	buf = mem_strdup(maxbuf);
-	mem_free(maxbuf);
+	mem_free0(maxbuf);
 	return buf;
 }
 

--- a/common/list.c
+++ b/common/list.c
@@ -90,7 +90,7 @@ list_unlink(list_t *list, list_t *elem)
 		head = elem->next; // elem was the head
 	if (elem->next)
 		elem->next->prev = elem->prev;
-	mem_free(elem);
+	mem_free0(elem);
 
 	return head;
 }
@@ -199,7 +199,7 @@ list_replace(list_t *list, list_t *elem, void *data)
 	if (elem->next)
 		elem->next->prev = e;
 
-	mem_free(elem);
+	mem_free0(elem);
 
 	return head;
 }

--- a/common/logf.c
+++ b/common/logf.c
@@ -226,7 +226,7 @@ logf_file_new(const char *name)
 	char *name_with_time_of_day = logf_file_new_name(name);
 	f = fopen(name_with_time_of_day, "w");
 
-	mem_free(name_with_time_of_day);
+	mem_free0(name_with_time_of_day);
 
 	return f;
 }

--- a/common/loopdev.c
+++ b/common/loopdev.c
@@ -73,7 +73,7 @@ loopdev_new(void)
 void
 loopdev_free(char *dev)
 {
-	mem_free(dev);
+	mem_free0(dev);
 }
 
 int

--- a/common/mem.c
+++ b/common/mem.c
@@ -115,6 +115,12 @@ mem_printf(const char *fmt, ...)
 }
 
 void
+mem_free(void *ptr)
+{
+	free(ptr);
+}
+
+void
 mem_free_array(void **array, size_t size)
 {
 	if (array != NULL) {

--- a/common/mem.c
+++ b/common/mem.c
@@ -128,13 +128,13 @@ mem_free_array(void **array, size_t size)
 		while (i < size) {
 			if (array[i] != NULL) {
 				DEBUG("[MEM] Freeing element %zu", i);
-				mem_free(array[i]);
+				mem_free0(array[i]);
 			}
 
 			i++;
 		}
 
 		DEBUG("[MEM] Freeing array");
-		mem_free(array);
+		mem_free0(array);
 	}
 }

--- a/common/mem.h
+++ b/common/mem.h
@@ -127,19 +127,21 @@ mem_printf(const char *fmt, ...)
 
 /**
  * Frees the allocated memory.
+ * This is a wrapper for free(3) (which is provided for consistency).
+ * @param mem Memory to be freed.
+ */
+void
+mem_free(void *ptr);
+
+/**
+ * Frees the allocated memory.
  * This is a wrapper for free(3).
  * If we seccessfully free a pointer,
  * the wrapper sets it to NULL to prevent use-after-free,
  * double-free and similar exploitable issues.
  * @param mem Memory pointer to be freed.
  */
-#define mem_free(ptr)                                                                              \
-	do {                                                                                       \
-		if (ptr) {                                                                         \
-			free(ptr);                                                                 \
-			ptr = NULL;                                                                \
-		}                                                                                  \
-	} while (0)
+#define mem_free0(ptr) ((void)(free(ptr), (ptr) = NULL))
 
 /**
  * Frees the allocated memory of each array element and the array itself.

--- a/common/mem.test.c
+++ b/common/mem.test.c
@@ -59,7 +59,7 @@ test_can_allocate_primitives_and_structs(UNUSED const MunitParameter params[], U
 
 	*ptr_int = 0xc0ffe;
 	munit_assert_int(*ptr_int, ==, 0xc0ffe);
-	mem_free(ptr_int);
+	mem_free0(ptr_int);
 
 	// we can calloc memory and modify it
 	ptr_int = mem_alloc0(sizeof(int));
@@ -68,7 +68,7 @@ test_can_allocate_primitives_and_structs(UNUSED const MunitParameter params[], U
 
 	*ptr_int = 0xb0b0;
 	munit_assert_int(*ptr_int, ==, 0xb0b0);
-	mem_free(ptr_int);
+	mem_free0(ptr_int);
 
 	// we can alloc new objects and modify it
 	struct complex_t *ptr_struct = mem_new(struct complex_t, 1);
@@ -82,7 +82,7 @@ test_can_allocate_primitives_and_structs(UNUSED const MunitParameter params[], U
 	munit_assert_char(ptr_struct->buf[10], ==, 'V');
 	munit_assert_int(ptr_struct->int_field, ==, 0xdead);
 	munit_assert_ullong(ptr_struct->long_field, ==, 0xbeef);
-	mem_free(ptr_struct);
+	mem_free0(ptr_struct);
 
 	// we can calloc new objects and modify them
 	ptr_struct = mem_new0(struct complex_t, 1);
@@ -94,7 +94,7 @@ test_can_allocate_primitives_and_structs(UNUSED const MunitParameter params[], U
 	munit_assert_double_equal(ptr_struct->precision_number, 0, 9);
 	for (size_t i = 0; i < sizeof(ptr_struct->buf); i++)
 		munit_assert_char(ptr_struct->buf[i], ==, 0);
-	mem_free(ptr_struct);
+	mem_free0(ptr_struct);
 
 	return MUNIT_OK;
 }
@@ -116,8 +116,8 @@ test_can_realloc_primitives_and_structs(UNUSED const MunitParameter params[], UN
 	munit_assert_not_null(ptr_struct);
 	munit_assert_char(ptr_struct->buf[15], ==, 'Z');
 
-	mem_free(ptr_int);
-	mem_free(ptr_struct);
+	mem_free0(ptr_int);
+	mem_free0(ptr_struct);
 
 	return MUNIT_OK;
 }
@@ -135,26 +135,26 @@ test_strdup_strndup(UNUSED const MunitParameter params[], UNUSED void *data)
 	// b is in a different memory chunk than a and can be modified
 	b[8] = '\0';
 	munit_assert_string_not_equal(a, b);
-	mem_free(b);
+	mem_free0(b);
 
 	// strndup copies full string
 	char *c = mem_strndup(a, strlen(a));
 	munit_assert_not_null(c);
 	munit_assert_string_equal(a, c);
-	mem_free(c);
+	mem_free0(c);
 
 	// strndup cuts
 	c = mem_strndup(a, 7);
 	munit_assert_not_null(c);
 	munit_assert_string_not_equal(a, c);
 	munit_assert_string_equal("hehe, s", c);
-	mem_free(c);
+	mem_free0(c);
 
 	// strndup does not overflow
 	c = mem_strndup(a, 1024);
 	munit_assert_not_null(c);
 	munit_assert_string_equal(a, c);
-	mem_free(c);
+	mem_free0(c);
 
 	return MUNIT_OK;
 }
@@ -174,20 +174,20 @@ test_mem_memcpy(UNUSED const MunitParameter params[], UNUSED void *data)
 	// b is in a different memory chunk than a and can be modified
 	b[8] = ~b[8];
 	munit_assert_memory_not_equal(TEST_MEM_MEMCPY_BUF_SIZE, a, b);
-	mem_free(b);
+	mem_free0(b);
 
 	// memcpy copies entire memory
 	unsigned char *c = mem_memcpy(a, TEST_MEM_MEMCPY_BUF_SIZE);
 	munit_assert_not_null(c);
 	munit_assert_memory_equal(TEST_MEM_MEMCPY_BUF_SIZE, a, c);
-	mem_free(c);
+	mem_free0(c);
 
 	// memcpy cuts
 	c = mem_memcpy(a, (TEST_MEM_MEMCPY_BUF_SIZE / 2) + 1);
 	munit_assert_not_null(c);
 	munit_assert_memory_not_equal(TEST_MEM_MEMCPY_BUF_SIZE, a, c);
 	munit_assert_memory_equal(129, a, c);
-	mem_free(c);
+	mem_free0(c);
 
 	return MUNIT_OK;
 }
@@ -209,8 +209,8 @@ test_printf_dynamic_buffer(UNUSED const MunitParameter params[], UNUSED void *da
 
 	//TODO: test against format string attacks. The %n modifier should be killed.
 
-	mem_free(buf);
-	mem_free(ptr);
+	mem_free0(buf);
+	mem_free0(ptr);
 
 	return MUNIT_OK;
 }
@@ -223,13 +223,13 @@ test_freed_pointers_are_set_to_null(UNUSED const MunitParameter params[], UNUSED
 	// for primitives
 	int *x = mem_alloc(sizeof(int));
 	munit_assert_not_null(x);
-	mem_free(x);
+	mem_free0(x);
 	munit_assert_null(x);
 
 	// for structs
 	struct complex_t *ptr = (struct complex_t *)mem_alloc(sizeof(struct complex_t));
 	munit_assert_not_null(ptr);
-	mem_free(ptr);
+	mem_free0(ptr);
 	munit_assert_null(ptr);
 
 	return MUNIT_OK;
@@ -246,7 +246,7 @@ test_integer_overflow_in_mem_new_is_detected(UNUSED const MunitParameter params[
 	struct complex_t *ptr = mem_new(struct complex_t, MAX >> 1);
 
 	// shouldn't be reached
-	mem_free(ptr);
+	mem_free0(ptr);
 	return MUNIT_FAIL;
 }
 
@@ -261,7 +261,7 @@ test_integer_overflow_in_mem_new0_is_detected(UNUSED const MunitParameter params
 	struct complex_t *ptr = mem_new0(struct complex_t, MAX >> 1);
 
 	// shouldn't be reached
-	mem_free(ptr);
+	mem_free0(ptr);
 	return MUNIT_FAIL;
 }
 
@@ -277,7 +277,7 @@ test_integer_overflow_in_mem_renew_is_detected(UNUSED const MunitParameter param
 	ptr = mem_renew(struct complex_t, ptr, MAX >> 1);
 
 	// shouldn't be reached
-	mem_free(ptr);
+	mem_free0(ptr);
 	return MUNIT_FAIL;
 }
 

--- a/common/network.c
+++ b/common/network.c
@@ -69,7 +69,7 @@ network_call_ip(const char *addr, uint32_t subnet, const char *interface, char *
 	char *net = mem_printf("%s/%i", addr, subnet);
 	const char *const argv[] = { IP_PATH, "addr", action, net, "dev", interface, NULL };
 	int ret = proc_fork_and_execvp(argv);
-	mem_free(net);
+	mem_free0(net);
 	return ret;
 }
 
@@ -85,8 +85,8 @@ network_move_link_ns(pid_t src_pid, pid_t dest_pid, const char *interface)
 	for (int i = 0; argv[i]; i++)
 		DEBUG("-- %s", argv[i]);
 	int ret = proc_fork_and_execvp(argv);
-	mem_free(src_pid_str);
-	mem_free(dest_pid_str);
+	mem_free0(src_pid_str);
+	mem_free0(dest_pid_str);
 	return ret;
 }
 
@@ -99,9 +99,9 @@ network_list_link_ns(pid_t pid, list_t **link_list)
 	char *line = mem_new0(char, line_size);
 
 	fp = popen(command, "r");
-	mem_free(command);
+	mem_free0(command);
 	if (fp == NULL) {
-		mem_free(line);
+		mem_free0(line);
 		return -1;
 	}
 
@@ -116,7 +116,7 @@ network_list_link_ns(pid_t pid, list_t **link_list)
 		}
 	}
 	pclose(fp);
-	mem_free(line);
+	mem_free0(line);
 	return 0;
 }
 
@@ -226,9 +226,9 @@ network_setup_port_forwarding(const char *srcip, uint16_t srcport, const char *d
 				      srcip,	     NULL };
 	error |= proc_fork_and_execvp(argv2);
 
-	mem_free(src_port);
-	mem_free(dst_port);
-	mem_free(dst);
+	mem_free0(src_port);
+	mem_free0(dst_port);
+	mem_free0(dst);
 
 	return error;
 }
@@ -372,7 +372,7 @@ network_route_localnet(const char *interface, bool enable)
 			    interface);
 		error = -1;
 	}
-	mem_free(route_localnet_file);
+	mem_free0(route_localnet_file);
 	return error;
 }
 #endif
@@ -425,7 +425,7 @@ network_interface_is_wifi(const char *if_name)
 
 	phy_path = mem_printf("/sys/class/net/%s/phy80211", if_name);
 	ret = file_exists(phy_path);
-	mem_free(phy_path);
+	mem_free0(phy_path);
 
 	return ret;
 }
@@ -450,7 +450,7 @@ network_get_physical_interfaces_new()
 		} else {
 			DEBUG("Skipping %d: Not a physical network interface", i->if_index);
 		}
-		mem_free(dev_drv_path);
+		mem_free0(dev_drv_path);
 	}
 	if_freenameindex(if_ni);
 	return if_name_list;
@@ -473,8 +473,8 @@ network_nl80211_get_index(const char *if_name)
 	phy_index = atoi(phy_file);
 
 out:
-	mem_free(phy_file);
-	mem_free(dev_phy_path);
+	mem_free0(phy_file);
+	mem_free0(dev_phy_path);
 	return phy_index;
 }
 
@@ -682,14 +682,14 @@ network_get_mac_by_ifname(const char *ifname, uint8_t mac[6])
 
 	char *dev_addr_path = mem_printf("/sys/class/net/%s/address", ifname);
 	char *mac_str = file_read_new(dev_addr_path, 128);
-	mem_free(dev_addr_path);
+	mem_free0(dev_addr_path);
 
 	IF_NULL_RETVAL(mac_str, -1);
 
 	memset(mac, 0, 6);
 	int ret = network_str_to_mac_addr(mac_str, mac);
 
-	mem_free(mac_str);
+	mem_free0(mac_str);
 	return ret;
 }
 
@@ -708,7 +708,7 @@ network_get_ifname_by_addr_new(uint8_t mac[6])
 	for (i = if_ni; i->if_index != 0 || i->if_name != NULL; i++) {
 		char *dev_addr_path = mem_printf("/sys/class/net/%s/address", i->if_name);
 		char *mac_str = file_read_new(dev_addr_path, 128);
-		mem_free(dev_addr_path);
+		mem_free0(dev_addr_path);
 		if (mac_str == NULL)
 			continue;
 
@@ -716,11 +716,11 @@ network_get_ifname_by_addr_new(uint8_t mac[6])
 
 		if ((0 == network_str_to_mac_addr(mac_str, mac_i)) &&
 		    (0 == memcmp(mac, mac_i, 6))) {
-			mem_free(mac_str);
+			mem_free0(mac_str);
 			return mem_strdup(i->if_name);
 		}
 
-		mem_free(mac_str);
+		mem_free0(mac_str);
 	}
 
 	return NULL;
@@ -811,6 +811,6 @@ network_phys_allow_mac(const char *chain, const char *netif, uint8_t mac[6], boo
 
 	int ret = proc_fork_and_execvp(argv);
 
-	mem_free(mac_str);
+	mem_free0(mac_str);
 	return ret;
 }

--- a/common/nl.c
+++ b/common/nl.c
@@ -342,7 +342,7 @@ nl_sock_free(nl_sock_t *nl)
 {
 	IF_NULL_RETURN(nl);
 	close(nl->fd);
-	mem_free(nl);
+	mem_free0(nl);
 }
 
 struct nlattr *
@@ -642,7 +642,7 @@ nl_eval_ack(const nl_sock_t *nl, UNUSED uint32_t seq)
 					break;
 				} else {
 					DEBUG("ACK successfully found");
-					mem_free(buf);
+					mem_free0(buf);
 					return 0;
 				}
 			}
@@ -651,7 +651,7 @@ nl_eval_ack(const nl_sock_t *nl, UNUSED uint32_t seq)
 
 	/* ACK could not be validated */
 	ERROR("Message could not be received/decoded or was not an ACK response");
-	mem_free(buf);
+	mem_free0(buf);
 	return -1;
 }
 
@@ -712,7 +712,7 @@ void
 nl_msg_free(nl_msg_t *msg)
 {
 	IF_NULL_RETURN(msg);
-	mem_free(msg);
+	mem_free0(msg);
 }
 
 int
@@ -816,7 +816,7 @@ nl_msg_receive_and_check_kernel(const nl_sock_t *nl)
 	IF_NULL_RETVAL_TRACE(buf, -1);
 
 	if (nl_msg_receive_kernel(nl, buf, NL_DEFAULT_SOCK_RCVBUF_SIZE, false) < 0) {
-		mem_free(buf);
+		mem_free0(buf);
 		return -1;
 	}
 
@@ -829,7 +829,7 @@ nl_msg_receive_and_check_kernel(const nl_sock_t *nl)
 			ret = -1;
 		}
 	}
-	mem_free(buf);
+	mem_free0(buf);
 	return ret;
 }
 
@@ -962,7 +962,7 @@ nl_genl_family_getid(const char *family_name)
 	if (nl_sock)
 		nl_sock_free(nl_sock);
 	if (buf)
-		mem_free(buf);
+		mem_free0(buf);
 	return ret;
 
 msg_err:
@@ -971,6 +971,6 @@ msg_err:
 	if (nl_sock)
 		nl_sock_free(nl_sock);
 	if (buf)
-		mem_free(buf);
+		mem_free0(buf);
 	return 0;
 }

--- a/common/ns.c
+++ b/common/ns.c
@@ -108,18 +108,18 @@ do_join_namespace(const char *namespace, const int pid)
 		goto error;
 	}
 
-	mem_free(target_namespace_path);
-	mem_free(target_namespace_id);
-	mem_free(current_namespace_path);
-	mem_free(current_namespace_id);
+	mem_free0(target_namespace_path);
+	mem_free0(target_namespace_id);
+	mem_free0(current_namespace_path);
+	mem_free0(current_namespace_id);
 
 	return 0;
 
 error:
-	mem_free(target_namespace_path);
-	mem_free(target_namespace_id);
-	mem_free(current_namespace_path);
-	mem_free(current_namespace_id);
+	mem_free0(target_namespace_path);
+	mem_free0(target_namespace_id);
+	mem_free0(current_namespace_path);
+	mem_free0(current_namespace_id);
 
 	return -1;
 }
@@ -239,7 +239,7 @@ ns_setns_cb(const char *path, const char *file, void *data)
 
 	if (ns_is_self_userns_file(ns_file)) {
 		TRACE("Joining same user namespace, not allowed and also not necessary -> skip.");
-		mem_free(ns_file);
+		mem_free0(ns_file);
 		return EXIT_SUCCESS;
 	}
 
@@ -256,12 +256,12 @@ ns_setns_cb(const char *path, const char *file, void *data)
 
 	*i = *i + 1;
 
-	mem_free(ns_file);
+	mem_free0(ns_file);
 	return EXIT_SUCCESS;
 
 error:
 	TRACE("An error occurred. Exiting...");
-	mem_free(ns_file);
+	mem_free0(ns_file);
 	exit(EXIT_FAILURE);
 }
 
@@ -292,14 +292,14 @@ ns_join_all(pid_t pid, bool userns)
 
 	TRACE("Successfully joined all namespaces");
 
-	mem_free(pid_string);
-	mem_free(folder);
+	mem_free0(pid_string);
+	mem_free0(folder);
 	return 0;
 
 error:
 	TRACE("An error occurred. Exiting...");
-	mem_free(pid_string);
-	mem_free(folder);
+	mem_free0(pid_string);
+	mem_free0(folder);
 	return -1;
 }
 
@@ -317,7 +317,7 @@ ns_bind(char *ns, pid_t pid, char *ns_path)
 		ret = -1;
 	}
 
-	mem_free(ns_proc_path);
+	mem_free0(ns_proc_path);
 	return ret;
 }
 

--- a/common/proc.c
+++ b/common/proc.c
@@ -71,7 +71,7 @@ proc_status_new(pid_t pid)
 
 	file = mem_printf("/proc/%d/status", pid);
 	buf = file_read_new(file, 4096);
-	mem_free(file);
+	mem_free0(file);
 
 	IF_NULL_RETVAL(buf, NULL);
 
@@ -118,18 +118,18 @@ proc_status_new(pid_t pid)
 	TRACE("Parsed gid for %d: %u %u %u %u", pid, status->rgid, status->egid, status->sgid,
 	      status->fgid);
 
-	mem_free(buf);
+	mem_free0(buf);
 	return status;
 error:
-	mem_free(status);
-	mem_free(buf);
+	mem_free0(status);
+	mem_free0(buf);
 	return NULL;
 }
 
 void
 proc_status_free(proc_status_t *status)
 {
-	mem_free(status);
+	mem_free0(status);
 }
 
 const char *
@@ -263,7 +263,7 @@ proc_cap_last_cap(void)
 		cap = -1;
 	}
 
-	mem_free(str_cap_last_cap);
+	mem_free0(str_cap_last_cap);
 	return cap;
 }
 

--- a/common/protobuf.c
+++ b/common/protobuf.c
@@ -103,18 +103,18 @@ protobuf_send_message(int fd, const ProtobufCMessage *message)
 	if (!(buflen < PROTOBUF_MAX_MESSAGE_SIZE)) {
 		ERROR("Packed message exceeds PROTOBUF_MAX_MESSAGE_SIZE");
 		if (buf)
-			mem_free(buf);
+			mem_free0(buf);
 
 		return -1;
 	}
 
 	if (-1 == protobuf_send_message_packed(fd, buf, buflen)) {
 		ERROR_ERRNO("Failed to write packed protobuf message to fd %d.", fd);
-		mem_free(buf);
+		mem_free0(buf);
 		return -1;
 	}
 
-	mem_free(buf);
+	mem_free0(buf);
 
 	return buflen;
 }
@@ -155,7 +155,7 @@ protobuf_recv_message_packed_new(int fd, ssize_t *ret_len)
 		bytes_read = fd_read(fd, (char *)buf, buflen);
 	} while (-1 == bytes_read && errno == EINTR);
 	if (-1 == bytes_read) {
-		mem_free(buf);
+		mem_free0(buf);
 		goto error_read;
 	}
 	TRACE("read protobuf message data (%zd bytes read, %u bytes expected)", bytes_read, buflen);
@@ -163,7 +163,7 @@ protobuf_recv_message_packed_new(int fd, ssize_t *ret_len)
 	if ((size_t)bytes_read != buflen) {
 		ERROR("Dropped protobuf message (expected length : %zd bytes read != %u bytes expected)",
 		      bytes_read, buflen);
-		mem_free(buf);
+		mem_free0(buf);
 		goto error_read;
 	}
 	// TODO: what if only part of a message could be read?
@@ -198,7 +198,7 @@ protobuf_recv_message(int fd, const ProtobufCMessageDescriptor *descriptor)
 	}
 
 	ProtobufCMessage *msg = protobuf_c_message_unpack(descriptor, NULL, buflen, buf);
-	mem_free(buf);
+	mem_free0(buf);
 	return msg;
 }
 
@@ -234,7 +234,7 @@ protobuf_dump_message(int fd, const ProtobufCMessage *message)
 		return -1;
 	}
 	ssize_t bytes_written = write(fd, string, strlen(string));
-	mem_free(string);
+	mem_free0(string);
 	if (-1 == bytes_written)
 		WARN_ERRNO("Failed to write text protobuf message to fd %d.", fd);
 	return bytes_written;
@@ -322,7 +322,7 @@ protobuf_message_new_from_buf(const uint8_t *buf, size_t buflen,
 
 	ProtobufCMessage *msg = protobuf_message_new_from_string(string, descriptor);
 
-	mem_free(string);
+	mem_free0(string);
 	return msg;
 }
 

--- a/common/ssl_util.c
+++ b/common/ssl_util.c
@@ -214,7 +214,7 @@ ssl_read_pkcs12_token(const char *token_file, const char *passphrase, EVP_PKEY *
 end:
 	if (p12)
 		PKCS12_free(p12);
-	mem_free(passphr);
+	mem_free0(passphr);
 	return ret;
 }
 
@@ -587,9 +587,9 @@ ssl_wrap_key(EVP_PKEY *pkey, const unsigned char *plain_key, size_t plain_key_le
 
 	res = 0;
 cleanup:
-	mem_free(tmpkey);
-	mem_free(iv_buf);
-	mem_free(out);
+	mem_free0(tmpkey);
+	mem_free0(iv_buf);
+	mem_free0(out);
 	EVP_CIPHER_CTX_free(ctx);
 	return res;
 }
@@ -1064,7 +1064,7 @@ error:
 	if (key)
 		EVP_PKEY_free(key);
 	if (signature)
-		mem_free(signature);
+		mem_free0(signature);
 	if (md_ctx)
 		EVP_MD_CTX_free(md_ctx);
 	return ret;
@@ -1299,7 +1299,7 @@ ssl_hash_file(const char *file_to_hash, unsigned int *calc_len, const char *hash
 	ret = (unsigned char *)mem_alloc0(EVP_MAX_MD_SIZE);
 	if (EVP_DigestFinal(md_ctx, ret, calc_len) != 1) {
 		ERROR("Error in file hashing (computing hash)");
-		mem_free(ret);
+		mem_free0(ret);
 		ret = NULL;
 		goto error;
 	}
@@ -1389,7 +1389,7 @@ ssl_create_pkcs12_token(const char *token_file, const char *cert_file, const cha
 	DEBUG("PKCS12_free %p", (void *)p12);
 	PKCS12_free(p12);
 	DEBUG("mem_free passphr %p", (void *)passphr);
-	mem_free(passphr);
+	mem_free0(passphr);
 	DEBUG("all free done");
 	return 0;
 error:
@@ -1399,7 +1399,7 @@ error:
 		X509_free(cert);
 	if (p12)
 		PKCS12_free(p12);
-	mem_free(passphr);
+	mem_free0(passphr);
 	return -1;
 }
 

--- a/common/str.c
+++ b/common/str.c
@@ -55,7 +55,7 @@ str_append_printf_internal(str_t *str, const char *fmt, va_list ap)
 
 	buf = mem_vprintf(fmt, ap);
 	str_insert_len(str, -1, buf, -1);
-	mem_free(buf);
+	mem_free0(buf);
 }
 
 str_t *
@@ -252,13 +252,13 @@ str_free(str_t *str, bool free_buf)
 	IF_NULL_RETVAL(str, NULL);
 
 	if (free_buf) {
-		mem_free(str->buf);
+		mem_free0(str->buf);
 		buf = NULL;
 	} else {
 		buf = str->buf;
 	}
 
-	mem_free(str);
+	mem_free0(str);
 
 	return buf;
 }

--- a/common/uuid.c
+++ b/common/uuid.c
@@ -165,8 +165,8 @@ uuid_free(uuid_t *uuid)
 {
 	IF_NULL_RETURN(uuid);
 
-	mem_free(uuid->string);
-	mem_free(uuid);
+	mem_free0(uuid->string);
+	mem_free0(uuid);
 }
 
 const char *

--- a/control/control.c
+++ b/control/control.c
@@ -177,8 +177,8 @@ get_container_usb_pin_entry(uuid_t *uuid, int sock)
 
 	pin_entry = resp->container_cmld_handles_pin;
 
-	mem_free(msg.container_uuids[0]);
-	mem_free(msg.container_uuids);
+	mem_free0(msg.container_uuids[0]);
+	mem_free0(msg.container_uuids);
 	protobuf_free_message((ProtobufCMessage *)resp);
 
 	return pin_entry;
@@ -717,7 +717,7 @@ main(int argc, char *argv[])
 		if (strcmp(msg.device_newpin, newpin_verify) != 0)
 			FATAL("Passwords don't match!");
 
-		mem_free(newpin_verify);
+		mem_free0(newpin_verify);
 	} else
 		print_usage(argv[0]);
 
@@ -778,7 +778,7 @@ send_message:
 					      argv[optind]);
 
 					send_message(sock, &inputmsg);
-					mem_free(inputmsg.container_uuids);
+					mem_free0(inputmsg.container_uuids);
 					TRACE("[CLIENT] Sent input to cmld");
 				}
 			}
@@ -864,28 +864,28 @@ exit:
 	tcsetattr(STDIN_FILENO, TCSAFLUSH, &termios_before);
 
 	if (msg.has_container_config_file)
-		mem_free(msg.container_config_file.data);
+		mem_free0(msg.container_config_file.data);
 	if (msg.has_guestos_rootcert)
-		mem_free(msg.guestos_rootcert.data);
+		mem_free0(msg.guestos_rootcert.data);
 	if (msg.has_guestos_config_file)
-		mem_free(msg.guestos_config_file.data);
+		mem_free0(msg.guestos_config_file.data);
 	if (msg.has_guestos_config_signature)
-		mem_free(msg.guestos_config_signature.data);
+		mem_free0(msg.guestos_config_signature.data);
 	if (msg.has_guestos_config_certificate)
-		mem_free(msg.guestos_config_certificate.data);
+		mem_free0(msg.guestos_config_certificate.data);
 	if (msg.has_device_cert)
-		mem_free(msg.device_cert.data);
+		mem_free0(msg.device_cert.data);
 
 	if (has_container_start_params_key)
-		mem_free(container_start_params.key);
+		mem_free0(container_start_params.key);
 	if (msg.device_pin)
-		mem_free(msg.device_pin);
+		mem_free0(msg.device_pin);
 	if (msg.device_newpin)
-		mem_free(msg.device_newpin);
+		mem_free0(msg.device_newpin);
 
 	for (size_t i = 0; i < msg.n_container_uuids; ++i)
-		mem_free(msg.container_uuids[i]);
-	mem_free(msg.container_uuids);
+		mem_free0(msg.container_uuids[i]);
+	mem_free0(msg.container_uuids);
 	if (uuid)
 		uuid_free(uuid);
 

--- a/converter/control.c
+++ b/converter/control.c
@@ -119,11 +119,11 @@ control_push_guestos(char *cfgfile, char *certfile, char *sigfile)
 	ret = send_message(&msg);
 out:
 	if (cfg)
-		mem_free(cfg);
+		mem_free0(cfg);
 	if (sig)
-		mem_free(sig);
+		mem_free0(sig);
 	if (cert)
-		mem_free(cert);
+		mem_free0(cert);
 	return ret;
 }
 
@@ -153,6 +153,6 @@ control_register_localca(char *ca_cert_file)
 	ret = send_message(&msg);
 out:
 	if (ca_cert)
-		mem_free(ca_cert);
+		mem_free0(ca_cert);
 	return ret;
 }

--- a/converter/converter.c
+++ b/converter/converter.c
@@ -198,7 +198,7 @@ write_guestos_config(docker_config_t *config, const char *root_image_file, const
 
 	char *local_ip = get_ifname_ip_new("eth0");
 	cfg.update_base_url = mem_printf("http://%s/", local_ip);
-	mem_free(local_ip);
+	mem_free0(local_ip);
 
 	protobuf_message_write_to_file(out_file, (ProtobufCMessage *)&cfg);
 
@@ -231,31 +231,31 @@ write_guestos_config(docker_config_t *config, const char *root_image_file, const
 	else
 		ret = control_push_guestos(out_file, out_cert_file, out_sig_file);
 
-	mem_free(cfg.update_base_url);
-	mem_free(out_sig_file);
-	mem_free(out_cert_file);
-	mem_free(out_www_image_path_versioned);
+	mem_free0(cfg.update_base_url);
+	mem_free0(out_sig_file);
+	mem_free0(out_cert_file);
+	mem_free0(out_www_image_path_versioned);
 
 free_stuff:
 	for (uint32_t j = 0; j < cfg.n_mounts; ++j) {
-		mem_free(cfg.mounts[j]->image_file);
-		mem_free(cfg.mounts[j]->mount_point);
-		mem_free(cfg.mounts[j]->fs_type);
-		mem_free(cfg.mounts[j]->image_sha1);
-		mem_free(cfg.mounts[j]->image_sha2_256);
+		mem_free0(cfg.mounts[j]->image_file);
+		mem_free0(cfg.mounts[j]->mount_point);
+		mem_free0(cfg.mounts[j]->fs_type);
+		mem_free0(cfg.mounts[j]->image_sha1);
+		mem_free0(cfg.mounts[j]->image_sha2_256);
 		if (j > 0) {
-			mem_free(cfg.mounts[j]);
+			mem_free0(cfg.mounts[j]);
 		}
 	}
-	mem_free(cfg.name);
-	mem_free(cfg.upstream_version);
-	mem_free(cfg.mounts);
-	mem_free(description.en);
-	mem_free(description.de);
-	mem_free(init);
-	mem_free(image_path_unversioned);
-	mem_free(out_image_path_versioned);
-	mem_free(out_file);
+	mem_free0(cfg.name);
+	mem_free0(cfg.upstream_version);
+	mem_free0(cfg.mounts);
+	mem_free0(description.en);
+	mem_free0(description.de);
+	mem_free0(init);
+	mem_free0(image_path_unversioned);
+	mem_free0(out_image_path_versioned);
+	mem_free0(out_file);
 
 	return ret;
 }
@@ -284,20 +284,20 @@ merge_layers_new(docker_manifest_t *manifest, char *in_path, char *out_path, cha
 		INFO("Extracting layer[%d]: %s", i, layer_file_name);
 		if (-1 == util_tar_extract(layer_file_name, extracted_image_path)) {
 			ERROR_ERRNO("Failed to extract %s", layer_file_name);
-			mem_free(layer_file_name);
+			mem_free0(layer_file_name);
 			goto out;
 		}
-		mem_free(layer_file_name);
+		mem_free0(layer_file_name);
 	}
 	image_file = mem_printf("%s/%s", target_image_path, IMAGE_NAME_ROOT);
 	if (util_squash_image(extracted_image_path, image_file) < 0) {
-		mem_free(image_file);
+		mem_free0(image_file);
 		image_file = NULL;
 		goto out;
 	}
 out:
-	mem_free(extracted_image_path);
-	mem_free(target_image_path);
+	mem_free0(extracted_image_path);
+	mem_free0(target_image_path);
 	return image_file;
 }
 
@@ -424,8 +424,8 @@ main(UNUSED int argc, char **argv)
 		}
 		docker_set_host_url(url);
 		docker_generate_basic_auth(user, password, token_file);
-		mem_free(token_file);
-		mem_free(docker_image_path);
+		mem_free0(token_file);
+		mem_free0(docker_image_path);
 		return 0;
 	}
 
@@ -449,7 +449,7 @@ main(UNUSED int argc, char **argv)
 
 	ml = docker_parse_manifest_list_new(buf);
 
-	mem_free(buf);
+	mem_free0(buf);
 	buf = NULL;
 
 	for (int i = 0; i < ml->manifests_size; ++i) {
@@ -489,7 +489,7 @@ main(UNUSED int argc, char **argv)
 
 	manifest = docker_parse_manifest_new(buf);
 
-	mem_free(buf);
+	mem_free0(buf);
 	buf = NULL;
 
 	if (docker_download_image(token, manifest, docker_image_path, image_name, image_tag) < 0) {
@@ -532,39 +532,39 @@ main(UNUSED int argc, char **argv)
 
 	write_guestos_config(config, trustx_image_file, trustx_image_path, image_name, image_tag);
 
-	mem_free(manifest_list_file);
-	mem_free(manifest_file);
-	mem_free(docker_image_path);
-	mem_free(trustx_image_path);
-	mem_free(trustx_image_file);
+	mem_free0(manifest_list_file);
+	mem_free0(manifest_file);
+	mem_free0(docker_image_path);
+	mem_free0(trustx_image_path);
+	mem_free0(trustx_image_file);
 
 	docker_manifest_free(manifest);
 	docker_config_free(config);
 
-	mem_free(token_file);
-	mem_free(token);
+	mem_free0(token_file);
+	mem_free0(token);
 	return 0;
 
 err:
 	INFO("Cleaning up token_file: %s", token_file);
 	if (file_exists(token_file))
 		remove(token_file);
-	mem_free(token_file);
+	mem_free0(token_file);
 	if (token)
-		mem_free(token);
+		mem_free0(token);
 
 	if (manifest_list_file)
-		mem_free(manifest_list_file);
+		mem_free0(manifest_list_file);
 	if (manifest_url_digest)
-		mem_free(manifest_url_digest);
+		mem_free0(manifest_url_digest);
 	if (manifest_file)
-		mem_free(manifest_file);
+		mem_free0(manifest_file);
 	if (docker_image_path)
-		mem_free(docker_image_path);
+		mem_free0(docker_image_path);
 	if (trustx_image_path)
-		mem_free(trustx_image_path);
+		mem_free0(trustx_image_path);
 	if (trustx_image_file)
-		mem_free(trustx_image_file);
+		mem_free0(trustx_image_file);
 
 	if (manifest)
 		docker_manifest_free(manifest);

--- a/converter/docker.c
+++ b/converter/docker.c
@@ -50,19 +50,19 @@ static void
 docker_remote_file_free(docker_remote_file_t *rf)
 {
 	if (rf->media_type)
-		mem_free(rf->media_type);
+		mem_free0(rf->media_type);
 	if (rf->digest_algorithm)
-		mem_free(rf->digest_algorithm);
+		mem_free0(rf->digest_algorithm);
 	// strtok sub pointer
 	//if (rf->digest)
-	//	mem_free(rf->digest);
+	//	mem_free0(rf->digest);
 	if (rf->suffix)
-		mem_free(rf->suffix);
+		mem_free0(rf->suffix);
 	if (rf->platform_arch)
-		mem_free(rf->platform_arch);
+		mem_free0(rf->platform_arch);
 	if (rf->platform_variant)
-		mem_free(rf->platform_variant);
-	mem_free(rf);
+		mem_free0(rf->platform_variant);
+	mem_free0(rf);
 }
 
 static docker_remote_file_t *
@@ -129,7 +129,7 @@ docker_parse_manifest_list_new(const char *raw_file_buffer)
 			ml->manifests[0]->platform_arch = mem_strdup(jarchitecture->valuestring);
 		} else {
 			ERROR("Unsuported schema verison = %d", ml->schema_version);
-			mem_free(ml);
+			mem_free0(ml);
 			ml = NULL;
 			goto out;
 		}
@@ -140,7 +140,7 @@ docker_parse_manifest_list_new(const char *raw_file_buffer)
 		ml->manifests_size = cJSON_GetArraySize(jmanifests);
 		if (ml->manifests_size < 0) {
 			ERROR("No manifests in list");
-			mem_free(ml);
+			mem_free0(ml);
 			ml = NULL;
 			goto out;
 		}
@@ -159,7 +159,7 @@ docker_parse_manifest_list_new(const char *raw_file_buffer)
 	}
 	default:
 		ERROR("Unsuported schema verison = %d", ml->schema_version);
-		mem_free(ml);
+		mem_free0(ml);
 		ml = NULL;
 	}
 out:
@@ -171,12 +171,12 @@ void
 docker_manifest_list_free(docker_manifest_list_t *ml)
 {
 	if (ml->media_type)
-		mem_free(ml->media_type);
+		mem_free0(ml->media_type);
 	for (int i = 0; i < ml->manifests_size; ++i) {
 		if (ml->manifests[i])
 			docker_remote_file_free(ml->manifests[i]);
 	}
-	mem_free(ml);
+	mem_free0(ml);
 }
 
 docker_manifest_t *
@@ -215,7 +215,7 @@ void
 docker_manifest_free(docker_manifest_t *manifest)
 {
 	if (manifest->media_type)
-		mem_free(manifest->media_type);
+		mem_free0(manifest->media_type);
 
 	if (manifest->config)
 		docker_remote_file_free(manifest->config);
@@ -224,7 +224,7 @@ docker_manifest_free(docker_manifest_t *manifest)
 		if (manifest->layers[i])
 			docker_remote_file_free(manifest->layers[i]);
 	}
-	mem_free(manifest);
+	mem_free0(manifest);
 }
 
 docker_config_t *
@@ -324,41 +324,41 @@ void
 docker_config_free(docker_config_t *cfg)
 {
 	if (cfg->hostname)
-		mem_free(cfg->hostname);
+		mem_free0(cfg->hostname);
 	if (cfg->domainname)
-		mem_free(cfg->domainname);
+		mem_free0(cfg->domainname);
 	if (cfg->user)
-		mem_free(cfg->user);
+		mem_free0(cfg->user);
 
 	for (list_t *l = cfg->exposedports_list; l; l = l->next) {
-		mem_free(l->data);
+		mem_free0(l->data);
 	}
 	list_delete(cfg->exposedports_list);
 
 	if (cfg->env) {
 		for (int i = 0; i < cfg->env_size; ++i)
-			mem_free(cfg->env[i]);
-		mem_free(cfg->env);
+			mem_free0(cfg->env[i]);
+		mem_free0(cfg->env);
 	}
 
 	if (cfg->cmd) {
 		for (int i = 0; i < cfg->cmd_size; ++i)
-			mem_free(cfg->cmd[i]);
-		mem_free(cfg->cmd);
+			mem_free0(cfg->cmd[i]);
+		mem_free0(cfg->cmd);
 	}
 
 	if (cfg->entrypoint) {
 		for (int i = 0; i < cfg->entrypoint_size; ++i)
-			mem_free(cfg->entrypoint[i]);
-		mem_free(cfg->entrypoint);
+			mem_free0(cfg->entrypoint[i]);
+		mem_free0(cfg->entrypoint);
 	}
 
 	for (list_t *l = cfg->labels_list; l; l = l->next) {
-		mem_free(l->data);
+		mem_free0(l->data);
 	}
 	list_delete(cfg->labels_list);
 
-	mem_free(cfg);
+	mem_free0(cfg);
 }
 
 void
@@ -390,10 +390,10 @@ docker_generate_basic_auth(const char *user, const char *password, const char *t
 		file_printf(token_file, "{ \"token\": \"%s\" }", out);
 	}
 
-	mem_free(in);
-	mem_free(out);
-	mem_free(auth);
-	mem_free(url);
+	mem_free0(in);
+	mem_free0(out);
+	mem_free0(auth);
+	mem_free0(url);
 
 	return ret;
 }
@@ -424,7 +424,7 @@ docker_get_curl_token_new(char *image_name, char *token_file)
 	char *token = mem_strdup(jtoken->valuestring);
 	//DEBUG("token: %s", token);
 
-	mem_free(url);
+	mem_free0(url);
 	cJSON_Delete(jroot);
 	return token;
 }
@@ -452,9 +452,9 @@ docker_download_manifest_list(const char *curl_token, const char *out_file, cons
 		ret = proc_fork_and_execvp(argv_basic);
 	}
 
-	mem_free(url);
-	mem_free(auth_basic);
-	mem_free(auth_bearer);
+	mem_free0(url);
+	mem_free0(auth_basic);
+	mem_free0(auth_bearer);
 	return ret;
 }
 
@@ -484,9 +484,9 @@ docker_download_manifest(const char *curl_token, const char *out_file, const cha
 		ret = proc_fork_and_execvp(argv_basic);
 	}
 
-	mem_free(url);
-	mem_free(auth_basic);
-	mem_free(auth_bearer);
+	mem_free0(url);
+	mem_free0(auth_basic);
+	mem_free0(auth_bearer);
 	return ret;
 }
 
@@ -503,10 +503,10 @@ download_docker_remote_file(const char *curl_token, const docker_remote_file_t *
 		image_hash = util_hash_sha256_image_file_new(out_file);
 		if (!strncmp(image_hash, rf->digest, strlen(image_hash))) {
 			INFO("File %s already downloaded!", rf->digest);
-			mem_free(image_hash);
+			mem_free0(image_hash);
 			return ret;
 		}
-		mem_free(image_hash);
+		mem_free0(image_hash);
 	}
 
 	//char *url = mem_printf("https://registry-1.docker.io/v2/library/%s/blobs/%s:%s",
@@ -525,9 +525,9 @@ download_docker_remote_file(const char *curl_token, const docker_remote_file_t *
 	if (ret != 0)
 		ret = proc_fork_and_execvp(argv_basic);
 
-	mem_free(url);
-	mem_free(auth_basic);
-	mem_free(auth_bearer);
+	mem_free0(url);
+	mem_free0(auth_basic);
+	mem_free0(auth_bearer);
 
 	if (ret < 0) {
 		ERROR("Download failed!");
@@ -542,7 +542,7 @@ download_docker_remote_file(const char *curl_token, const docker_remote_file_t *
 	INFO("Download of file %s completed!", rf->digest);
 
 	if (image_hash)
-		mem_free(image_hash);
+		mem_free0(image_hash);
 
 	return ret;
 }

--- a/converter/util.c
+++ b/converter/util.c
@@ -72,7 +72,7 @@
 //    	char value = mem_strdup(owner_info);
 //    	hashmapPut(pseudo_file_map, key, value);
 //    } else {
-//	mem_free(old_owner_info);
+//	mem_free0(old_owner_info);
 //	*old_owner_info = owner_info;
 //    }
 //}

--- a/daemon/c_audit.c
+++ b/daemon/c_audit.c
@@ -77,7 +77,7 @@ c_audit_set_contid(c_audit_t *audit)
 	INFO("Set audit container ID '%llu'",
 	     (unsigned long long)uuid_get_node(container_get_uuid(audit->container)));
 out:
-	mem_free(aucontid_file);
+	mem_free0(aucontid_file);
 	return ret;
 }
 
@@ -135,7 +135,7 @@ c_audit_set_last_ack(c_audit_t *audit, const char *last_ack)
 	ASSERT(last_ack);
 
 	if (audit->last_ack)
-		mem_free(audit->last_ack);
+		mem_free0(audit->last_ack);
 
 	audit->last_ack = mem_strdup(last_ack);
 }

--- a/daemon/c_cap.c
+++ b/daemon/c_cap.c
@@ -171,7 +171,7 @@ c_cap_do_exec_cap_systime(const container_t *container, char *const *argv)
 			else if (file_exists("/lib/libc.so.6") &&
 				 symlink("/lib/libc.so.6", "/usr/lib/libc.so"))
 				WARN_ERRNO("symlink to libc.so failed!");
-			mem_free(multiarch_dir);
+			mem_free0(multiarch_dir);
 		}
 		execve(argv[0], argv, env_ntp);
 		ERROR_ERRNO("exec with uid_wrapper of '%s' failed!", argv[0]);
@@ -193,7 +193,7 @@ c_cap_exec_cap_systime_sigchld_cb(UNUSED int signum, event_signal_t *sig, void *
 		TRACE("Reaped exec_cap_systime process: %d", *pid);
 		event_remove_signal(sig);
 		event_signal_free(sig);
-		mem_free(pid);
+		mem_free0(pid);
 	} else {
 		TRACE("Failed to reap exec_cap_systime process");
 	}
@@ -224,7 +224,7 @@ c_cap_exec_cap_systime(const container_t *container, char *const *argv)
 				      uid_wrapper_lib);
 			if (chmod(uid_wrapper_lib, 0755))
 				WARN_ERRNO("Could not set %s executeable", uid_wrapper_lib);
-			mem_free(uid_wrapper_lib);
+			mem_free0(uid_wrapper_lib);
 		}
 		// join container namespace but maintain root user ns
 		if (ns_join_all(container_get_pid(container), false) < 0) {

--- a/daemon/c_fifo.c
+++ b/daemon/c_fifo.c
@@ -100,7 +100,7 @@ c_fifo_create_fifos(c_fifo_t *fifo, container_t *container)
 		char *fifo_path = mem_printf("%s/%s", fifo_dir, current_fifo);
 		if (0 != mkfifo(fifo_path, 666)) {
 			ERROR_ERRNO("Failed to create fifo at %s", fifo_path);
-			mem_free(fifo_path);
+			mem_free0(fifo_path);
 			audit_log_event(container_get_uuid(fifo->container), FSA, CMLD,
 					CONTAINER_ISOLATION, "create-fifo",
 					uuid_string(container_get_uuid(fifo->container)), 2, "name",
@@ -119,7 +119,7 @@ c_fifo_create_fifos(c_fifo_t *fifo, container_t *container)
 					uuid_string(container_get_uuid(fifo->container)), 2, "path",
 					fifo_path);
 			ERROR("Failed to chown fifo dir to %d", uid);
-			mem_free(fifo_path);
+			mem_free0(fifo_path);
 			goto error;
 		}
 
@@ -129,15 +129,15 @@ c_fifo_create_fifos(c_fifo_t *fifo, container_t *container)
 				fifo_path);
 		DEBUG("Chowned FIFO at %s to %d", fifo_path ? fifo_path : "NULL", uid);
 
-		mem_free(fifo_path);
+		mem_free0(fifo_path);
 	}
 
-	mem_free(fifo_dir);
+	mem_free0(fifo_dir);
 
 	return 0;
 
 error:
-	mem_free(fifo_dir);
+	mem_free0(fifo_dir);
 	return -1;
 }
 

--- a/daemon/c_net.c
+++ b/daemon/c_net.c
@@ -174,13 +174,13 @@ c_net_get_next_ipv4_cmld_addr(int offset, struct in_addr *ipv4_addr)
 	}
 
 	if (!inet_aton(ipv4_next, ipv4_addr)) {
-		mem_free(ipv4_next);
+		mem_free0(ipv4_next);
 		ERROR("failed to determine free ip address");
 		return -1;
 	}
 
 	DEBUG("next free ip cmld address is: %s", ipv4_next);
-	mem_free(ipv4_next);
+	mem_free0(ipv4_next);
 	return 0;
 }
 
@@ -221,13 +221,13 @@ c_net_get_next_ipv4_cont_addr(int offset, struct in_addr *ipv4_addr)
 	}
 
 	if (!inet_aton(ipv4_next, ipv4_addr)) {
-		mem_free(ipv4_next);
+		mem_free0(ipv4_next);
 		ERROR("failed to determine free ip address");
 		return -1;
 	}
 
 	DEBUG("next free ipv4 container address is: %s", ipv4_next);
-	mem_free(ipv4_next);
+	mem_free0(ipv4_next);
 	return 0;
 }
 
@@ -260,11 +260,11 @@ c_net_is_veth_used(const char *if_name)
 			if (!strncmp(dp->d_name, if_name, IFNAMSIZ)) {
 				DEBUG("veth %s is occupied", if_name);
 				closedir(dirp);
-				mem_free(path);
+				mem_free0(path);
 				return 1;
 			}
 		}
-		mem_free(path);
+		mem_free0(path);
 	}
 
 	DEBUG("veth %s is free", if_name);
@@ -516,7 +516,7 @@ c_net_mac_filter(const char *if_name, list_t *mac_whitelist, bool apply)
 		if (ret) {
 			char *mac_str = network_mac_addr_to_str_new(mac);
 			ERROR("Failed to allow %s on %s", mac_str, if_name);
-			mem_free(mac_str);
+			mem_free0(mac_str);
 			return -1;
 		}
 	}
@@ -594,9 +594,9 @@ c_net_bridge_ifi(const char *if_name, list_t *mac_whitelist, const pid_t pid)
 		goto err_port;
 	}
 
-	mem_free(br_cmld_name);
-	mem_free(veth_cmld_name);
-	mem_free(veth_cont_name);
+	mem_free0(br_cmld_name);
+	mem_free0(veth_cmld_name);
+	mem_free0(veth_cont_name);
 
 	return 0;
 
@@ -607,9 +607,9 @@ err_br:
 	network_delete_link(veth_cont_name);
 	network_set_flag(if_name, IFF_DOWN);
 err:
-	mem_free(br_cmld_name);
-	mem_free(veth_cmld_name);
-	mem_free(veth_cont_name);
+	mem_free0(br_cmld_name);
+	mem_free0(veth_cmld_name);
+	mem_free0(veth_cont_name);
 
 	return -1;
 }
@@ -652,9 +652,9 @@ c_net_unbridge_ifi(const char *if_name, list_t *mac_whitelist, const pid_t pid)
 	if (-1 == c_net_mac_filter(if_name, mac_whitelist, false))
 		WARN("Failed apply mac_filter to %s", if_name);
 
-	mem_free(br_cmld_name);
-	mem_free(veth_cmld_name);
-	mem_free(veth_cont_name);
+	mem_free0(br_cmld_name);
+	mem_free0(veth_cmld_name);
+	mem_free0(veth_cont_name);
 
 	return 0;
 }
@@ -705,8 +705,8 @@ c_net_add_interface(c_net_t *net, container_pnet_cfg_t *pnet_cfg)
 	     container_get_name(net->container));
 	return 0;
 err:
-	mem_free(if_name);
-	mem_free(pnet_cfg);
+	mem_free0(if_name);
+	mem_free0(pnet_cfg);
 	return -1;
 }
 
@@ -731,14 +731,14 @@ c_net_remove_interface(c_net_t *net, const char *if_name_mac)
 					 mem_strdup(_cfg->pnet_name);
 		if (strcmp(if_name, _if_name)) {
 			cfg = _cfg;
-			mem_free(_if_name);
+			mem_free0(_if_name);
 			break;
 		}
-		mem_free(_if_name);
+		mem_free0(_if_name);
 	}
 
 	if (NULL == cfg) {
-		mem_free(if_name);
+		mem_free0(if_name);
 		return 0;
 	}
 
@@ -754,11 +754,11 @@ c_net_remove_interface(c_net_t *net, const char *if_name_mac)
 	container_pnet_cfg_free(cfg);
 
 	cmld_netif_phys_add_by_name(if_name);
-	mem_free(if_name);
+	mem_free0(if_name);
 	return 0;
 
 err:
-	mem_free(if_name);
+	mem_free0(if_name);
 	return -1;
 }
 
@@ -930,12 +930,12 @@ c_net_udhcpd_start(c_net_interface_t *ni)
 		event_add_signal(sigchld);
 	}
 out:
-	mem_free(lease_file);
-	mem_free(pid_file);
-	mem_free(run_dir);
-	mem_free(conf_file);
-	mem_free(ipv4_start);
-	mem_free(ipv4_end);
+	mem_free0(lease_file);
+	mem_free0(pid_file);
+	mem_free0(run_dir);
+	mem_free0(conf_file);
+	mem_free0(ipv4_start);
+	mem_free0(ipv4_end);
 
 	return (bytes_written > 0) ? 0 : -1;
 }
@@ -1011,11 +1011,11 @@ err:
 				TRACE("network interface %s could not be destroyed",
 				      ni->veth_cmld_name);
 		}
-		mem_free(ni->veth_cmld_name);
+		mem_free0(ni->veth_cmld_name);
 		ni->veth_cmld_name = NULL;
 	}
 	if (ni->veth_cont_name) {
-		mem_free(ni->veth_cont_name);
+		mem_free0(ni->veth_cont_name);
 		ni->veth_cont_name = NULL;
 	}
 	return -1;
@@ -1073,7 +1073,7 @@ c_net_start_post_clone_interface(pid_t pid, c_net_interface_t *ni)
 		if (network_rename_ifi(ni->veth_cmld_name, hardware_get_radio_ifname()))
 			return -1;
 
-		mem_free(ni->veth_cmld_name);
+		mem_free0(ni->veth_cmld_name);
 		ni->veth_cmld_name = mem_strdup(hardware_get_radio_ifname());
 	}
 
@@ -1095,7 +1095,7 @@ c_net_helper_sigchild_cb(UNUSED int signum, event_signal_t *sig, void *data)
 		/* remove the sigchld callback for this container from the event loop */
 		event_remove_signal(sig);
 		event_signal_free(sig);
-		mem_free(c0_netns_pid);
+		mem_free0(c0_netns_pid);
 	} else {
 		TRACE("Failed to reap c0 netns helper process");
 	}
@@ -1167,7 +1167,7 @@ c_net_start_post_clone(c_net_t *net)
 	*c0_netns_pid = fork();
 	if (*c0_netns_pid == -1) {
 		ERROR_ERRNO("Could not fork for switching to c0's netns");
-		mem_free(c0_netns_pid);
+		mem_free0(c0_netns_pid);
 		return -1;
 	} else if (*c0_netns_pid == 0) {
 		const char *hostns = cmld_containers_get_c0() ? "c0" : "CML";
@@ -1179,7 +1179,7 @@ c_net_start_post_clone(c_net_t *net)
 			char *c0_netns = mem_printf("/proc/%d/ns/net",
 						    container_get_pid(cmld_containers_get_c0()));
 			int netns_fd = open(c0_netns, O_RDONLY);
-			mem_free(c0_netns);
+			mem_free0(c0_netns);
 			if (netns_fd == -1)
 				FATAL_ERRNO("Could not open netns file of c0");
 			if (setns(netns_fd, CLONE_NEWNET) == -1)
@@ -1363,7 +1363,7 @@ c_net_cleanup_interface(c_net_interface_t *ni)
 	c_net_unset_offset(ni->cont_offset);
 
 	if (ni->subnet) {
-		mem_free(ni->subnet);
+		mem_free0(ni->subnet);
 		ni->subnet = NULL;
 	}
 	memset(&ni->ipv4_cmld_addr, 0, sizeof(struct in_addr));
@@ -1371,11 +1371,11 @@ c_net_cleanup_interface(c_net_interface_t *ni)
 	memset(&ni->ipv4_bc_addr, 0, sizeof(struct in_addr));
 
 	if (ni->veth_cmld_name) {
-		mem_free(ni->veth_cmld_name);
+		mem_free0(ni->veth_cmld_name);
 		ni->veth_cmld_name = NULL;
 	}
 	if (ni->veth_cont_name) {
-		mem_free(ni->veth_cont_name);
+		mem_free0(ni->veth_cont_name);
 		ni->veth_cont_name = NULL;
 	}
 }
@@ -1393,7 +1393,7 @@ c_net_cleanup_c0(c_net_t *net)
 	*c0_netns_pid = fork();
 	if (*c0_netns_pid == -1) {
 		ERROR_ERRNO("Could not fork for switching to c0's netns");
-		mem_free(c0_netns_pid);
+		mem_free0(c0_netns_pid);
 		return -1;
 	} else if (*c0_netns_pid == 0) {
 		const char *hostns = cmld_containers_get_c0() ? "c0" : "CML";
@@ -1472,7 +1472,7 @@ c_net_cleanup(c_net_t *net, bool is_rebooting)
 			      container_get_name(net->container));
 			if (-1 == c_net_unbridge_ifi(if_name, cfg->mac_whitelist, -1))
 				WARN("Failed to remove phys if %s", if_name);
-			mem_free(if_name);
+			mem_free0(if_name);
 		}
 	}
 
@@ -1489,11 +1489,11 @@ c_net_free_interface(c_net_interface_t *ni)
 	ASSERT(ni);
 
 	if (ni->subnet)
-		mem_free(ni->subnet);
-	mem_free(ni->veth_cmld_name);
-	mem_free(ni->veth_cont_name);
-	mem_free(ni->nw_name);
-	mem_free(ni);
+		mem_free0(ni->subnet);
+	mem_free0(ni->veth_cmld_name);
+	mem_free0(ni->veth_cont_name);
+	mem_free0(ni->nw_name);
+	mem_free0(ni);
 }
 
 /**
@@ -1514,8 +1514,8 @@ c_net_free(c_net_t *net)
 		container_pnet_cfg_free(pnet);
 	}
 	list_delete(net->pnet_mv_list);
-	mem_free(net->ns_path);
-	mem_free(net);
+	mem_free0(net->ns_path);
+	mem_free0(net);
 }
 
 char *

--- a/daemon/c_net.test.c
+++ b/daemon/c_net.test.c
@@ -140,12 +140,12 @@ main(void)
 	DEBUG("offset checking done");
 
 	list_delete(nw_name_list);
-	mem_free(real_cmld_ip_string);
-	mem_free(real_cont_ip_string);
-	mem_free(real_bc_ip_string);
-	mem_free(cmld_ip_string);
-	mem_free(cont_ip_string);
-	mem_free(bc_ip_string);
+	mem_free0(real_cmld_ip_string);
+	mem_free0(real_cont_ip_string);
+	mem_free0(real_bc_ip_string);
+	mem_free0(cmld_ip_string);
+	mem_free0(cont_ip_string);
+	mem_free0(bc_ip_string);
 	container_free(cont0);
 	c_net_free(net0);
 	container_free(cont1);

--- a/daemon/c_run.c
+++ b/daemon/c_run.c
@@ -138,18 +138,18 @@ c_run_session_free(c_run_session_t *session)
 {
 	ASSERT(session);
 	if (session->cmd)
-		mem_free(session->cmd);
+		mem_free0(session->cmd);
 	if (session->pty_slave_name)
-		mem_free(session->pty_slave_name);
+		mem_free0(session->pty_slave_name);
 	mem_free_array((void *)session->argv, session->argc);
-	mem_free(session);
+	mem_free0(session);
 }
 
 void
 c_run_free(c_run_t *run)
 {
 	ASSERT(run);
-	mem_free(run);
+	mem_free0(run);
 }
 
 static void

--- a/daemon/c_service.c
+++ b/daemon/c_service.c
@@ -71,7 +71,7 @@ c_service_send_container_cfg_name_proto(c_service_t *service)
 
 	ret = protobuf_send_message(service->sock_connected, (ProtobufCMessage *)&message_proto);
 
-	mem_free(message_proto.container_cfg_name);
+	mem_free0(message_proto.container_cfg_name);
 	return ret;
 }
 
@@ -93,7 +93,7 @@ c_service_send_container_cfg_dns_proto(c_service_t *service)
 
 	ret = protobuf_send_message(service->sock_connected, (ProtobufCMessage *)&message_proto);
 
-	mem_free(message_proto.container_cfg_dns);
+	mem_free0(message_proto.container_cfg_dns);
 	return ret;
 }
 
@@ -302,7 +302,7 @@ c_service_free(c_service_t *service)
 	ASSERT(service);
 
 	c_service_cleanup(service);
-	mem_free(service);
+	mem_free0(service);
 }
 
 int

--- a/daemon/c_time.c
+++ b/daemon/c_time.c
@@ -71,7 +71,7 @@ c_time_get_creation_time_from_file(c_time_t *_time)
 	INFO("container %s was created at %s", uuid_string(container_get_uuid(_time->container)),
 	     ctime(&ret));
 
-	mem_free(file_name_created);
+	mem_free0(file_name_created);
 	return ret;
 }
 
@@ -98,7 +98,7 @@ void
 c_time_free(c_time_t *time)
 {
 	ASSERT(time);
-	mem_free(time);
+	mem_free0(time);
 }
 
 int
@@ -144,10 +144,10 @@ c_time_start_pre_exec(const c_time_t *time)
 	}
 	INFO("Successfully updated timens offsets in new time namespace");
 
-	mem_free(path_timens_offsets);
+	mem_free0(path_timens_offsets);
 	return 0;
 error:
-	mem_free(path_timens_offsets);
+	mem_free0(path_timens_offsets);
 	return -1;
 }
 

--- a/daemon/c_user.c
+++ b/daemon/c_user.c
@@ -176,7 +176,7 @@ c_user_set_next_uid_range_start(c_user_t *user)
 	user->uid_start = UID_RANGES_START + (user->offset * UID_RANGE);
 	DEBUG("Next free uid/gid map start is: %u", user->uid_start);
 
-	mem_free(file_name_uid);
+	mem_free0(file_name_uid);
 	return 0;
 }
 
@@ -184,9 +184,9 @@ static void
 c_user_shift_free(struct c_user_shift *s)
 {
 	IF_NULL_RETURN_ERROR(s);
-	mem_free(s->target);
-	mem_free(s->mark);
-	mem_free(s);
+	mem_free0(s->target);
+	mem_free0(s->mark);
+	mem_free0(s);
 }
 
 /**
@@ -240,14 +240,14 @@ c_user_setup_mapping(const c_user_t *user)
 	INFO("uid/gid mapping '%s' for %s activated", uid_mapping,
 	     container_get_name(user->container));
 
-	mem_free(uid_mapping);
-	mem_free(uid_map_path);
-	mem_free(gid_map_path);
+	mem_free0(uid_mapping);
+	mem_free0(uid_map_path);
+	mem_free0(gid_map_path);
 	return 0;
 error:
-	mem_free(uid_mapping);
-	mem_free(uid_map_path);
-	mem_free(gid_map_path);
+	mem_free0(uid_mapping);
+	mem_free0(uid_map_path);
+	mem_free0(gid_map_path);
 	return -1;
 }
 
@@ -258,14 +258,14 @@ c_user_cleanup_marks_cb(const char *path, const char *file, UNUSED void *data)
 	if (file_is_mountpoint(mark)) {
 		if (umount2(mark, MNT_DETACH) < 0) {
 			WARN_ERRNO("Could not umount shift mark on %s", mark);
-			mem_free(mark);
+			mem_free0(mark);
 			return -1;
 		}
 		if (rmdir(mark) < 0)
 			TRACE("Unable to remove %s", mark);
 		INFO("Cleanup mark '%s' done.", mark);
 	}
-	mem_free(mark);
+	mem_free0(mark);
 	return 0;
 }
 
@@ -301,7 +301,7 @@ c_user_cleanup(c_user_t *user, bool is_rebooting)
 		WARN("Could not release marks in '%s'", path);
 	if (rmdir(path) < 0)
 		TRACE("Unable to remove %s", path);
-	mem_free(path);
+	mem_free0(path);
 }
 
 /**
@@ -311,8 +311,8 @@ void
 c_user_free(c_user_t *user)
 {
 	ASSERT(user);
-	mem_free(user->ns_path);
-	mem_free(user);
+	mem_free0(user->ns_path);
+	mem_free0(user);
 }
 
 int
@@ -332,7 +332,7 @@ c_user_chown_dev_cb(const char *path, const char *file, void *data)
 
 	char *file_to_chown = mem_printf("%s/%s", path, file);
 	if (lstat(file_to_chown, &s) == -1) {
-		mem_free(file_to_chown);
+		mem_free0(file_to_chown);
 		return -1;
 	}
 
@@ -365,7 +365,7 @@ c_user_chown_dev_cb(const char *path, const char *file, void *data)
 		ERROR_ERRNO("Could not chown dir '%s' to (%d:%d)", path, uid, gid);
 		ret--;
 	}
-	mem_free(file_to_chown);
+	mem_free0(file_to_chown);
 	return ret;
 }
 
@@ -592,15 +592,15 @@ c_user_shift_mounts(const c_user_t *user)
 	}
 
 	if (target_dev)
-		mem_free(target_dev);
+		mem_free0(target_dev);
 	if (saved_dev)
-		mem_free(saved_dev);
+		mem_free0(saved_dev);
 	return 0;
 error:
 	if (target_dev)
-		mem_free(target_dev);
+		mem_free0(target_dev);
 	if (saved_dev)
-		mem_free(saved_dev);
+		mem_free0(saved_dev);
 	return -1;
 }
 

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -362,7 +362,7 @@ cmld_set_device_provisioned(void)
 			return -1;
 		}
 	}
-	mem_free(provisioned_file);
+	mem_free0(provisioned_file);
 
 	cmld_device_provisioned = true;
 
@@ -452,8 +452,8 @@ cmld_load_containers_cb(const char *path, const char *name, UNUSED void *data)
 cleanup:
 	if (uuid)
 		uuid_free(uuid);
-	mem_free(dir);
-	mem_free(prefix);
+	mem_free0(dir);
+	mem_free0(prefix);
 	return res;
 }
 
@@ -479,7 +479,7 @@ cmld_reload_containers(void)
 	char *path = mem_printf("%s/%s", cmld_path, CMLD_PATH_CONTAINERS_DIR);
 	ret = cmld_load_containers(path);
 
-	mem_free(path);
+	mem_free0(path);
 	return ret;
 }
 
@@ -516,10 +516,10 @@ cmld_rename_logfiles()
 				else
 					DEBUG("Rename successful %s -> %s", old_filename_with_path,
 					      new_filename_with_path);
-				mem_free(filename_with_old_timestamp);
-				mem_free(filename_with_correct_timestamp);
-				mem_free(old_filename_with_path);
-				mem_free(new_filename_with_path);
+				mem_free0(filename_with_old_timestamp);
+				mem_free0(filename_with_correct_timestamp);
+				mem_free0(old_filename_with_path);
+				mem_free0(new_filename_with_path);
 			}
 		}
 		closedir(directory);
@@ -569,7 +569,7 @@ cmld_init_control_cb(container_t *container, container_callback_t *cb, void *dat
 			INFO("Create unpriv control socket for %s",
 			     container_get_description(container));
 		}
-		mem_free(control_sock_p);
+		mem_free0(control_sock_p);
 		container_unregister_observer(container, cb);
 	}
 	// TODO think about if this is unregistered correctly in corner cases...
@@ -717,7 +717,7 @@ cmld_init_c0_cb(container_t *container, container_callback_t *cb, void *data)
 	if (state == CONTAINER_STATE_BOOTING || state == CONTAINER_STATE_RUNNING) {
 		/* Initialize control interface on the socket previously bound into c0 */
 		cmld_control_gui = control_new(*control_sock_p, true);
-		mem_free(control_sock_p);
+		mem_free0(control_sock_p);
 		container_unregister_observer(container, cb);
 	}
 	// TODO think about if this is unregistered correctly in corner cases...
@@ -894,11 +894,11 @@ cmld_init_c0(const char *path, const char *c0os)
 	/* store c0 as first element of the cmld_containers_list */
 	cmld_containers_list = list_prepend(cmld_containers_list, new_c0);
 
-	mem_free(c0_images_folder);
+	mem_free0(c0_images_folder);
 
 out:
 	uuid_free(c0_uuid);
-	mem_free(c0_config_file);
+	mem_free0(c0_config_file);
 
 	return 0;
 }
@@ -999,7 +999,7 @@ cmld_init(const char *path)
 	char *users_path = mem_printf("%s/%s", path, CMLD_PATH_USERS_DIR);
 	if (mkdir(users_path, 0700) < 0 && errno != EEXIST)
 		FATAL_ERRNO("Could not mkdir users directory %s", users_path);
-	mem_free(users_path);
+	mem_free0(users_path);
 
 	const char *device_path = DEFAULT_CONF_BASE_PATH "/" CMLD_PATH_DEVICE_CONF;
 	device_config_t *device_config = device_config_new(device_path);
@@ -1052,7 +1052,7 @@ cmld_init(const char *path)
 
 	char *btime = mem_printf("%lld", (long long)time_cml(NULL));
 	audit_log_event(NULL, SSA, CMLD, GENERIC, "boot-time", NULL, 2, "time", btime);
-	mem_free(btime);
+	mem_free0(btime);
 
 	if (uevent_init() < 0)
 		FATAL("Could not init uevent module");
@@ -1083,7 +1083,7 @@ cmld_init(const char *path)
 	} else {
 		DEBUG("Device is not yet provisioned and provision-status-file does not yet exist");
 	}
-	mem_free(provisioned_file);
+	mem_free0(provisioned_file);
 
 	/* the control module sets up a local or remote socket, registers a
 	 * callback (via event_) and parses incoming commands
@@ -1114,13 +1114,13 @@ cmld_init(const char *path)
 
 	char *tokens_path = mem_printf("%s/%s", path, CMLD_PATH_CONTAINER_KEYS_DIR);
 	cmld_smartcard = smartcard_new(tokens_path);
-	mem_free(tokens_path);
+	mem_free0(tokens_path);
 
 	char *guestos_path = mem_printf("%s/%s", path, CMLD_PATH_GUESTOS_DIR);
 	bool allow_locally_signed = device_config_get_locally_signed_images(device_config);
 	if (guestos_mgr_init(guestos_path, allow_locally_signed) < 0 && !cmld_hostedmode)
 		FATAL("Could not load guest operating systems");
-	mem_free(guestos_path);
+	mem_free0(guestos_path);
 	INFO("guestos initialized.");
 	guestos_mgr_update_images();
 
@@ -1131,7 +1131,7 @@ cmld_init(const char *path)
 	char *keys_path = mem_printf("%s/%s", path, CMLD_PATH_CONTAINER_KEYS_DIR);
 	if (mkdir(containers_path, 0700) < 0 && errno != EEXIST)
 		FATAL_ERRNO("Could not mkdir container keys directory %s", containers_path);
-	mem_free(keys_path);
+	mem_free0(keys_path);
 
 	if (cmld_smartcard == NULL)
 		FATAL("Could not connect to smartcard daemon");
@@ -1147,7 +1147,7 @@ cmld_init(const char *path)
 	if (cmld_start_c0(cmld_containers_get_c0()) < 0)
 		FATAL("Could not start c0");
 
-	mem_free(containers_path);
+	mem_free0(containers_path);
 
 	device_config_free(device_config);
 	return 0;
@@ -1192,7 +1192,7 @@ cmld_container_create_from_config(const uint8_t *config, size_t config_len, uint
 		audit_log_event(NULL, FSA, CMLD, CONTAINER_MGMT, "container-create", NULL, 0);
 		WARN("Could not create new container object from config");
 	}
-	mem_free(path);
+	mem_free0(path);
 	return c;
 }
 
@@ -1378,7 +1378,7 @@ cmld_netif_phys_remove_by_name(const char *if_name)
 		char *cmld_if_name = l->data;
 		if (0 == strcmp(if_name, cmld_if_name)) {
 			found = l;
-			mem_free(cmld_if_name);
+			mem_free0(cmld_if_name);
 			break;
 		}
 	}
@@ -1411,7 +1411,7 @@ cmld_is_shiftfs_supported(void)
 {
 	char *fses = file_read_new(PROC_FSES, 2048);
 	bool ret = strstr(fses, "shiftfs") ? true : false;
-	mem_free(fses);
+	mem_free0(fses);
 	return ret;
 }
 
@@ -1483,15 +1483,15 @@ cmld_cleanup(void)
 	if (cmld_smartcard)
 		smartcard_free(cmld_smartcard);
 
-	mem_free(cmld_device_uuid);
-	mem_free(cmld_device_update_base_url);
-	mem_free(cmld_device_host_dns);
-	mem_free(cmld_c0os_name);
-	mem_free(cmld_shared_data_dir);
+	mem_free0(cmld_device_uuid);
+	mem_free0(cmld_device_update_base_url);
+	mem_free0(cmld_device_host_dns);
+	mem_free0(cmld_c0os_name);
+	mem_free0(cmld_shared_data_dir);
 
 	for (list_t *l = cmld_netif_phys_list; l; l = l->next) {
 		char *name = l->data;
-		mem_free(name);
+		mem_free0(name);
 	}
 	list_delete(cmld_netif_phys_list);
 }

--- a/daemon/container.stub.c
+++ b/daemon/container.stub.c
@@ -58,8 +58,8 @@ void
 container_free(container_t *container)
 {
 	uuid_free(container->uuid);
-	mem_free((void *)container->name);
-	mem_free((void *)container);
+	mem_free0((void *)container->name);
+	mem_free0((void *)container);
 }
 
 /**

--- a/daemon/container_config.c
+++ b/daemon/container_config.c
@@ -138,7 +138,7 @@ container_config_verify(const char *prefix, uint8_t *conf_buf, size_t conf_len, 
 			sig = mem_alloc(sig_size);
 			if (-1 == file_read(sig_file, (char *)sig, sig_size)) {
 				ERROR("Failed to read sig file '%s'!", sig_file);
-				mem_free(sig);
+				mem_free0(sig);
 				sig = NULL;
 			}
 		}
@@ -147,12 +147,12 @@ container_config_verify(const char *prefix, uint8_t *conf_buf, size_t conf_len, 
 			cert = mem_alloc(cert_size);
 			if (-1 == file_read(cert_file, (char *)cert, cert_size)) {
 				ERROR("Failed to read cert file '%s'!", cert_file);
-				mem_free(cert);
+				mem_free0(cert);
 				cert = NULL;
 			}
 		}
-		mem_free(sig_file);
-		mem_free(cert_file);
+		mem_free0(sig_file);
+		mem_free0(cert_file);
 	}
 
 	// check cert and signature buffers
@@ -165,8 +165,8 @@ container_config_verify(const char *prefix, uint8_t *conf_buf, size_t conf_len, 
 out:
 	INFO("Verify Result of target with prefix '%s': %s", prefix, ret ? "GOOD" : "UNSIGNED");
 
-	mem_free(sig);
-	mem_free(cert);
+	mem_free0(sig);
+	mem_free0(cert);
 	return ret;
 }
 
@@ -195,7 +195,7 @@ container_config_new(const char *file, const uint8_t *buf, size_t len, uint8_t *
 		if (conf_len > 0) {
 			buf_internal = mem_alloc(conf_len);
 			if (-1 == file_read(file, (char *)buf_internal, conf_len)) {
-				mem_free(buf_internal);
+				mem_free0(buf_internal);
 				buf_internal = NULL;
 			}
 		}
@@ -237,8 +237,8 @@ container_config_new(const char *file, const uint8_t *buf, size_t len, uint8_t *
 	config->file = mem_strdup(file);
 	config->cfg = ccfg;
 out:
-	mem_free(buf_internal);
-	mem_free(prefix);
+	mem_free0(buf_internal);
+	mem_free0(prefix);
 	return config;
 }
 
@@ -247,8 +247,8 @@ container_config_free(container_config_t *config)
 {
 	ASSERT(config);
 	protobuf_free_message((ProtobufCMessage *)config->cfg);
-	mem_free(config->file);
-	mem_free(config);
+	mem_free0(config->file);
+	mem_free0(config);
 }
 
 int
@@ -285,7 +285,7 @@ container_config_set_name(container_config_t *config, UNUSED const char *name)
 	ASSERT(config);
 	ASSERT(config->cfg);
 	if (config->cfg->name)
-		mem_free(config->cfg->name);
+		mem_free0(config->cfg->name);
 	config->cfg->name = mem_strdup(name);
 }
 
@@ -303,7 +303,7 @@ container_config_set_guestos(container_config_t *config, const char *os)
 	ASSERT(config);
 	ASSERT(config->cfg);
 	if (config->cfg->guest_os)
-		mem_free(config->cfg->guest_os);
+		mem_free0(config->cfg->guest_os);
 	config->cfg->guest_os = mem_strdup(os);
 }
 
@@ -403,7 +403,7 @@ container_config_get_net_ifaces_list_new(const container_config_t *config)
 				if (0 != network_str_to_mac_addr(
 						 config->cfg->net_ifaces[i]->mac_filter[j],
 						 whitelisted_mac)) {
-					mem_free(whitelisted_mac);
+					mem_free0(whitelisted_mac);
 				} else {
 					mac_whitelist = list_append(mac_whitelist, whitelisted_mac);
 				}
@@ -488,7 +488,7 @@ container_config_append_net_ifaces(const container_config_t *config, const char 
 		config->cfg->net_ifaces[i] = pnet_iface;
 	}
 	if (n > 0)
-		mem_free(old_net_ifaces);
+		mem_free0(old_net_ifaces);
 
 	ContainerPnetConfig *pnet_iface = mem_new(ContainerPnetConfig, 1);
 	container_pnet_config__init(pnet_iface);
@@ -531,7 +531,7 @@ container_config_remove_net_ifaces(const container_config_t *config, const char 
 		}
 		protobuf_free_message((ProtobufCMessage *)old_net_ifaces[i]);
 	}
-	mem_free(old_net_ifaces);
+	mem_free0(old_net_ifaces);
 }
 
 list_t *

--- a/daemon/control.c
+++ b/daemon/control.c
@@ -141,7 +141,7 @@ control_send_log_file(int fd, char *log_file_name, bool read_low_level, bool sen
 			skipped_lines = true;
 			break;
 		}
-		mem_free(message.msg);
+		mem_free0(message.msg);
 	}
 	if (send_last_line_info) {
 		message.msg = mem_printf("Last line of log");
@@ -149,10 +149,10 @@ control_send_log_file(int fd, char *log_file_name, bool read_low_level, bool sen
 		if (protobuf_send_message(fd, (ProtobufCMessage *)&out) < 0) {
 			ERROR("Could not sent last line info for %s", log_file_name);
 		}
-		mem_free(message.msg);
+		mem_free0(message.msg);
 	}
 	if (out.device_uuid != NULL) {
-		mem_free(out.device_uuid);
+		mem_free0(out.device_uuid);
 	}
 	if (file_is_open) {
 		if (read_low_level) {
@@ -263,10 +263,10 @@ static void
 control_container_status_free(ContainerStatus *c_status)
 {
 	IF_NULL_RETURN(c_status);
-	mem_free(c_status->name);
-	mem_free(c_status->uuid);
-	mem_free(c_status->guestos);
-	mem_free(c_status);
+	mem_free0(c_status->name);
+	mem_free0(c_status->uuid);
+	mem_free0(c_status->guestos);
+	mem_free0(c_status);
 }
 
 static ssize_t
@@ -335,7 +335,7 @@ control_cb_read_console(int fd, unsigned events, event_io_t *io, void *data)
 		}
 
 		TRACE("Sent notification of command termination to client");
-		mem_free(cfd);
+		mem_free0(cfd);
 	}
 }
 
@@ -549,7 +549,7 @@ control_handle_cmd_list_guestos_configs(UNUSED const ControllerToDaemon *msg, in
 	}
 
 	// collect garbage
-	mem_free(results);
+	mem_free0(results);
 }
 
 /**
@@ -820,8 +820,8 @@ control_handle_message(control_t *control, const ControllerToDaemon *msg, int fd
 
 		// collect garbage
 		for (size_t i = 0; i < n; i++)
-			mem_free(results[i]);
-		mem_free(results);
+			mem_free0(results[i]);
+		mem_free0(results);
 	} break;
 
 	case CONTROLLER_TO_DAEMON__COMMAND__GET_CONTAINER_STATUS: {
@@ -850,7 +850,7 @@ control_handle_message(control_t *control, const ControllerToDaemon *msg, int fd
 		list_delete(containers);
 		for (size_t i = 0; i < n; i++)
 			control_container_status_free(results[i]);
-		mem_free(results);
+		mem_free0(results);
 	} break;
 
 	case CONTROLLER_TO_DAEMON__COMMAND__GET_CONTAINER_CONFIG: {
@@ -894,7 +894,7 @@ control_handle_message(control_t *control, const ControllerToDaemon *msg, int fd
 					TRACE("freed config time results[%zu]->vnet_configs[%zu]",
 					      number_of_configs, i);
 				}
-				mem_free(results[number_of_configs]->vnet_configs);
+				mem_free0(results[number_of_configs]->vnet_configs);
 				list_t *vnet_runtime_cfg_list =
 					container_get_vnet_runtime_cfg_new(container);
 				int vnet_config_len = list_length(vnet_runtime_cfg_list);
@@ -920,7 +920,7 @@ control_handle_message(control_t *control, const ControllerToDaemon *msg, int fd
 					      i, vnet_configs[i]->if_name,
 					      vnet_configs[i]->if_rootns_name,
 					      vnet_configs[i]->configure ? "configured" : "manual");
-					mem_free(vnet_cfg);
+					mem_free0(vnet_cfg);
 				}
 				list_delete(vnet_runtime_cfg_list);
 				results[number_of_configs]->n_vnet_configs = vnet_config_len;
@@ -952,12 +952,12 @@ control_handle_message(control_t *control, const ControllerToDaemon *msg, int fd
 		// collect garbage
 		list_delete(containers);
 		for (size_t i = 0; i < number_of_configs; i++) {
-			mem_free(result_uuids[i]);
+			mem_free0(result_uuids[i]);
 			if (results[i] != NULL)
 				protobuf_free_message((ProtobufCMessage *)results[i]);
 		}
-		mem_free(result_uuids);
-		mem_free(results);
+		mem_free0(result_uuids);
+		mem_free0(results);
 	} break;
 
 	case CONTROLLER_TO_DAEMON__COMMAND__GET_LAST_LOG: {
@@ -1029,7 +1029,7 @@ control_handle_message(control_t *control, const ControllerToDaemon *msg, int fd
 			WARN("Could not send device csr!");
 		}
 		if (csr)
-			mem_free(csr);
+			mem_free0(csr);
 	} break;
 
 	case CONTROLLER_TO_DAEMON__COMMAND__PUSH_DEVICE_CERT: {
@@ -1091,9 +1091,9 @@ control_handle_message(control_t *control, const ControllerToDaemon *msg, int fd
 
 		if (!ccfg[0]) {
 			ERROR("Failed to get new config for %s", cuuid_str[0]);
-			mem_free(ccfg);
-			mem_free(cuuid_str[0]);
-			mem_free(cuuid_str);
+			mem_free0(ccfg);
+			mem_free0(cuuid_str[0]);
+			mem_free0(cuuid_str);
 			if (protobuf_send_message(fd, (ProtobufCMessage *)&out) < 0)
 				WARN("Could not send empty Response to CREATE");
 			break;
@@ -1106,10 +1106,10 @@ control_handle_message(control_t *control, const ControllerToDaemon *msg, int fd
 		if (protobuf_send_message(fd, (ProtobufCMessage *)&out) < 0) {
 			WARN("Could not send container config as Response to CREATE");
 		}
-		mem_free(cuuid_str[0]);
-		mem_free(cuuid_str);
+		mem_free0(cuuid_str[0]);
+		mem_free0(cuuid_str);
 		protobuf_free_message((ProtobufCMessage *)ccfg[0]);
-		mem_free(ccfg);
+		mem_free0(ccfg);
 	} break;
 
 	// Container-specific commands:
@@ -1172,9 +1172,9 @@ control_handle_message(control_t *control, const ControllerToDaemon *msg, int fd
 
 		if (!ccfg[0]) {
 			ERROR("Failed to get new config for %s", cuuid_str[0]);
-			mem_free(ccfg);
-			mem_free(cuuid_str[0]);
-			mem_free(cuuid_str);
+			mem_free0(ccfg);
+			mem_free0(cuuid_str[0]);
+			mem_free0(cuuid_str);
 			if (protobuf_send_message(fd, (ProtobufCMessage *)&out) < 0)
 				WARN("Could not send empty Response to UPDATE_CONFIG");
 			break;
@@ -1192,10 +1192,10 @@ control_handle_message(control_t *control, const ControllerToDaemon *msg, int fd
 		if (protobuf_send_message(fd, (ProtobufCMessage *)&out) < 0) {
 			WARN("Could not send container config as Response to UPDATE_CONFIG");
 		}
-		mem_free(cuuid_str[0]);
-		mem_free(cuuid_str);
+		mem_free0(cuuid_str[0]);
+		mem_free0(cuuid_str);
 		protobuf_free_message((ProtobufCMessage *)ccfg[0]);
-		mem_free(ccfg);
+		mem_free0(ccfg);
 	} break;
 	case CONTROLLER_TO_DAEMON__COMMAND__CONTAINER_START: {
 		if (NULL == container) {
@@ -1325,8 +1325,8 @@ control_handle_message(control_t *control, const ControllerToDaemon *msg, int fd
 		// collect garbage
 		list_delete(link_list);
 		for (size_t i = 0; i < n; i++)
-			mem_free(results[i]);
-		mem_free(results);
+			mem_free0(results[i]);
+		mem_free0(results);
 	} break;
 
 	case CONTROLLER_TO_DAEMON__COMMAND__CONTAINER_EXEC_CMD: {
@@ -1470,12 +1470,12 @@ control_cb_recv_message(int fd, unsigned events, event_io_t *io, void *data)
 				WARN("Could not send LOGON message");
 			}
 			DEBUG("Sent LOGON message");
-			mem_free(out.device_uuid);
-			mem_free(out.logon_hardware_name);
-			mem_free(out.logon_hardware_serial);
-			mem_free(out.logon_imei);
-			mem_free(out.logon_mac_address);
-			mem_free(out.logon_phone_number);
+			mem_free0(out.device_uuid);
+			mem_free0(out.logon_hardware_name);
+			mem_free0(out.logon_hardware_serial);
+			mem_free0(out.logon_imei);
+			mem_free0(out.logon_mac_address);
+			mem_free0(out.logon_phone_number);
 
 			/* remove write watch */
 			event_remove_io(io);
@@ -1761,7 +1761,7 @@ control_free(control_t *control)
 		close(control->sock_client);
 	}
 	if (control->hostip)
-		mem_free(control->hostip);
+		mem_free0(control->hostip);
 
 	if (control->reconnect_timer) {
 		event_remove_timer(control->reconnect_timer);
@@ -1771,6 +1771,6 @@ control_free(control_t *control)
 
 	control_list = list_remove(control_list, control);
 
-	mem_free(control);
+	mem_free0(control);
 	return;
 }

--- a/daemon/device_config.c
+++ b/daemon/device_config.c
@@ -79,8 +79,8 @@ device_config_free(device_config_t *config)
 {
 	ASSERT(config);
 	protobuf_free_message((ProtobufCMessage *)config->cfg);
-	mem_free(config->file);
-	mem_free(config);
+	mem_free0(config->file);
+	mem_free0(config);
 }
 
 #if 0

--- a/daemon/download.c
+++ b/daemon/download.c
@@ -59,9 +59,9 @@ void
 download_free(download_t *dl)
 {
 	IF_NULL_RETURN(dl);
-	mem_free(dl->url);
-	mem_free(dl->file);
-	mem_free(dl);
+	mem_free0(dl->url);
+	mem_free0(dl->file);
+	mem_free0(dl);
 }
 
 static void

--- a/daemon/guestos.c
+++ b/daemon/guestos.c
@@ -151,12 +151,12 @@ void
 guestos_free(guestos_t *os)
 {
 	IF_NULL_RETURN(os);
-	mem_free(os->cert_file);
-	mem_free(os->sig_file);
-	mem_free(os->cfg_file);
-	mem_free(os->dir);
+	mem_free0(os->cert_file);
+	mem_free0(os->sig_file);
+	mem_free0(os->cfg_file);
+	mem_free0(os->dir);
 	guestos_config_free(os->cfg);
-	mem_free(os);
+	mem_free0(os);
 }
 
 /******************************************************************************/
@@ -189,8 +189,8 @@ static void
 check_mount_image_free(check_mount_image_t *task)
 {
 	IF_NULL_RETURN_WARN(task);
-	mem_free(task->img_path);
-	mem_free(task);
+	mem_free0(task->img_path);
+	mem_free0(task);
 }
 
 static void
@@ -248,7 +248,7 @@ convert_hex_to_bin_new(const char *hex_str, int *out_length)
 	return bin;
 err:
 	ERROR("Converstion of hex string to bin failed!");
-	mem_free(bin);
+	mem_free0(bin);
 	return NULL;
 }
 
@@ -283,7 +283,7 @@ guestos_check_mount_image_block(const guestos_t *os, const mount_entry_t *e, boo
 		if (mount_entry_get_sha256(e) == NULL) { // fallback to sha1
 			char *sha1 = smartcard_crypto_hash_file_block_new(img_path, SHA1);
 			match = mount_entry_match_sha1(e, sha1);
-			mem_free(sha1);
+			mem_free0(sha1);
 		} else {
 			char *sha256 = smartcard_crypto_hash_file_block_new(img_path, SHA256);
 			match = mount_entry_match_sha256(e, sha256);
@@ -292,16 +292,16 @@ guestos_check_mount_image_block(const guestos_t *os, const mount_entry_t *e, boo
 				uint8_t *sha256_bin =
 					convert_hex_to_bin_new(sha256, &sha256_bin_len);
 				tss_ml_append(img_path, sha256_bin, sha256_bin_len, TSS_SHA256);
-				mem_free(sha256_bin);
+				mem_free0(sha256_bin);
 			}
-			mem_free(sha256);
+			mem_free0(sha256);
 		}
 		if (!match)
 			res = CHECK_IMAGE_HASH_MISMATCH;
 	}
 
 cleanup:
-	mem_free(img_path);
+	mem_free0(img_path);
 	return res;
 }
 
@@ -363,7 +363,7 @@ guestos_check_mount_image(guestos_t *os, mount_entry_t *e, check_mount_image_com
 	check_mount_image_t *task = check_mount_image_new(os, e, img_path, cb, data);
 	smartcard_crypto_hash_file(img_path, SHA1, check_mount_image_cb_sha1, task);
 
-	mem_free(img_path);
+	mem_free0(img_path);
 }
 
 // ITERATE IMAGES
@@ -418,7 +418,7 @@ iterate_images_free(iterate_images_t *task)
 {
 	IF_NULL_RETURN(task);
 	mount_free(task->mnt);
-	mem_free(task);
+	mem_free0(task);
 }
 
 static void
@@ -591,8 +591,8 @@ iterate_images_trigger_download(iterate_images_t *task)
 	// invoke downloader
 	DEBUG("Downloading %s to %s (attempt=%u).", img_url, img_path, task->dl_attempts);
 	download_t *dl = download_new(img_url, img_path, iterate_images_cb_download_complete, task);
-	mem_free(img_url);
-	mem_free(img_path);
+	mem_free0(img_url);
+	mem_free0(img_path);
 	if (download_start(dl) < 0) {
 		ERROR("Failed to start download for %s", download_get_url(dl));
 		download_free(dl);
@@ -773,8 +773,8 @@ verify_partition(const char *img_path, const char *part_path)
 	res = VERIFY_PARTITION_MISMATCH;
 
 cleanup:
-	mem_free(part_buf);
-	mem_free(img_buf);
+	mem_free0(part_buf);
+	mem_free0(img_buf);
 cleanup_files:
 	if (img != -1)
 		close(img);
@@ -846,8 +846,8 @@ verify_flash_mount_entry(guestos_t *os, mount_entry_t *e)
 		break;
 	}
 
-	mem_free(flash_path);
-	mem_free(img_path);
+	mem_free0(flash_path);
+	mem_free0(img_path);
 	return res;
 }
 
@@ -931,7 +931,7 @@ guestos_purge(guestos_t *os)
 		if (file_exists(img_path) && unlink(img_path) < 0) {
 			WARN_ERRNO("Failed to erase file %s", img_path);
 		}
-		mem_free(img_path);
+		mem_free0(img_path);
 	}
 	// remove config and signature file
 	const char *file = guestos_get_cfg_file(os);

--- a/daemon/guestos_mgr.c
+++ b/daemon/guestos_mgr.c
@@ -139,11 +139,11 @@ guestos_mgr_load_operatingsystems_cb(const char *path, const char *name, UNUSED 
 	}
 
 cleanup_files:
-	mem_free(cfg_file);
-	mem_free(sig_file);
-	mem_free(cert_file);
+	mem_free0(cfg_file);
+	mem_free0(sig_file);
+	mem_free0(cert_file);
 cleanup:
-	mem_free(dir);
+	mem_free0(dir);
 	return res;
 }
 
@@ -278,7 +278,7 @@ download_complete_cb(bool complete, unsigned int count, guestos_t *os, void *dat
 out:
 	if (control_send_message(resp, *resp_fd) < 0)
 		WARN("Could not send response to fd=%d", *resp_fd);
-	mem_free(resp_fd);
+	mem_free0(resp_fd);
 }
 
 /**
@@ -358,7 +358,7 @@ write_to_tmpfile_new(unsigned char *buf, size_t buflen)
 	} else {
 		ERROR("Failed to create temp file.");
 	}
-	mem_free(file);
+	mem_free0(file);
 	return NULL;
 }
 
@@ -416,8 +416,8 @@ push_config_verify_buf_cb(smartcard_crypto_verify_result_t verify_result, unsign
 					os_name, 4, "installed_version", installed_str,
 					"update_version", update_str);
 
-			mem_free(installed_str);
-			mem_free(update_str);
+			mem_free0(installed_str);
+			mem_free0(update_str);
 
 			WARN("Skipping update of GuestOS %s version %" PRIu64
 			     " to older/same version %" PRIu64 ".",
@@ -479,7 +479,7 @@ trigger_download:
 		WARN("Could not send response to fd=%d", *resp_fd);
 	guestos_mgr_download_latest(os_name, *resp_fd);
 
-	mem_free(resp_fd);
+	mem_free0(resp_fd);
 	return;
 
 cleanup_purge:
@@ -491,7 +491,7 @@ err:
 
 	if (control_send_message(CONTROL_RESPONSE_GUESTOS_MGR_INSTALL_FAILED, *resp_fd) < 0)
 		WARN("Could not send response to fd=%d", *resp_fd);
-	mem_free(resp_fd);
+	mem_free0(resp_fd);
 }
 
 int
@@ -521,7 +521,7 @@ guestos_mgr_push_config(unsigned char *cfg, size_t cfglen, unsigned char *sig, s
 	if (res < 0) {
 		if (control_send_message(CONTROL_RESPONSE_GUESTOS_MGR_INSTALL_FAILED, resp_fd) < 0)
 			WARN("Could not send response to fd=%d", resp_fd);
-		mem_free(cb_resp_fd);
+		mem_free0(cb_resp_fd);
 	}
 
 	return res;
@@ -544,7 +544,7 @@ guestos_mgr_register_localca(unsigned char *cacert, size_t cacertlen)
 		INFO("Successfully installed localca root certificate %s to %s", tmp_cacert_file,
 		     LOCALCA_ROOT_CERT);
 	}
-	mem_free(tmp_cacert_file);
+	mem_free0(tmp_cacert_file);
 	return ret;
 }
 
@@ -581,9 +581,9 @@ guestos_mgr_register_newca(unsigned char *cacert, size_t cacertlen)
 		     cacert_file);
 	}
 out:
-	mem_free(cacert_file);
-	mem_free(cacert_hash);
-	mem_free(tmp_cacert_file);
+	mem_free0(cacert_file);
+	mem_free0(cacert_hash);
+	mem_free0(tmp_cacert_file);
 	return ret;
 }
 

--- a/daemon/input.c
+++ b/daemon/input.c
@@ -154,7 +154,7 @@ input_get_usb_input_event_file(uint16_t vendor_id, uint16_t product_id)
 	}
 
 	fclose(fp);
-	mem_free(line);
+	mem_free0(line);
 	return event_path;
 }
 
@@ -179,7 +179,7 @@ pin_entry_timeout_cb(event_timer_t *timer, void *data)
 	input_key_index = 0;
 	if (input_key) {
 		memset(input_key, 0x0, strlen(input_key));
-		mem_free(input_key);
+		mem_free0(input_key);
 	}
 	event_remove_timer(timer);
 	event_timer_free(timer);
@@ -208,7 +208,7 @@ input_clean_pin_entry(void)
 	input_key_index = 0;
 	if (input_key) {
 		memset(input_key, 0x0, strlen(input_key));
-		mem_free(input_key);
+		mem_free0(input_key);
 	}
 	event_remove_timer(input_timer);
 	event_timer_free(input_timer);
@@ -318,10 +318,10 @@ exit:
 	event_io_free(io);
 	close(fd);
 
-	mem_free(cb_data);
+	mem_free0(cb_data);
 	if (input_key) {
 		memset(input_key, 0x0, input_key_index);
-		mem_free(input_key);
+		mem_free0(input_key);
 	}
 	input_key_index = 0;
 	input_pin_entry_active = false;
@@ -382,13 +382,13 @@ input_register_container_ctrl_cb(control_t *control, container_t *container,
 
 	TRACE("Registering callback for pin entry");
 	event_add_io(input_event_io);
-	mem_free(input_file);
+	mem_free0(input_file);
 
 	input_pin_entry_active = true;
 
 	return 0;
 
 err:
-	mem_free(input_file);
+	mem_free0(input_file);
 	return -1;
 }

--- a/daemon/lxcfs.c
+++ b/daemon/lxcfs.c
@@ -51,7 +51,7 @@ lxcfs_get_bin_path_if_supported(void)
 	char *fses = file_read_new(PROC_FSES, 2048);
 	bool ret = strstr(fses, "fuse") ? true : false;
 
-	mem_free(fses);
+	mem_free0(fses);
 
 	IF_FALSE_RETVAL_TRACE(ret, NULL);
 
@@ -109,7 +109,7 @@ lxcfs_daemon_start(const char *rt_path)
 				INFO("Killing previous instance of lxcfs!");
 				kill(lxcfs_daemon_prev_pid, SIGTERM);
 			}
-			mem_free(pid_buf);
+			mem_free0(pid_buf);
 			for (int i = 0; file_exists(LXCFS_PID_FILE); ++i) {
 				sleep(1);
 				if (i > 4) {
@@ -157,8 +157,8 @@ lxcfs_proc_dir_foreach_cb(const char *path, const char *file, void *data)
 	else
 		TRACE("Applied overlay on %s with %s from lxcfs!", dst, src);
 
-	mem_free(dst);
-	mem_free(src);
+	mem_free0(dst);
+	mem_free0(src);
 	return ret;
 }
 
@@ -174,7 +174,7 @@ lxcfs_mount_proc_overlay(char *target)
 		ERROR("Could not mount proc overlay %s -> %s", lxcfs_proc, target);
 		ret = -1;
 	}
-	mem_free(lxcfs_proc);
+	mem_free0(lxcfs_proc);
 	return ret;
 }
 

--- a/daemon/mount.c
+++ b/daemon/mount.c
@@ -92,21 +92,21 @@ mount_free(mount_t *mnt)
 		mount_entry_t *mntent = mnt->list->data;
 		ASSERT(mntent);
 		// free mandatory/required fields
-		mem_free(mntent->image_file);
-		mem_free(mntent->mount_point);
-		mem_free(mntent->fs_type);
+		mem_free0(mntent->image_file);
+		mem_free0(mntent->mount_point);
+		mem_free0(mntent->fs_type);
 		// free optional fields
 		if (mntent->sha1)
-			mem_free(mntent->sha1);
+			mem_free0(mntent->sha1);
 		if (mntent->sha256)
-			mem_free(mntent->sha256);
+			mem_free0(mntent->sha256);
 		if (mntent->mount_data)
-			mem_free(mntent->mount_data);
-		mem_free(mntent);
+			mem_free0(mntent->mount_data);
+		mem_free0(mntent);
 		mnt->list = list_unlink(mnt->list, mnt->list);
 	}
 
-	mem_free(mnt);
+	mem_free0(mnt);
 }
 
 size_t
@@ -162,7 +162,7 @@ mount_entry_set_img(mount_entry_t *mntent, char *image_name)
 	ASSERT(mntent);
 	IF_NULL_RETURN(image_name);
 	if (mntent->image_file)
-		mem_free(mntent->image_file);
+		mem_free0(mntent->image_file);
 	mntent->image_file = mem_strdup(image_name);
 }
 
@@ -369,13 +369,13 @@ mount_cgroups_create_and_mount_subsys(const char *subsys, const char *mount_path
 		char *use_hierarchy = mem_printf("%s/memory.use_hierarchy", mount_path);
 		if (file_printf(use_hierarchy, "1") < 0)
 			WARN_ERRNO("Cloning default setting to child cgroups failes!");
-		mem_free(use_hierarchy);
+		mem_free0(use_hierarchy);
 	}
 	if (strcmp(subsys, "devices")) {
 		char *cgroup_clone_children = mem_printf("%s/cgroup.clone_children", mount_path);
 		if (file_printf(cgroup_clone_children, "1") < 0)
 			WARN_ERRNO("Cloning default setting to child cgroups failes!");
-		mem_free(cgroup_clone_children);
+		mem_free0(cgroup_clone_children);
 	}
 	return ret;
 }
@@ -403,10 +403,10 @@ mount_cgroups(list_t *cgroups_subsystems)
 		char *subsys = l->data;
 		char *mount_path = mem_printf("%s/%s", MOUNT_CGROUPS_FOLDER, subsys);
 		if (mount_cgroups_create_and_mount_subsys(subsys, mount_path) < 0) {
-			mem_free(mount_path);
+			mem_free0(mount_path);
 			goto error;
 		}
-		mem_free(mount_path);
+		mem_free0(mount_path);
 	}
 
 	// create a named hierarchy for systemd containers
@@ -423,7 +423,7 @@ error:
 		char *subsys = l->data;
 		char *subsys_path = mem_printf("%s/%s", MOUNT_CGROUPS_FOLDER, subsys);
 		umount(subsys_path);
-		mem_free(subsys_path);
+		mem_free0(subsys_path);
 	}
 	umount(MOUNT_CGROUPS_FOLDER "/systemd");
 	umount(MOUNT_CGROUPS_FOLDER);

--- a/daemon/time.c
+++ b/daemon/time.c
@@ -95,11 +95,11 @@ time_get_ntp_coarse(char *server)
 	time_t ret = (time_t)(ntp->tx_timestamp_sec - NTP_TIMESTAMP_DELTA);
 
 	INFO("Got current time from server %s", ctime(&ret));
-	mem_free(ntp);
+	mem_free0(ntp);
 	return ret;
 err:
 	ERROR("Communication Error with NTP Server '%s'!", server);
-	mem_free(ntp);
+	mem_free0(ntp);
 	return (time_t)-1;
 }
 

--- a/daemon/tss.c
+++ b/daemon/tss.c
@@ -73,7 +73,7 @@ tss_is_tpm2d_installed(void)
 	for (size_t i = 0; i < 6; ++i) {
 		char *binary = mem_printf("%s/%s", path[i], TPM2D_BINARY_NAME);
 		found = file_exists(binary);
-		mem_free(binary);
+		mem_free0(binary);
 		if (found)
 			return true;
 	}

--- a/rattestation/attestation.c
+++ b/rattestation/attestation.c
@@ -90,7 +90,7 @@ attestation_verify_resp(Tpm2dToRemote *resp, RAttestationConfig *config, uint8_t
 	if (resp->has_quoted) {
 		char *quote_str = convert_bin_to_hex_new(resp->quoted.data, resp->quoted.len);
 		DEBUG("Quote (Length %zu): %s", resp->quoted.len, quote_str);
-		mem_free(quote_str);
+		mem_free0(quote_str);
 	} else {
 		ERROR("Response does not contain quote to be verified");
 		ret = false;
@@ -100,7 +100,7 @@ attestation_verify_resp(Tpm2dToRemote *resp, RAttestationConfig *config, uint8_t
 	if (resp->has_signature) {
 		char *sig_str = convert_bin_to_hex_new(resp->signature.data, resp->signature.len);
 		DEBUG("Signature (Length %zu): %s\n", resp->signature.len, sig_str);
-		mem_free(sig_str);
+		mem_free0(sig_str);
 	} else {
 		ERROR("Response does not contain signature");
 		goto err;
@@ -191,8 +191,8 @@ attestation_verify_resp(Tpm2dToRemote *resp, RAttestationConfig *config, uint8_t
 						     tpms_attest.extraData.t.size);
 	DEBUG("Nonce (sent %s, received %s) - %s", nonce_str, rcv_nonce_str,
 	      ret_nonce ? "VERIFICATION FAILED" : "VERIFICATION SUCCESSFUL");
-	mem_free(nonce_str);
-	mem_free(rcv_nonce_str);
+	mem_free0(nonce_str);
+	mem_free0(rcv_nonce_str);
 	if (ret_nonce) {
 		ret = false;
 		goto err;
@@ -226,7 +226,7 @@ attestation_verify_resp(Tpm2dToRemote *resp, RAttestationConfig *config, uint8_t
 	char *pcr_digest = convert_bin_to_hex_new(tpms_attest.attested.quote.pcrDigest.t.buffer,
 						  tpms_attest.attested.quote.pcrDigest.t.size);
 	DEBUG("Quote PCR Digest: %s", pcr_digest);
-	mem_free(pcr_digest);
+	mem_free0(pcr_digest);
 	SHA256_CTX ctx;
 	SHA256_Init(&ctx);
 	uint8_t pcr_calc[SHA256_DIGEST_LENGTH] = { 0 };
@@ -271,7 +271,7 @@ err:
 
 	// Free resources
 	for (size_t i = 0; i < resp->n_pcr_values; i++) {
-		mem_free(pcr_strings[i]);
+		mem_free0(pcr_strings[i]);
 	}
 	ssl_free();
 
@@ -310,9 +310,9 @@ cleanup:
 	if (resp_cb_data->resp_verified_cb)
 		(resp_cb_data->resp_verified_cb)(verified);
 	if (resp_cb_data->nonce)
-		mem_free(resp_cb_data->nonce);
+		mem_free0(resp_cb_data->nonce);
 	protobuf_free_message((ProtobufCMessage *)resp_cb_data->config);
-	mem_free(resp_cb_data);
+	mem_free0(resp_cb_data);
 }
 
 int
@@ -365,7 +365,7 @@ attestation_do_request(const char *host, char *config_file, void (*resp_verified
 
 	char *nonce_str = convert_bin_to_hex_new(nonce, nonce_len);
 	INFO("Request with Nonce %s, Request size=%zd", nonce_str, msg_size);
-	mem_free(nonce_str);
+	mem_free0(nonce_str);
 
 	struct attestation_resp_cb_data *resp_cb_data =
 		mem_new0(struct attestation_resp_cb_data, 1);

--- a/rattestation/config.c
+++ b/rattestation/config.c
@@ -70,6 +70,6 @@ rattestation_read_config_new(const char *file)
 	}
 
 err:
-	mem_free(buf);
+	mem_free0(buf);
 	return config;
 }

--- a/rattestation/modsig.c
+++ b/rattestation/modsig.c
@@ -87,10 +87,10 @@ x509_get_common_name_new(X509_NAME *name)
 void
 modsig_free(sig_info_t *s)
 {
-	mem_free(s->key_id);
-	mem_free(s->sig);
-	mem_free(s->signer);
-	mem_free(s);
+	mem_free0(s->key_id);
+	mem_free0(s->sig);
+	mem_free0(s->signer);
+	mem_free0(s);
 }
 
 sig_info_t *

--- a/scd/control.c
+++ b/scd/control.c
@@ -95,7 +95,7 @@ write_to_tmpfile_new(unsigned char *buf, size_t buflen)
 	} else {
 		ERROR("Failed to create temp file.");
 	}
-	mem_free(file);
+	mem_free0(file);
 	return NULL;
 }
 
@@ -121,7 +121,7 @@ scd_control_verify_cert_ca_cb(const char *path, const char *file, void *data)
 		// break dir_foreach
 		ret = -1;
 	}
-	mem_free(ca_file);
+	mem_free0(ca_file);
 	return ret;
 }
 
@@ -302,7 +302,7 @@ scd_control_handle_message(const DaemonToToken *msg, int fd)
 		protobuf_send_message(fd, (ProtobufCMessage *)&out);
 		if (out.has_wrapped_key) {
 			memset(wrapped_key, 0, wrapped_key_len);
-			mem_free(wrapped_key);
+			mem_free0(wrapped_key);
 		}
 	} break;
 	case DAEMON_TO_TOKEN__CODE__UNWRAP_KEY: {
@@ -332,7 +332,7 @@ scd_control_handle_message(const DaemonToToken *msg, int fd)
 		protobuf_send_message(fd, (ProtobufCMessage *)&out);
 		if (out.has_unwrapped_key) {
 			memset(unwrapped_key, 0, unwrapped_key_len);
-			mem_free(unwrapped_key);
+			mem_free0(unwrapped_key);
 		}
 	} break;
 	case DAEMON_TO_TOKEN__CODE__CHANGE_PIN: {
@@ -410,7 +410,7 @@ scd_control_handle_message(const DaemonToToken *msg, int fd)
 		protobuf_send_message(fd, (ProtobufCMessage *)&out);
 		INFO("csr: %p", csr);
 		if (csr)
-			mem_free(csr);
+			mem_free0(csr);
 	} break;
 	case DAEMON_TO_TOKEN__CODE__PUSH_DEVICE_CERT: {
 		TRACE("SCD: Handle messsage PUSH_DEV_CERT");
@@ -452,7 +452,7 @@ scd_control_handle_message(const DaemonToToken *msg, int fd)
 
 		protobuf_send_message(fd, (ProtobufCMessage *)&out);
 		if (hash)
-			mem_free(hash);
+			mem_free0(hash);
 	} break;
 	case DAEMON_TO_TOKEN__CODE__CRYPTO_VERIFY_BUF: {
 		TokenToDaemon out = TOKEN_TO_DAEMON__INIT;
@@ -473,15 +473,15 @@ scd_control_handle_message(const DaemonToToken *msg, int fd)
 		protobuf_send_message(fd, (ProtobufCMessage *)&out);
 		if (tmp_data_file) {
 			unlink(tmp_data_file);
-			mem_free(tmp_data_file);
+			mem_free0(tmp_data_file);
 		}
 		if (tmp_sig_file) {
 			unlink(tmp_sig_file);
-			mem_free(tmp_sig_file);
+			mem_free0(tmp_sig_file);
 		}
 		if (tmp_cert_file) {
 			unlink(tmp_cert_file);
-			mem_free(tmp_cert_file);
+			mem_free0(tmp_cert_file);
 		}
 
 	} break;

--- a/scd/scd.c
+++ b/scd/scd.c
@@ -99,11 +99,11 @@ is_softtoken(const char *path, const char *file, UNUSED void *data)
 		return 0;
 	if (!strncmp(ext, TOKEN_DEFAULT_EXT, strlen(TOKEN_DEFAULT_EXT))) {
 		DEBUG("Found token file: %s", location);
-		mem_free(location);
+		mem_free0(location);
 		return 1;
 	}
 
-	mem_free(location);
+	mem_free0(location);
 	return 0;
 }
 
@@ -214,7 +214,7 @@ provisioning_mode()
 			// set device uuid
 			char *proto_uid = mem_strdup(uid);
 			// free this element, as it is overwritten
-			mem_free(dev_cfg->uuid);
+			mem_free0(dev_cfg->uuid);
 			dev_cfg->uuid = proto_uid;
 
 			// write the uuid to device config file
@@ -230,9 +230,9 @@ provisioning_mode()
 
 			// this call also frees proto_uid
 			protobuf_free_message((ProtobufCMessage *)dev_cfg);
-			mem_free(hw_serial);
-			mem_free(hw_name);
-			mem_free(common_name);
+			mem_free0(hw_serial);
+			mem_free0(hw_name);
+			mem_free0(common_name);
 			uuid_free(dev_uuid);
 			DEBUG("CSR with privkey created and stored");
 		} else {
@@ -273,7 +273,7 @@ provisioning_mode()
 					    TOKEN_DEFAULT_NAME) != 0) {
 			FATAL("Unable to create initial user token");
 		}
-		mem_free(token_file);
+		mem_free0(token_file);
 		ssl_free();
 	}
 
@@ -388,7 +388,7 @@ scd_load_softtoken(const char *path, const char *name)
 		TRACE("Softtoken filename: %s", token_file);
 
 		ntoken = softtoken_new_from_p12(token_file);
-		mem_free(token_file);
+		mem_free0(token_file);
 		return ntoken;
 	}
 

--- a/scd/softtoken.c
+++ b/scd/softtoken.c
@@ -134,9 +134,9 @@ softtoken_free(softtoken_t *token)
 	softtoken_free_secrets(token);
 
 	if (token->token_file)
-		mem_free(token->token_file);
+		mem_free0(token->token_file);
 
-	mem_free(token);
+	mem_free0(token);
 }
 
 int

--- a/scd/token.c
+++ b/scd/token.c
@@ -139,7 +139,7 @@ err:
 	goto close_fd;
 
 close_fd:
-	mem_free(brsp);
+	mem_free0(brsp);
 	if (close(fd) < 0)
 		WARN_ERRNO("Failed to close connected control socket");
 	return;
@@ -159,7 +159,7 @@ out:
 	if ((protobuf_send_message(fd, (ProtobufCMessage *)&out)) < 0) {
 		ERROR("Could not send protobuf response on socket %d", fd);
 	}
-	mem_free(brsp);
+	mem_free0(brsp);
 }
 
 /**
@@ -296,8 +296,8 @@ scd_tokencontrol_new(scd_token_t *token)
 	return 0;
 
 err:
-	mem_free(token->token_data->tctrl);
-	mem_free(token->token_data->tctrl->lsock_path);
+	mem_free0(token->token_data->tctrl);
+	mem_free0(token->token_data->tctrl->lsock_path);
 	return -1;
 }
 
@@ -321,9 +321,9 @@ scd_tokencontrol_free(scd_token_t *token)
 			   uuid_string(token->token_data->token_uuid));
 	};
 	token->token_data->tctrl->lsock = -1;
-	mem_free(token->token_data->tctrl->lsock_path);
+	mem_free0(token->token_data->tctrl->lsock_path);
 
-	mem_free(token->token_data->tctrl);
+	mem_free0(token->token_data->tctrl);
 }
 #endif // ENABLESCHSM
 
@@ -520,17 +520,17 @@ token_new(const token_constr_data_t *constr_data)
 			if (softtoken_create_p12(token_file, STOKEN_DEFAULT_PASS,
 						 constr_data->uuid) != 0) {
 				ERROR("Could not create new softtoken file");
-				mem_free(token_file);
+				mem_free0(token_file);
 				goto err;
 			}
 		}
 		new_token->token_data->int_token.softtoken = softtoken_new_from_p12(token_file);
 		if (!new_token->token_data->int_token.softtoken) {
 			ERROR("Creation of softtoken failed");
-			mem_free(token_file);
+			mem_free0(token_file);
 			goto err;
 		}
-		mem_free(token_file);
+		mem_free0(token_file);
 
 		new_token->token_data->type = SOFT;
 		new_token->lock = int_lock_st;
@@ -589,9 +589,9 @@ err:
 	if (new_token->token_data->token_uuid)
 		uuid_free(new_token->token_data->token_uuid);
 	if (new_token->token_data)
-		mem_free(new_token->token_data);
+		mem_free0(new_token->token_data);
 	if (new_token)
-		mem_free(new_token);
+		mem_free0(new_token);
 
 	return NULL;
 }
@@ -639,7 +639,7 @@ token_free(scd_token_t *token)
 
 		if (token->token_data->token_uuid)
 			uuid_free(token->token_data->token_uuid);
-		mem_free(token->token_data);
+		mem_free0(token->token_data);
 	}
-	mem_free(token);
+	mem_free0(token);
 }

--- a/scd/usbtoken.c
+++ b/scd/usbtoken.c
@@ -265,7 +265,7 @@ token_filter_by_serial(const unsigned char *readers, const unsigned short lr, co
 			TRACE("USBTOKEN: token_filter_by_serial() found reader with serial: %s at port 0x%04x",
 			      serial, iport);
 			*port = iport;
-			mem_free(s);
+			mem_free0(s);
 			return 0;
 		}
 
@@ -274,7 +274,7 @@ token_filter_by_serial(const unsigned char *readers, const unsigned short lr, co
 	}
 
 	*port = 0;
-	mem_free(s);
+	mem_free0(s);
 	return -1;
 }
 
@@ -291,7 +291,7 @@ usbtoken_reset_schsm_sess(usbtoken_t *token, unsigned char *brsp, size_t brsp_le
 		return -1;
 	}
 	if (NULL != token->latr)
-		mem_free(token->latr);
+		mem_free0(token->latr);
 	token->latr = mem_memcpy(brsp, lr);
 	token->latr_len = lr;
 
@@ -340,7 +340,7 @@ usbtoken_init_ctapi_int(usbtoken_t *token, unsigned char *brsp, size_t brsp_len)
 		ERROR("Could not find specified token reader with serial %s", token->serial);
 		goto err;
 	}
-	mem_free(readers);
+	mem_free0(readers);
 	token->port = port;
 
 	rc = CT_init(token->ctn, port);
@@ -359,7 +359,7 @@ usbtoken_init_ctapi_int(usbtoken_t *token, unsigned char *brsp, size_t brsp_len)
 	return 0;
 
 err:
-	mem_free(readers);
+	mem_free0(readers);
 	return -1;
 }
 
@@ -387,7 +387,7 @@ usbtoken_new(const char *serial)
 	IF_NULL_GOTO_ERROR(token->serial, err);
 
 	rc = usbtoken_init_ctapi_int(token, brsp, brsp_len);
-	mem_free(brsp);
+	mem_free0(brsp);
 	if (rc != 0) {
 		ERROR("Failed to initialize ctapi interface to usb token reader");
 		goto err;
@@ -399,8 +399,8 @@ usbtoken_new(const char *serial)
 	return token;
 
 err:
-	mem_free(token->serial);
-	mem_free(token);
+	mem_free0(token->serial);
+	mem_free0(token);
 	return NULL;
 }
 
@@ -543,7 +543,7 @@ usbtoken_free_secrets(usbtoken_t *token)
 	IF_NULL_RETURN(token->auth_code);
 
 	memset(token->auth_code, 0, token->auth_code_len);
-	mem_free(token->auth_code);
+	mem_free0(token->auth_code);
 }
 
 void
@@ -557,12 +557,12 @@ usbtoken_free(usbtoken_t *token)
 		ERROR("Closing CT interface to token failed.");
 	}
 
-	mem_free(token->latr);
+	mem_free0(token->latr);
 
-	mem_free(token->serial);
+	mem_free0(token->serial);
 	usbtoken_free_secrets(token);
 
-	mem_free(token);
+	mem_free0(token);
 	g_ctn--;
 }
 

--- a/service/exec_cap_systime.c
+++ b/service/exec_cap_systime.c
@@ -72,6 +72,6 @@ main(int argc, char **argv)
 	// closing socket to cmld
 	close(sock);
 
-	mem_free(msg.captime_exec_param);
+	mem_free0(msg.captime_exec_param);
 	return 0;
 }

--- a/service/service.c
+++ b/service/service.c
@@ -103,7 +103,7 @@ service_set_hostname(int fd)
 	// write hostname to kernel
 	rc += file_write("/proc/sys/kernel/hostname", name, strlen(name));
 
-	mem_free(line);
+	mem_free0(line);
 	if (resp)
 		protobuf_free_message((ProtobufCMessage *)resp);
 
@@ -137,7 +137,7 @@ service_set_dnsserver(int fd)
 	line = mem_printf("nameserver %s\n", dns_addr);
 	rc = file_write("/etc/resolv.conf", line, strlen(line));
 
-	mem_free(line);
+	mem_free0(line);
 	if (resp)
 		protobuf_free_message((ProtobufCMessage *)resp);
 
@@ -200,7 +200,7 @@ process_audit_record(CmldToServiceMessage *msg, uint8_t *buf, uint32_t buf_len)
 	if (!fgets(hash_buf, 129, hash_file)) {
 		ERROR("Hash length was smaller than 64 bytes");
 		fclose(hash_file);
-		mem_free(hash_buf);
+		mem_free0(hash_buf);
 		goto out;
 	}
 	fclose(hash_file);
@@ -213,7 +213,7 @@ process_audit_record(CmldToServiceMessage *msg, uint8_t *buf, uint32_t buf_len)
 		TRACE("Storing audit record %s", record);
 		file_write_append(AUDIT_LOGDIR "/audit.log", record, strlen(record));
 
-		mem_free(LAST_AUDIT_HASH);
+		mem_free0(LAST_AUDIT_HASH);
 		LAST_AUDIT_HASH = hash_buf;
 		ret = 0;
 	} else {
@@ -241,7 +241,7 @@ audit_send_ack(int sock, const char *hash)
 	if (msg_size < 0)
 		WARN("Could not request audit event delivery, error: %zd\n", msg_size);
 
-	mem_free(auditmsg.audit_ack);
+	mem_free0(auditmsg.audit_ack);
 
 	return 0;
 }
@@ -324,7 +324,7 @@ service_cb_recv_message(int fd, unsigned events, event_io_t *io, UNUSED void *da
 
 out:
 	if (buf)
-		mem_free(buf);
+		mem_free0(buf);
 	if (msg)
 		protobuf_free_message((ProtobufCMessage *)msg);
 

--- a/tpm2d/control.c
+++ b/tpm2d/control.c
@@ -165,9 +165,9 @@ tpm2d_control_handle_message(const ControllerToTpm *msg, int fd, tpm2d_control_t
 		out.rand_data = rand_hex;
 		protobuf_send_message(fd, (ProtobufCMessage *)&out);
 		if (rand)
-			mem_free(rand);
+			mem_free0(rand);
 		if (rand_hex)
-			mem_free(rand_hex);
+			mem_free0(rand_hex);
 	} break;
 	case CONTROLLER_TO_TPM__CODE__CLEAR: {
 		INFO("Received Clear command!");

--- a/tpm2d/ek.c
+++ b/tpm2d/ek.c
@@ -35,7 +35,7 @@ ek_get_certificate_new(TPMI_ALG_PUBLIC alg, size_t *cert_len)
 	uint8_t *cert_raw = mem_new0(uint8_t, *cert_len);
 	if (tpm2_nv_read(TPM_RH_NULL, cert_index, NULL, cert_raw, cert_len)) {
 		ERROR("Reading Index of EK cert failed!");
-		mem_free(cert_raw);
+		mem_free0(cert_raw);
 		return NULL;
 	}
 	const unsigned char *p = cert_raw;

--- a/tpm2d/ml.c
+++ b/tpm2d/ml.c
@@ -139,7 +139,7 @@ ml_get_ima_list_new(size_t *len)
 				TRACE("Reading from fd %d: Blocked, retrying...", fd);
 				continue;
 			}
-			mem_free(buf);
+			mem_free0(buf);
 			l = 0;
 			ERROR("Failed to read binary_runtime_measurements");
 			goto out;
@@ -157,13 +157,13 @@ void
 ml_container_list_free(MlContainerEntry **entries, size_t len)
 {
 	for (size_t i = 0; i < len; i++) {
-		mem_free(entries[i]->filename);
-		mem_free(entries[i]->template_hash_alg);
-		mem_free(entries[i]->template_hash.data);
-		mem_free(entries[i]->data_hash_alg);
-		mem_free(entries[i]->data_hash.data);
+		mem_free0(entries[i]->filename);
+		mem_free0(entries[i]->template_hash_alg);
+		mem_free0(entries[i]->template_hash.data);
+		mem_free0(entries[i]->data_hash_alg);
+		mem_free0(entries[i]->data_hash.data);
 	}
-	mem_free(entries);
+	mem_free0(entries);
 }
 
 MlContainerEntry **

--- a/tpm2d/nvmcrypt.c
+++ b/tpm2d/nvmcrypt.c
@@ -69,7 +69,7 @@ cleanup:
 		if (pcrs[i])
 			tpm2_pcrread_free(pcrs[i]);
 	if (pcrs)
-		mem_free(pcrs);
+		mem_free0(pcrs);
 
 	return ret;
 }
@@ -140,7 +140,7 @@ nvmcrypt_load_key_new(const char *fde_key_pw)
 				WARN("nv_read returned with unexpected error %08x", ret);
 				fde_state = FDE_UNEXPECTED_ERROR;
 			}
-			mem_free(fde_key);
+			mem_free0(fde_key);
 			return NULL;
 		}
 	}
@@ -198,16 +198,16 @@ nvmcrypt_load_key_new(const char *fde_key_pw)
 		goto err;
 	}
 
-	mem_free(verify_key);
+	mem_free0(verify_key);
 
 	fde_state = FDE_OK;
 	return fde_key;
 err:
 	fde_state = FDE_KEYGEN_FAILED;
 	if (verify_key)
-		mem_free(verify_key);
+		mem_free0(verify_key);
 	if (fde_key)
-		mem_free(fde_key);
+		mem_free0(fde_key);
 
 	return NULL;
 }
@@ -233,9 +233,9 @@ nvmcrypt_dm_setup(const char *device_path, const char *fde_pw)
 		fde_state = FDE_NO_DEVICE;
 	}
 
-	mem_free(mapped_path);
-	mem_free(ascii_key);
-	mem_free(key);
+	mem_free0(mapped_path);
+	mem_free0(ascii_key);
+	mem_free0(key);
 	return fde_state;
 }
 

--- a/tpm2d/rcontrol.c
+++ b/tpm2d/rcontrol.c
@@ -239,7 +239,7 @@ tpm2d_rcontrol_handle_message(const RemoteToTpm2d *msg, int fd, tpm2d_rcontrol_t
 		DEBUG("Received INTERNAL_ATTESTATION_RES, now sending reply");
 		protobuf_send_message(fd, (ProtobufCMessage *)&out);
 
-		mem_free(out.ml_ima_entry.data);
+		mem_free0(out.ml_ima_entry.data);
 		ml_container_list_free(out.ml_container_entry, out.n_ml_container_entry);
 
 	err_att_req:
@@ -250,16 +250,16 @@ tpm2d_rcontrol_handle_message(const RemoteToTpm2d *msg, int fd, tpm2d_rcontrol_t
 				if (pcr_array[i])
 					tpm2_pcrread_free(pcr_array[i]);
 				if (out_pcrs && out_pcrs[i])
-					mem_free(out_pcrs[i]);
+					mem_free0(out_pcrs[i]);
 			}
 		if (out_pcrs)
-			mem_free(out_pcrs);
+			mem_free0(out_pcrs);
 		if (pcr_array)
-			mem_free(pcr_array);
+			mem_free0(pcr_array);
 		if (quote)
 			tpm2_quote_free(quote);
 		if (attestation_cert)
-			mem_free(attestation_cert);
+			mem_free0(attestation_cert);
 	} break;
 	default:
 		WARN("RemoteToTpm2d command %d unknown or not implemented yet", msg->code);

--- a/tpm2d/tpm2_commands.c
+++ b/tpm2d/tpm2_commands.c
@@ -119,7 +119,7 @@ convert_hex_to_bin_new(const char *hex_str, int *out_length)
 	return bin;
 err:
 	ERROR("Converstion of hex string to bin failed!");
-	mem_free(bin);
+	mem_free0(bin);
 	return NULL;
 }
 
@@ -924,10 +924,10 @@ void
 tpm2_quote_free(tpm2d_quote_t *quote)
 {
 	if (quote->quoted_value)
-		mem_free(quote->quoted_value);
+		mem_free0(quote->quoted_value);
 	if (quote->signature_value)
-		mem_free(quote->signature_value);
-	mem_free(quote);
+		mem_free0(quote->signature_value);
+	mem_free0(quote);
 }
 
 TPM_RC
@@ -1124,14 +1124,14 @@ tpm2_getrandom_new(size_t rand_length)
 
 	if (TPM_RC_SUCCESS != rc) {
 		TSS_TPM_CMD_ERROR(rc, "CC_GetRandom");
-		mem_free(rand);
+		mem_free0(rand);
 		return NULL;
 	}
 
 	char *rand_hex = convert_bin_to_hex_new(rand, rand_length);
 	INFO("Generated Rand: %s", rand_hex);
 
-	mem_free(rand_hex);
+	mem_free0(rand_hex);
 
 	if (TPM_RC_SUCCESS != tpm2_flushcontext(se_handle))
 		WARN("Flush failed, maybe session handle was allready flushed.");
@@ -1191,8 +1191,8 @@ void
 tpm2_pcrread_free(tpm2d_pcr_t *pcr)
 {
 	if (pcr->pcr_value)
-		mem_free(pcr->pcr_value);
-	mem_free(pcr);
+		mem_free0(pcr->pcr_value);
+	mem_free0(pcr);
 }
 
 size_t

--- a/tpm2d/tpm2d.c
+++ b/tpm2d/tpm2d.c
@@ -133,7 +133,7 @@ tpm2d_setup_keys(void)
 
 	if (file_exists(TPM2D_ATT_PRIV_FILE)) {
 		INFO("Signing key for attestation found in %s, nothing to be done.", token_dir);
-		mem_free(token_dir);
+		mem_free0(token_dir);
 		return;
 	}
 
@@ -188,7 +188,7 @@ retry:
 		INFO("Created signing key for attestation in %s, not loading need to wait for provsg ...",
 		     token_dir);
 	}
-	mem_free(token_dir);
+	mem_free0(token_dir);
 }
 #endif /* ifndef TPM2D_NVMCRYPT_ONLY */
 
@@ -241,7 +241,7 @@ tpm2d_init(void)
 	nvmcrypt_init(false);
 #endif
 
-	mem_free(session_dir);
+	mem_free0(session_dir);
 	INFO("Sucessfully initialized TPM2.0");
 	tss2_destroy();
 }


### PR DESCRIPTION
**common/mem: provide explicit mem_free0 macro**
    
We redefined mem_free to mem_free0, thus it would be explicit
clear that the parameter ptr will be set to NULL. We also restored
the previous behaviour of the mem_free() wrapper as just wrapping
a direct call to free().

***: use new mem_free0 macro instead of mem_free**
    
The former mem_free macro was replaced by mem_free0. To maintain the
detection of simple double free mistakes we switch to the explicit
mem_free0().
