### PR TITLE
daemon/hw_x86: fixed path for hardware RNG

### DIFF
--- a/daemon/hw_x86.c
+++ b/daemon/hw_x86.c
@@ -186,7 +186,7 @@ hardware_get_routing_table_radio(void)
 int
 hardware_get_random(unsigned char *buf, size_t len)
 {
-	const char *rnd = "/dev/hw_random";
+	const char *rnd = "/dev/hwrng";
 	const char *sw = "/dev/random";
 
 	int bytes_read = file_read(rnd, (char *)buf, len);


### PR DESCRIPTION
The character device for the hardware RNG '/dev/hw_random' does not
exist anymore. Switch to correct path '/dev/hwrng'.

Signed-off-by: Michael Weiß <michael.weiss@aisec.fraunhofer.de>