### PR TITLE
daemon/scd/tpm2d: Fixes for init scripts

### DIFF
--- a/daemon/Makefile_lsb
+++ b/daemon/Makefile_lsb
@@ -38,6 +38,6 @@ install:
 	install -d ${DESTDIR}/var/lib/cml
 	install -d ${DESTDIR}/etc/cml
 	echo "uuid: \"$(shell cat /proc/sys/kernel/random/uuid)\"" > ${DESTDIR}/etc/cml/device.conf
-	echo "hostedmode: true" >> ${DESTDIR}/etc/cml/device.conf
+	echo "hostedmode: true\ntpm_enabled: false" >> ${DESTDIR}/etc/cml/device.conf
 	install -d ${DESTDIR}/usr/share/doc/cml
 	install guestos.proto ${DESTDIR}/usr/share/doc/cml/

--- a/daemon/cmld.c
+++ b/daemon/cmld.c
@@ -1356,7 +1356,7 @@ cmld_init(const char *path)
 	audit_log_event(NULL, SSA, CMLD, GENERIC, "boot-time", NULL, 2, "time", btime);
 	mem_free0(btime);
 
-	if (scd_init() < 0)
+	if (scd_init(!cmld_is_hostedmode_active()) < 0)
 		FATAL("Could not init scd module");
 	INFO("scd initialized.");
 	if (atexit(&scd_cleanup))
@@ -1372,7 +1372,7 @@ cmld_init(const char *path)
 		INFO("ksm initialized.");
 
 	if (device_config_get_tpm_enabled(device_config)) {
-		if (tss_init() < 0) {
+		if (tss_init(!cmld_is_hostedmode_active()) < 0) {
 			FATAL("Failed to initialize TSS / TPM 2.0 and tpm2d");
 		} else {
 			INFO("tss initialized.");

--- a/daemon/init.d/cmld
+++ b/daemon/init.d/cmld
@@ -1,12 +1,12 @@
 #!/bin/sh
 ### BEGIN INIT INFO
-# Provides:          cmld
-# Required-Start:    $local_fs $remote_fs cml-scd
-# Required-Stop:     $local_fs $remote_fs
-# Default-Start:     2 3 4 5
-# Default-Stop:      0 1 6
-# Short-Description: control cmld start at boot time
-# Description:       control Container Management daemon (cmld) start at
+# Provides:		  cmld
+# Required-Start:	$local_fs $remote_fs
+# Required-Stop:	 $local_fs $remote_fs
+# Default-Start:	 2 3 4 5
+# Default-Stop:	  0 1 6
+# Short-Description: CML container management daemon (cmld)
+# Description:	   The CML's main daemon managing containers
 ### END INIT INFO
 
 DAEMON=/usr/sbin/cmld
@@ -17,44 +17,62 @@ test -x $DAEMON || exit 0
 . /lib/lsb/init-functions
 
 start_cml_daemon() {
-    start-stop-daemon --start --quiet -b --exec $DAEMON
+	# make sure cml-scd and tpm2d are stopped correctly
+	# on platforms not supporting Required-Stop
 
-    # allow group cml-control to use socket
-    if getent group cml-control >/dev/null 2>&1 ; then
-        chgrp cml-control "$CONTROL_SOCK_PATH"
-    fi
+	if ! [ -S "/run/socket/cml-scd-control" ]  ;then
+		log_daemon_msg "cml-scd is not running, aborting..."
+		return 1
+	fi
+
+	start-stop-daemon --start --quiet -b --exec $DAEMON
+
+	# allow group cml-control to use socket
+	if getent group cml-control >/dev/null 2>&1 ; then
+		while ! chgrp cml-control "$CONTROL_SOCK_PATH" ;do
+			echo "chgrp failed"
+			sleep 1
+		done
+		return 0
+	fi
 }
 
 stop_cml_daemon() {
-	start-stop-daemon --stop --quiet --signal TERM --exec $DAEMON
+	# make sure cml-scd and tpm2d are stopped correctly
+	# on platforms not supporting Required-Stop
+
+
+	start-stop-daemon --stop --quiet --retry TERM/10/KILL/10 --oknodo --exec $DAEMON
+	rm -fr /run/socket/cml-control /run/socket/cml-tokencontrol
+
 }
 
 case "$1" in
   start)
 	log_daemon_msg "Starting CML daemon" "cmld"
-        start_cml_daemon
-        log_end_msg $?
-        ;;
+		start_cml_daemon
+		log_end_msg $?
+		;;
   stop)
-        log_daemon_msg "Stopping CML daemon" "cmld"
-        stop_cml_daemon
-        log_end_msg $?
-        ;;
+		log_daemon_msg "Stopping CML daemon" "cmld"
+		stop_cml_daemon
+		log_end_msg $?
+		;;
   restart|force-reload)
-        log_daemon_msg "Restarting CML daemon" "cmld"
-        stop_cmld_daemon
-        sleep 1
-        start_cml_daemon
-        log_end_msg $?
-        ;;
+		log_daemon_msg "Restarting CML daemon" "cmld"
+		$0 stopstop_cmld_daemon
+		sleep 1
+		start_cml_daemon
+		log_end_msg $?
+		;;
   status)
