### PR TITLE
daemon/c_vol: map first tty to /dev/console in container

### DIFF
--- a/daemon/c_cgroups.h
+++ b/daemon/c_cgroups.h
@@ -71,8 +71,14 @@ c_cgroups_devices_is_dev_allowed(c_cgroups_t *cgroups, int major, int minor);
 int
 c_cgroups_set_ram_limit(c_cgroups_t *cgroups);
 
-/*******************/
-/* Hooks */
+int
+c_cgroups_add_pid(c_cgroups_t *cgroups, pid_t pid);
+
+/******************************/
+/*
+ * Container start hooks
+ * These Functions are part of TSF.CML.CompartmentIsolation.
+ */
 int
 c_cgroups_start_pre_clone(c_cgroups_t *cgroups);
 
@@ -86,10 +92,9 @@ int
 c_cgroups_start_pre_exec_child(c_cgroups_t *cgroups);
 
 int
-c_cgroups_add_pid(c_cgroups_t *cgroups, pid_t pid);
-
-int
 c_cgroups_start_child(c_cgroups_t *cgroups);
+
+/******************************/
 
 void
 c_cgroups_cleanup(c_cgroups_t *cgroups);

--- a/daemon/c_net.c
+++ b/daemon/c_net.c
@@ -660,7 +660,9 @@ c_net_unbridge_ifi(const char *if_name, list_t *mac_whitelist, const pid_t pid)
 }
 
 /*
- * used internally by c_net_new, than we already have grabbed the interface.
+ * This Funtion mainly implement TSF.CML.DeviceAccessControl for network devices.
+ *
+ * It is used internally by c_net_new, than we already have grabbed the interface.
  * also this function is used externally for new devices during runtime from control
  * or uevent handler. Then we have to grab the interface from cmld's list of available
  * interfaces and add the pnet_cfg to the internal c_net list.

--- a/daemon/c_net.h
+++ b/daemon/c_net.h
@@ -53,18 +53,21 @@ c_net_free(c_net_t *net);
 /**
  * Before clone, initialize c_net structure,
  * create a veth pair and configure the root ns veth
+ * This Function is part of TSF.CML.CompartmentIsolation.
  */
 int
 c_net_start_pre_clone(c_net_t *net);
 
 /**
  * After the clone, move the container veth into its namespace
+ * This Function is part of TSF.CML.CompartmentIsolation.
  */
 int
 c_net_start_post_clone(c_net_t *net);
 
 /**
  * In the container's namespace, the container veth is configured
+ * This Function is part of TSF.CML.CompartmentIsolation.
  */
 int
 c_net_start_child(c_net_t *net);
@@ -115,6 +118,7 @@ c_net_get_interface_mapping_new(c_net_t *net);
 
 /**
  * Rejoin existing netns on reboots where netns is kept active
+ * This Function is part of TSF.CML.CompartmentIsolation.
  */
 int
 c_net_join_netns(const c_net_t *net);

--- a/daemon/c_vol.c
+++ b/daemon/c_vol.c
@@ -1489,10 +1489,9 @@ c_vol_start_pre_exec(c_vol_t *vol)
 
 	if (c_vol_bind_token(vol) < 0) {
 		ERROR_ERRNO("Failed to bind token to container");
+		mem_free0(dev_mnt);
 		return -1;
 	}
-
-	return 0;
 
 	mem_free0(dev_mnt);
 	return 0;

--- a/daemon/c_vol.c
+++ b/daemon/c_vol.c
@@ -1196,6 +1196,10 @@ error:
 	return ret;
 }
 
+/**
+ * This Function verifes integrity of base images as part of
+ * TSF.CML.SecureCompartmentInit.
+ */
 static bool
 c_vol_verify_mount_entries(const c_vol_t *vol)
 {

--- a/daemon/container.h
+++ b/daemon/container.h
@@ -398,6 +398,8 @@ container_write_exec_input(container_t *container, char *exec_input, int session
 /**
  * Start the given container using the given key to decrypt its filesystem
  * image(s).
+ * This is the main function which sets up isolation mechnsims as part of
+ * TSF.CML.Isolation
  *
  * @param container The container to be started.
  * @param key The key used for filesystem image decryption. Can be NULL.

--- a/daemon/container_config.c
+++ b/daemon/container_config.c
@@ -105,6 +105,10 @@ container_config_proto_to_usb_type(ContainerUsbType type)
 
 /******************************************************************************/
 
+/**
+ * This function verifies the container configuration file at load time
+ * as part of TSF.CML.SecureCompartmentInit
+ */
 static bool
 container_config_verify(const char *prefix, uint8_t *conf_buf, size_t conf_len, uint8_t *sig_buf,
 			size_t sig_len, uint8_t *cert_buf, size_t cert_len)

--- a/daemon/guestos_mgr.c
+++ b/daemon/guestos_mgr.c
@@ -84,6 +84,10 @@ guestos_mgr_purge_obsolete(void)
 	}
 }
 
