### PR TITLE
rattestation: compare byte arrays instead of strings

### DIFF
--- a/rattestation/ima_verify.c
+++ b/rattestation/ima_verify.c
@@ -400,7 +400,7 @@ ima_verify_binary_runtime_measurements(uint8_t *buf, size_t size, const char *ce
 		return -1;
 	}
 
-	INFO("Verify IMA TPM PCR (kernel modules) SUCCESSFUL");
+	INFO("Verify IMA TPM PCR SUCCESSFUL");
 
 	return 0;
 }

--- a/rattestation/modsig.c
+++ b/rattestation/modsig.c
@@ -162,9 +162,6 @@ modsig_parse_new(const char *pkcs7_raw, size_t len)
 	mem_free0(hash_algo_name);
 	mem_free0(sig_algo_name);
 
-	INFO("XX HASH ALGO: %s", sig_info->hash_algo);
-	INFO("XX HASH ALGO: %s", sig_info->sig_algo);
-
 out:
 	PKCS7_free(pkcs7);
 	if (serial_bn) {


### PR DESCRIPTION
Convert the configuration pcr values to byte arrays
before comparing them with the byte arrays of the
measurements

Signed-off-by: Simon Ott <simon.ott@aisec.fraunhofer.de>