-        status_of_proc "$DAEMON" "cmld" && exit 0 || exit $?
-        ;;
+		status_of_proc "$DAEMON" "cmld" && exit 0 || exit $?
+		;;
   *)
-        N=/etc/init.d/cmld
-        echo "Usage: $N {start|stop|restart|force-reload|status}" >&2
-        exit 1
-        ;;
+		N=/etc/init.d/cmld
+		echo "Usage: $N {start|stop|restart|force-reload|status}" >&2
+		exit 1
+		;;
 esac
 
 exit 0

--- a/daemon/scd.c
+++ b/daemon/scd.c
@@ -118,6 +118,7 @@ scd_init(bool start_daemon)
 void
 scd_cleanup(void)
 {
+	IF_TRUE_RETURN_TRACE(scd_pid == -1);
 	DEBUG("Stopping %s process with pid=%d!", SCD_BINARY_NAME, scd_pid);
 	kill(scd_pid, SIGTERM);
 }

--- a/daemon/scd.h
+++ b/daemon/scd.h
@@ -24,12 +24,15 @@
 #ifndef CML_SCD_H
 #define CML_SCD_H
 
+#include <stdbool.h>
+
 /**
- * Initializies the scd subsystem (starts the corresponding daemon)
+ * Initializes the scd subsystem (starts the corresponding daemon)
+ * @param start_daemon Fork and execute the scd daemon
  * @return 0 on success, -1 on error
  */
 int
-scd_init(void);
+scd_init(bool start_daemon);
 
 /**
  * Cleans up the scd subsystem (stops the corresponding daemon)

--- a/daemon/tss.c
+++ b/daemon/tss.c
@@ -109,7 +109,7 @@ fork_and_exec_tpm2d(void)
 }
 
 int
-tss_init(void)
+tss_init(bool start_daemon)
 {
 	// Check if the platform has a TPM module attached
 	if (!file_exists("/dev/tpm0") || !tss_is_tpm2d_installed()) {
@@ -118,8 +118,13 @@ tss_init(void)
 	}
 
 	// Start the tpm2d
-	tss_tpm2d_pid = fork_and_exec_tpm2d();
-	IF_TRUE_RETVAL_TRACE(tss_tpm2d_pid == -1, -1);
+	// In hosted mode this should be handled by the respective init scripts
+	if (start_daemon) {
+		tss_tpm2d_pid = fork_and_exec_tpm2d();
+		IF_TRUE_RETVAL_TRACE(tss_tpm2d_pid == -1, -1);
+	} else {
+		DEBUG("Skipping tpm2d launch as requested");
+	}
 
 	// Connect to tpm2d
 	size_t retries = 0;

--- a/daemon/tss.h
+++ b/daemon/tss.h
@@ -25,14 +25,20 @@
 #define TSS_H
 
 #include <stdint.h>
+#include <stdbool.h>
 
 /*
  * type of supported hashes
  */
 typedef enum { TSS_SHA1 = 0, TSS_SHA256, TSS_SHA384 } tss_hash_algo_t;
 
+/**
+ * Initializes the tss subsystem (starts the corresponding daemon)
+ * @param start_daemon Fork and execute the tpm2d daemon
+ * @return 0 on success, -1 on error
+ */
 int