+/**
+ * This function verifies the guestos configuration file at load time
+ * as part of TSF.CML.SecureCompartmentInit
+ */
 static int
 guestos_mgr_load_operatingsystems_cb(const char *path, const char *name, UNUSED void *data)
 {

--- a/daemon/guestos_mgr.h
+++ b/daemon/guestos_mgr.h
@@ -41,6 +41,9 @@ typedef struct guestos guestos_mgr_t;
 
 /**
  * Initialize the operating system list by loading all information from storage.
+ * This function verifies each guestos configuration file as part of
+ * TSF.CML.SecureCompartmentInit at boottime of the CML subsystem.
+ *
  * @param path The directory where operating systems are stored.
  * @param allow_locally_signed enable images which are signed by a locally generated CA
  */

--- a/daemon/smartcard.c
+++ b/daemon/smartcard.c
@@ -336,6 +336,10 @@ smartcard_cb_start_container(int fd, unsigned events, event_io_t *io, void *data
 					     resp_fd);
 			done = true;
 		} break;
+
+		/*
+		 * This case handles key unwrapping as part of TSF.CML.CompartmentDataStorage.
+		 */
 		case TOKEN_TO_DAEMON__CODE__UNLOCK_SUCCESSFUL: {
 			audit_log_event(container_get_uuid(startdata->container), SSA, CMLD,
 					TOKEN_MGMT, "unlock-successful",
@@ -445,6 +449,9 @@ smartcard_cb_start_container(int fd, unsigned events, event_io_t *io, void *data
 			}
 			mem_free0(keyfile);
 		} break;
+		/*
+		 * This case handles key unwrapping as part of TSF.CML.CompartmentDataStorage.
+		 */
 		case TOKEN_TO_DAEMON__CODE__UNWRAPPED_KEY: {
 			// lock token via scd
 			DaemonToToken out = DAEMON_TO_TOKEN__INIT;

--- a/scd/control.c
+++ b/scd/control.c
@@ -125,6 +125,11 @@ scd_control_verify_cert_ca_cb(const char *path, const char *file, void *data)
 	return ret;
 }
 
+/*
+ * This function mainly handles verify request as part of
+ * TSF.CML.SecureCompartmentInit and TSF.CML.Updates.
+ * It wraps the corresponding OpenSSL calls.
+ */
 static TokenToDaemon__Code
 scd_control_handle_verify(const char *verify_data_file, const char *verify_sig_file,
 			  const char *verify_cert_file, const char *hash_algo)
@@ -429,6 +434,11 @@ scd_control_handle_message(const DaemonToToken *msg, int fd)
 		}
 		protobuf_send_message(fd, (ProtobufCMessage *)&out);
 	} break;
+	/*
+	 * This case handles hashing request as part of
+	 * TSF.CML.SecureCompartmentInit and TSF.CML.Updates
+	 * and wraps the corresponding OpenSSL calls.
+	 */
 	case DAEMON_TO_TOKEN__CODE__CRYPTO_HASH_FILE: {
 		TRACE("SCD: Handle messsage CRYPTO_HASH_FILE");
 		unsigned int hash_len;
@@ -454,6 +464,9 @@ scd_control_handle_message(const DaemonToToken *msg, int fd)
 		if (hash)
 			mem_free0(hash);
 	} break;
+	/*
+	 * This case handles verify requests as part of TSF.CML.Updates
+	 */
 	case DAEMON_TO_TOKEN__CODE__CRYPTO_VERIFY_BUF: {
 		TokenToDaemon out = TOKEN_TO_DAEMON__INIT;
 		out.code = TOKEN_TO_DAEMON__CODE__CRYPTO_VERIFY_ERROR;
@@ -485,6 +498,9 @@ scd_control_handle_message(const DaemonToToken *msg, int fd)
 		}
 
 	} break;
+	/*
+	 * This case handles verify requests as part of TSF.CML.SecureCompartmentInit
+	 */
 	case DAEMON_TO_TOKEN__CODE__CRYPTO_VERIFY_FILE: {
 		TRACE("SCD: Handle messsage CRYPTO_VERIFY_FILE");
 		TokenToDaemon out = TOKEN_TO_DAEMON__INIT;


### PR DESCRIPTION
Systemd expects /dev/console to be there, thus just link the
first tty to the contaienr if there is one configured in the
container config. A further patch needs to create a pty as
replacement if no tty is mapped.

Signed-off-by: Michael Weiß <michael.weiss@aisec.fraunhofer.de>