### PR TITLE
scripts/ci/unit-testing.sh: removed dependency to run tool

### DIFF
--- a/scripts/ci/unit-testing.sh
+++ b/scripts/ci/unit-testing.sh
@@ -14,7 +14,7 @@ REPO_DIR="$(cd "${DIR}/../.." >/dev/null 2>&1 && pwd)"
 # Piggyback on the compiler's static analysis;
 # Build every subproject with enabled aggressive warnings;
 # Check if the compiler catches any errors
-dirs=(common control converter daemon run scd)
+dirs=(common control converter daemon scd)
 for d in ${dirs[*]}; do
     cd "${REPO_DIR}/common"
     make clean


### PR DESCRIPTION
Lately, the run tool was removed from the cml repo. We forgot to
remove the dependency here. This is fixed now.

Signed-off-by: Michael Weiß <michael.weiss@aisec.fraunhofer.de>