### PR TITLE
daemon/uevent: Fixed masking of synth_uuid of coldboot events

### DIFF
--- a/daemon/uevent.c
+++ b/daemon/uevent.c
@@ -902,7 +902,7 @@ handle_kernel_event(struct uevent *uevent, char *raw_p)
 			ERROR("Failed to mask out container uuid from SYNTH_UUID in uevent");
 			goto out;
 		}
-		uevent_device_node_and_forward(uevent, container);
+		uevent_device_node_and_forward(uev_fwd, container);
 		mem_free0(uev_fwd);
 		goto out;
 	}


### PR DESCRIPTION
During container start cold boot uevents are triggered for containers
only by setting the UUID as synth_uuid in the event. This is masked
from the event before forwarding. However we accidentally forwarded
the original event instead of the newly created one without the
synth_uuid. This is herby fixed!

Signed-off-by: Michael Weiß <michael.weiss@aisec.fraunhofer.de>