### PR TITLE
scripts: Added options for code formatting

### DIFF
--- a/scripts/format-code.sh
+++ b/scripts/format-code.sh
@@ -1,3 +1,94 @@
 #!/usr/bin/env bash
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pwd)"
-$ROOT_DIR/scripts/clang-format -i -verbose -style=file $(find $ROOT_DIR -type f -regextype sed -regex ".*\(\.c\|\.h\)")
+
+# Usage
+#
+# format-code [-u] [-s] [-n] [-q]
+#
+# All options can be combined. If no options given, all files in
+# the directory will be formatted
+#
+# -u        Format unstaged, i.e. modified but not yet staged files
+# -s        Format staged files
+# -n        Format new, i.e. untracked files
+# -q        Quiet, do not print modified files
+
+ALL=1
+UNSTAGED=0
+STAGED=0
+NEW=0
+VERBOSE=-verbose
+
+for arg in "$@"
+do
+    case $arg in
+        -u|--unstaged) #
+        ALL=0
+        UNSTAGED=1
+        shift
+        ;;
+	    -s|--staged) # O
+        ALL=0
+        STAGED=1
+        shift
+        ;;
+        -n|--new)
+        ALL=0
+        NEW=1
+        shift
+        ;;
+        -q|--quiet)
+        VERBOSE=
+        shift
+        ;;
+		*)
+        OTHER_ARGUMENTS+=("$1")
+        shift
+        ;;
+    esac
+done
+
+FILES_UNSTAGED=$(git diff --name-only -- '*.c' '*.h' | tr '\n' ' ')
+FILES_STAGED=$(git diff --name-only --cached -- '*.c' '*.h' | tr '\n' ' ')
+FILES_NEW=$(git ls-files --others --exclude-standard -- '*.c' '*.h')
+FILES_ALL=$(find $ROOT_DIR -type f -regextype sed -regex ".*\(\.c\|\.h\)")
+FILES=
+
+if [ $ALL -eq 1 ]
+then
+    INFO="Formatting all files\n"
+    FILES=$FILES_ALL
+else
+    if [ $UNSTAGED -eq 1 ]
+    then
+        INFO="Formatting unstaged files\n"
+        FILES=${FILES}$FILES_UNSTAGED
+    fi
+    if [ $STAGED -eq 1 ]
+    then
+        INFO="${INFO}Formatting staged files\n"
+        FILES=${FILES}${FILES_STAGED}
+    fi
+    if [ $NEW -eq 1 ]
+    then
+        INFO="${INFO}Formatting NEW files\n"
+        FILES=${FILES}${FILES_NEW}
+    fi
+fi
+
+if [ -n "$VERBOSE" ]
+then
+    printf "$INFO"
+fi
+
+if [ -z "$FILES" ]
+then
+    if [ -n "$VERBOSE" ]
+    then
+        echo "No files to be formatted"
+    fi
+else
+   $ROOT_DIR/scripts/clang-format -i $VERBOSE -style=file $FILES
+fi
+
+


### PR DESCRIPTION
As discussed, my adjusted code fomatting script that allows selecting the files to be formatted. 

If used without options, the script behaves exactly as before, i.e. formats all files. With the newly introduced options, the output can be silenced and only any combination of new (untracked), modified (unstaged) and/or staged files can be formatted. Usual usage: ./scripts/format-code.sh -u (only formats modified (unstaged) files, much faster than default command). 

Signed-off-by: Simon Ott <simon.ott@aisec.fraunhofer.de>