-tss_init(void);
+tss_init(bool start_daemon);
 
 /**
  * Cleanup the tss submodule, mainly stop tpm2d daemon.

--- a/scd/init.d/cml-scd
+++ b/scd/init.d/cml-scd
@@ -1,58 +1,59 @@
 #!/bin/sh
 ### BEGIN INIT INFO
-# Provides:          cml-scd
-# Required-Start:    $local_fs $remote_fs
-# Required-Stop:     $local_fs $remote_fs
-# Default-Start:     2 3 4 5
-# Default-Stop:      0 1 6
-# Short-Description: control cml-scd start at boot time
-# Description:       control CML security helper daemon (cml-scd) start at
-#                    boot time needed for cmld
+# Provides:		  cml-scd
+# Required-Start:	$local_fs $remote_fs
+# Required-Stop:	 $local_fs $remote_fs
+# Default-Start:	 2 3 4 5
+# Default-Stop:	  0 1 6
+# Short-Description: CML security helper daemon
+# Description:	   Helper daemon wrapping cryptographic and token-related operations
 ### END INIT INFO
 
 DAEMON=/usr/sbin/cml-scd
 
-test -x $DAEMON || exit 0
+test -x $DAEMON || exit 1
 
 . /lib/lsb/init-functions
 
 start_scd_daemon() {
-	if [ ! -d /var/log/cml ]; then
-		mkdir -p /var/log/cml
-	fi
-	start-stop-daemon --start --quiet --oknodo -b --exec $DAEMON
+		# TODO Add option to make cml-scd detach itself
+		if ! [ -f /var/lib/cml/tokens/device.cert ];then
+			log_daemon_msg "Before running this service, execute $DAEMON as root once"
+			return 1
+		fi
+		start-stop-daemon --start --quiet -b --exec $DAEMON
+		log_end_msg $?
 }
 
 stop_scd_daemon() {
-	start-stop-daemon --stop --quiet --signal TERM --oknodo --exec $DAEMON
+		start-stop-daemon --stop --quiet --retry TERM/10/KILL/10 --oknodo --exec $DAEMON
+		rm -f /run/socket/cml-scd-control
 }
 
 case "$1" in
   start)
-        log_daemon_msg "Starting CML security helper daemon" "cml-scd"
-        start_scd_daemon
-        log_end_msg $?
-        ;;
+		log_daemon_msg "Starting CML security helper daemon" "cml-scd"
+		start_scd_daemon
+		;;
   stop)
-        log_daemon_msg "Stopping CML security helper daemon" "cml-scd"
-        stop_scd_daemon
-        log_end_msg $?
-        ;;
+		log_daemon_msg "Stopping CML security helper daemon" "cml-scd"
+		stop_scd_daemon
+		log_end_msg $?
+		;;
   restart|force-reload)
-        log_daemon_msg "Restarting CML security helper daemon" "cml-scd"
-        stop_scd_daemon
-        sleep 1
-        start_scd_daemon
-        log_end_msg $?
-        ;;
+		log_daemon_msg "Restarting CML security daemon" "cml-scd"
+		stop_scd_daemon
+		start_scd_daemon
+		log_end_msg $?
+		;;
   status)
-        status_of_proc "$DAEMON" "cml-scd" && exit 0 || exit $?
-        ;;
+		status_of_proc "$DAEMON" "scd" && exit 0 || exit $?
+		;;
   *)
-        N=/etc/init.d/cml-scd
-        echo "Usage: $N {start|stop|restart|force-reload|status}" >&2
-        exit 1
-        ;;
+		N=/etc/init.d/cml-scd
+		echo "Usage: $N {start|stop|restart|force-reload|status}" >&2
+		exit 1
+		;;
 esac
 
 exit 0

--- a/tpm2d/Makefile_lsb
+++ b/tpm2d/Makefile_lsb
@@ -32,3 +32,5 @@ SBINDIR := /usr/sbin
 install:
 	install -d ${DESTDIR}${SBINDIR}
 	install tpm2d ${DESTDIR}${SBINDIR}/
+	install -d ${DESTDIR}/etc/init.d
+	install init.d/tpm2d ${DESTDIR}/etc/init.d/

--- a/tpm2d/init.d/tpm2d
+++ b/tpm2d/init.d/tpm2d
@@ -1,0 +1,65 @@
+#!/bin/sh
+### BEGIN INIT INFO
+# Provides:          tpm2d
+# Required-Start:    $local_fs $remote_fs
+# Required-Stop:     $local_fs $remote_fs
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: CML TPM 2.0 helper daemon
+# Description:       Helper daemon for TPM 2.0 communication leveraged by the cmld
+### END INIT INFO
+
+DAEMON=/usr/sbin/tpm2d
+
+test -x $DAEMON || exit 1
+
+. /lib/lsb/init-functions
+
+start_tpm2d_daemon() {
+        if ! [ -z "$(grep "tpm_enabled: false" /etc/cml/device.conf)" ];then
+            log_daemon_msg "TPM support disabled in device.conf, not starting tpm2d"
+	    return 1
+        fi
+        start-stop-daemon --start --quiet -b --exec $DAEMON
+        ret=$?
+        #log_success_msg "tpm2d returned $ret"
+        if [ "0" != "$ret" ];then
+            log_failure_msg "tpm2d failed but tpm support is enabled" "tpm2d"
+	    return 1
+        fi
+}
+
+stop_tpm2d_daemon() {
+        start-stop-daemon --stop --quiet --retry TERM/10/KILL/10 --oknodo --exec $DAEMON
+        rm -f /run/socket/cml-scd-control
+}
+
+case "$1" in
+  start)
+        log_daemon_msg "Starting CML security helper daemon" "tpm2d"
+        start_tpm2d_daemon
+        log_end_msg $?
+        ;;
+  stop)
+        log_daemon_msg "Stopping CML security helper daemon" "tpm2d"
+        stop_tpm2d_daemon
+        log_end_msg $?
+        ;;
+  restart|force-reload)
+        log_daemon_msg "Restarting CML security daemon" "tpm2d"
+        stop_tpm2d_daemon
+        start_tpm2d_daemon
+        log_end_msg $?
+        ;;
+  status)
+        status_of_proc "$DAEMON" "tpm2d" && exit 0 || exit $?
+        ;;
+  *)
+        N=/etc/init.d/tpm2d
+        echo "Usage: $N {start|stop|restart|force-reload|status}" >&2
+        exit 1
+        ;;
+esac
+
+exit 0
+


### PR DESCRIPTION
This commit contains minor fixes for the cmld, scd and tpm2d init scripts.

Signed-off-by: Felix Wruck <felix.wruck@aisec.fraunhofer.de>