### PR TITLE
Bugfixes: logf_handler mem_leak, time submodule audit event

### DIFF
--- a/common/logf.c
+++ b/common/logf.c
@@ -245,7 +245,13 @@ logf_register(void (*func)(logf_prio_t prio, const char *msg, void *data), void 
 void
 logf_unregister(logf_handler_t *handler)
 {
+	IF_NULL_RETURN(handler);
 	logf_handler_list = list_remove(logf_handler_list, handler);
+
+	if (handler->data)
+		mem_free0(handler->data);
+
+	mem_free0(handler);
 }
 
 void

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -929,6 +929,8 @@ cmld_start_c0(container_t *new_c0)
 				uuid_string(container_get_uuid(new_c0)), 0);
 		return -1;
 	}
+	/* check that time is in trusted range after start */
+	time_register_clock_check();
 
 	audit_log_event(container_get_uuid(new_c0), SSA, CMLD, CONTAINER_MGMT, "c0-start",
 			uuid_string(container_get_uuid(new_c0)), 0);

--- a/daemon/main.c
+++ b/daemon/main.c
@@ -100,7 +100,7 @@ main_logfile_rename_cb(UNUSED event_timer_t *timer, UNUSED void *data)
 	logf_unregister(cml_daemon_logfile_handler);
 	cml_daemon_logfile_handler =
 		logf_register(&logf_file_write, logf_file_new(LOGFILE_DIR "/cml-daemon"));
-	logf_handler_set_prio(cml_daemon_logfile_handler, LOGF_PRIO_WARN);
+	logf_handler_set_prio(cml_daemon_logfile_handler, LOGF_PRIO_TRACE);
 }
 
 /******************************************************************************/

--- a/scd/scd.c
+++ b/scd/scd.c
@@ -296,7 +296,7 @@ scd_logfile_rename_cb(UNUSED event_timer_t *timer, UNUSED void *data)
 	logf_unregister(scd_logfile_handler);
 	scd_logfile_handler =
 		logf_register(&logf_file_write, logf_file_new(LOGFILE_DIR "/cml-scd"));
-	logf_handler_set_prio(scd_logfile_handler, LOGF_PRIO_WARN);
+	logf_handler_set_prio(scd_logfile_handler, LOGF_PRIO_TRACE);
 }
 
 int

--- a/tpm2d/tpm2d.c
+++ b/tpm2d/tpm2d.c
@@ -72,7 +72,7 @@ tpm2d_logfile_rename_cb(UNUSED event_timer_t *timer, UNUSED void *data)
 	logf_unregister(tpm2d_logfile_handler);
 	tpm2d_logfile_handler =
 		logf_register(&logf_file_write, logf_file_new(LOGFILE_DIR "/cml-tpm2d"));
-	logf_handler_set_prio(tpm2d_logfile_handler, LOGF_PRIO_WARN);
+	logf_handler_set_prio(tpm2d_logfile_handler, LOGF_PRIO_TRACE);
 }
 
 static void


### PR DESCRIPTION
**common/logf:** Release resources occupied by lof_handler
On logf_unregister() the memory resources used during registering
where not free'd. Thus, we now release this memory to avoid mem leaks
on release of logfile handlers. This was implicitly assumed by all
implementations of log rotate mechanisms in the CML.

**daemon/time,cmld:** audit system clock changes
If system clock changes is detected by time submodule, we now generate
an audit event. Further, also register the clock check already on start
of c0 and not only after each subsequent container start.
We also fixed up some excessive logging to trace.
